### PR TITLE
notifier: respawn workers if they're all dead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Airbrake Ruby Changelog
   ([#25](https://github.com/airbrake/airbrake-ruby/pull/25))
 * Made sure that generated notices always have a backtrace
   ([#21](https://github.com/airbrake/airbrake-ruby/pull/21))
+* Made the asynchronous delivery mechanism more robust
+  ([#26](https://github.com/airbrake/airbrake-ruby/pull/26))
 
 ### [v1.0.2][v1.0.2] (January 3, 2016)
 

--- a/lib/airbrake-ruby/notifier.rb
+++ b/lib/airbrake-ruby/notifier.rb
@@ -127,15 +127,13 @@ module Airbrake
     end
 
     def default_sender
-      if @async_sender.has_workers?
-        @async_sender
-      else
-        @config.logger.warn(
-          "#{LOG_LABEL} falling back to sync delivery because there are no " \
-          "running async workers"
-        )
-        @sync_sender
-      end
+      return @async_sender if @async_sender.has_workers?
+
+      @config.logger.warn(
+        "#{LOG_LABEL} falling back to sync delivery because there are no " \
+        "running async workers"
+      )
+      @sync_sender
     end
 
     def clean_backtrace


### PR DESCRIPTION
Potentially fixes https://github.com/airbrake/airbrake/issues/463
(falling back to sync delivery because there are no running async
workers)

I noticed I can reliably reproduce this message when I invoke the Rails
console and manually send a notice via `Airbrake.notify`. It happens
because by default Rails launches [Spring][1], which preloads the app
by using the `fork()` system call. And when that happens, as we know,
our worker threads die.

The fix is simply to respawn workers. It works reliably with the Rails
console and I assume it will fix the above mentioned issue.

[1]: https://github.com/rails/spring/