### PR TITLE
airbrake-ruby: fix add_filter block API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
 Airbrake Ruby Changelog
 =======================
 
+### master
+
+* Fixed the `Airbrake.add_filter` block API
+  ([#10](https://github.com/airbrake/airbrake-ruby/pull/10))
+
 ### [v1.0.0][v1.0.0] (December 18, 2015)
 
-* Improved backtrace parsing support ([#4](https://github.com/airbrake/airbrake-ruby/pull/4))
+* Improved backtrace parsing support
+  ([#4](https://github.com/airbrake/airbrake-ruby/pull/4))
 
 ### [v1.0.0.rc.1][v1.0.0.rc.1] (December 11, 2015)
 

--- a/lib/airbrake-ruby.rb
+++ b/lib/airbrake-ruby.rb
@@ -275,9 +275,9 @@ module Airbrake
     # Calls +method+ on +notifier+ with provided +args+.
     #
     # @raise [Airbrake::Error] if none of the notifiers exist
-    def call_notifier(notifier, method, *args)
+    def call_notifier(notifier, method, *args, &block)
       if @notifiers.key?(notifier)
-        @notifiers[notifier].__send__(method, *args)
+        @notifiers[notifier].__send__(method, *args, &block)
       else
         raise Airbrake::Error,
               "the '#{notifier}' notifier isn't configured"

--- a/spec/airbrake_spec.rb
+++ b/spec/airbrake_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Airbrake do
   end
 
   before do
-    described_class.configure do |c|
+    @notifier = described_class.configure do |c|
       c.project_id = 113743
       c.project_key = 'fd04e13d806a90f96614ad8e529b2822'
     end
@@ -161,6 +161,18 @@ RSpec.describe Airbrake do
 
   describe ".add_filter" do
     include_examples 'error handling', :add_filter
+
+    it "adds filters with help of blocks" do
+      filter_chain = @notifier.instance_variable_get(:@filter_chain)
+      filters = filter_chain.instance_variable_get(:@filters)
+
+      expect(filters.size).to eq(2)
+
+      described_class.add_filter {}
+
+      expect(filters.size).to eq(3)
+      expect(filters.last).to be_a(Proc)
+    end
   end
 
   describe ".whitelist_keys" do

--- a/spec/airbrake_spec.rb
+++ b/spec/airbrake_spec.rb
@@ -5,12 +5,14 @@ RSpec.describe Airbrake do
     'https://airbrake.io/api/v3/projects/113743/notices?key=fd04e13d806a90f96614ad8e529b2822'
   end
 
-  before do
-    @notifier = described_class.configure do |c|
+  let!(:notifier) do
+    described_class.configure do |c|
       c.project_id = 113743
       c.project_key = 'fd04e13d806a90f96614ad8e529b2822'
     end
+  end
 
+  before do
     stub_request(:post, endpoint).to_return(status: 201, body: '{}')
   end
 
@@ -163,7 +165,7 @@ RSpec.describe Airbrake do
     include_examples 'error handling', :add_filter
 
     it "adds filters with help of blocks" do
-      filter_chain = @notifier.instance_variable_get(:@filter_chain)
+      filter_chain = notifier.instance_variable_get(:@filter_chain)
       filters = filter_chain.instance_variable_get(:@filters)
 
       expect(filters.size).to eq(2)


### PR DESCRIPTION
Fixes #8 (add_filter throwing exception)