### PR TITLE
Fix OS match regex

### DIFF
--- a/spec/notifier_spec.rb
+++ b/spec/notifier_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe Airbrake::Notifier do
         end
 
         it "features 'context'" do
-          expect_a_request_with_body(/"context":{.*"os":"[\w-]+"/)
+          expect_a_request_with_body(/"context":{.*"os":"[\.\w-]+"/)
         end
 
         it "features 'errors'" do


### PR DESCRIPTION
The previous regex failed to match OS values containing a `.` such as
`x86_64-darwin14.0`, causing the test to fail on such systems.