### PR TITLE
notifier: make sure generated notices always have a backtrace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Airbrake Ruby Changelog
 
 * Improved parsing of backtraces
   ([#25](https://github.com/airbrake/airbrake-ruby/pull/25))
+* Made sure that generated notices always have a backtrace
+  ([#21](https://github.com/airbrake/airbrake-ruby/pull/21))
 
 ### [v1.0.2][v1.0.2] (January 3, 2016)
 

--- a/lib/airbrake-ruby/notifier.rb
+++ b/lib/airbrake-ruby/notifier.rb
@@ -139,7 +139,13 @@ module Airbrake
     end
 
     def clean_backtrace
-      caller.drop_while { |frame| frame.include?('/lib/airbrake') }
+      caller_copy = Kernel.caller
+      clean_bt = caller_copy.drop_while { |frame| frame.include?('/lib/airbrake') }
+
+      # If true, then it's likely an internal library error. In this case return
+      # at least some backtrace to simplify debugging.
+      return caller_copy if clean_bt.empty?
+      clean_bt
     end
   end
 end


### PR DESCRIPTION
In theory it's possible to generate a backtrace that consists only of
internal frames. When this happens, then we send a notice without a
backtrace, because all the internal frames are filtered. When we see a
notice without a backtrace in the dashboard, it's incredibly hard to
debug it.

This change ensures that in case of an internal error we at least can
debug the failure.