### PR TITLE
backtrace: add support for generic backtraces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 Airbrake Ruby Changelog
 =======================
 
+### [v1.0.0][v1.0.0] (December 17, 2015)
+
+* Improved backtrace parsing support ([#4](https://github.com/airbrake/airbrake-ruby/pull/4))
+
 ### [v1.0.0.rc.1][v1.0.0.rc.1] (December 11, 2015)
 
 * Initial release
 
 [v1.0.0.rc.1]: https://github.com/airbrake/airbrake-ruby/releases/tag/v1.0.0.rc.1
+[v1.0.0]: https://github.com/airbrake/airbrake-ruby/releases/tag/v1.0.0

--- a/lib/airbrake-ruby/backtrace.rb
+++ b/lib/airbrake-ruby/backtrace.rb
@@ -86,11 +86,10 @@ module Airbrake
       match = regexp.match(stackframe)
       return match if match
 
-      unless (matched_frame = GENERIC_STACKFRAME_REGEXP.match(stackframe))
-        raise Airbrake::Error, "failed parsing '#{stackframe}'"
-      end
+      match = GENERIC_STACKFRAME_REGEXP.match(stackframe)
+      return match if match
 
-      matched_frame
+      raise Airbrake::Error, "can't parse '#{stackframe}'"
     end
   end
 end

--- a/lib/airbrake-ruby/backtrace.rb
+++ b/lib/airbrake-ruby/backtrace.rb
@@ -14,7 +14,7 @@ module Airbrake
     ##
     # @return [Regexp] the pattern that matches standard Ruby stack frames,
     #   such as ./spec/notice_spec.rb:43:in `block (3 levels) in <top (required)>'
-    STACKFRAME_REGEXP = %r{\A
+    RUBY_STACKFRAME_REGEXP = %r{\A
       (?<file>.+)       # Matches './spec/notice_spec.rb'
       :
       (?<line>\d+)      # Matches '43'
@@ -35,6 +35,16 @@ module Airbrake
     \z/x
 
     ##
+    # @return [Regexp] the template that tries to assume what a generic stack
+    #   frame might look like, when exception's backtrace is set manually.
+    GENERIC_STACKFRAME_REGEXP = %r{\A
+      (?<file>.+)   # Matches '/foo/bar/baz.ext'
+      :
+      (?<line>\d+)  # Matches '43'
+      (?<function>) # No-op
+    \z}x
+
+    ##
     # Parses an exception's backtrace.
     #
     # @param [Exception] exception The exception, which contains a backtrace to
@@ -44,11 +54,11 @@ module Airbrake
       regexp = if java_exception?(exception)
                  JAVA_STACKFRAME_REGEXP
                else
-                 STACKFRAME_REGEXP
+                 RUBY_STACKFRAME_REGEXP
                end
 
       (exception.backtrace || []).map do |stackframe|
-        stack_frame(regexp.match(stackframe))
+        stack_frame(match_frame(regexp, stackframe))
       end
     end
 
@@ -70,6 +80,17 @@ module Airbrake
           line: (Integer(match[:line]) if match[:line]),
           function: match[:function] }
       end
+    end
+
+    def self.match_frame(regexp, stackframe)
+      match = regexp.match(stackframe)
+      return match if match
+
+      unless (matched_frame = GENERIC_STACKFRAME_REGEXP.match(stackframe))
+        raise Airbrake::Error, "failed parsing '#{stackframe}'"
+      end
+
+      matched_frame
     end
   end
 end

--- a/spec/backtrace_spec.rb
+++ b/spec/backtrace_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe Airbrake::Backtrace do
 
       it "raises error" do
         expect { described_class.parse(ex) }.
-          to raise_error(Airbrake::Error, /failed parsing/)
+          to raise_error(Airbrake::Error, /can't parse/)
       end
     end
   end


### PR DESCRIPTION
Sometimes exceptions can contain manual backtraces that quack similar to
Ruby exceptions, but do not stricly adhere their template. I stumbled
upon this issues, when I was working with SCSS. It sets a couple of
custom first frames such as:

```
Sass::SyntaxError: Undefined mixin 'animation'.
/home/app/assets/stylesheets/error_pages.scss:139:in `animation'
/home/app/app/assets/stylesheets/error_pages.scss:139
```

Previously, we were not able to parse the second frame.

Furthermore, we now raise error if we cannot parse a stack frame to
simplify debugguging and improving our parser.