### PR TITLE
airbrake-ruby: ignore SystemExit in the `at_exit` hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Airbrake Ruby Changelog
 
 ### master
 
+* Ignored `SystemExit` in the `at_exit` hook, which has fixed the Rake
+  integration for the [airbrake gem][airbrake-gem] gem
+  ([#14](https://github.com/airbrake/airbrake-ruby/pull/14))
+
 ### [v1.0.1][v1.0.1] (December 22, 2015)
 
 * Fixed the `Airbrake.add_filter` block API
@@ -17,6 +21,7 @@ Airbrake Ruby Changelog
 
 * Initial release
 
+[airbrake-gem]: https://github.com/airbrake/airbrake
 [v1.0.0.rc.1]: https://github.com/airbrake/airbrake-ruby/releases/tag/v1.0.0.rc.1
 [v1.0.0]: https://github.com/airbrake/airbrake-ruby/releases/tag/v1.0.0
 [v1.0.1]: https://github.com/airbrake/airbrake-ruby/releases/tag/v1.0.1

--- a/lib/airbrake-ruby.rb
+++ b/lib/airbrake-ruby.rb
@@ -286,7 +286,9 @@ module Airbrake
   end
 end
 
-# Notify of unhandled exceptions, if there were any.
+# Notify of unhandled exceptions, if there were any, but ignore SystemExit.
 at_exit do
-  Airbrake.notify_sync($ERROR_INFO) if $ERROR_INFO
+  if $ERROR_INFO && $ERROR_INFO.class != SystemExit
+    Airbrake.notify_sync($ERROR_INFO)
+  end
 end


### PR DESCRIPTION
Fixes #13 (Unnecessary airbrake error when running unknown rake task)

The problem with Rake is that on unknown task it
[raises SystemExit][1] with help of [`Kernel.exit`][2], which we catch
and try to send to Airbrake, which results in an Airbrake::Error.

This is the easiest fix. I tried messing with the airbrake gem to load
the Airbrake config when you launch a Rake task inside a Rails app, but
it's not easy to do: the Rails app is not initialised at that moment.

I stopped digging there, because I was getting into the rabbit hole.

[1]: https://github.com/ruby/rake/blob/805c13ab52eae9df55f9030f40c7fbc1beadc105/lib/rake/application.rb#L191
[2]: http://ruby-doc.org/core-2.2.3/Kernel.html#method-i-exit