### PR TITLE
nested_exception: fix backtrace parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ Airbrake Ruby Changelog
 ### master
 
 * Improved parsing of backtraces
-  ([#25](https://github.com/airbrake/airbrake-ruby/pull/25))
+  ([#25](https://github.com/airbrake/airbrake-ruby/pull/25),
+  [#29](https://github.com/airbrake/airbrake-ruby/pull/29),
+  [#30](https://github.com/airbrake/airbrake-ruby/pull/30))
 * Made sure that generated notices always have a backtrace
   ([#21](https://github.com/airbrake/airbrake-ruby/pull/21))
 * Made the asynchronous delivery mechanism more robust

--- a/lib/airbrake-ruby/backtrace.rb
+++ b/lib/airbrake-ruby/backtrace.rb
@@ -51,6 +51,8 @@ module Airbrake
     #   parse
     # @return [Array<Hash{Symbol=>String,Integer}>] the parsed backtrace
     def self.parse(exception)
+      return [] if exception.backtrace.nil? || exception.backtrace.none?
+
       regexp = if java_exception?(exception)
                  JAVA_STACKFRAME_REGEXP
                else

--- a/lib/airbrake-ruby/nested_exception.rb
+++ b/lib/airbrake-ruby/nested_exception.rb
@@ -16,7 +16,7 @@ module Airbrake
       unwind_exceptions.map do |exception|
         { type: exception.class.name,
           message: exception.message,
-          backtrace: parse_backtrace(exception) }
+          backtrace: Backtrace.parse(exception) }
       end
     end
 
@@ -32,11 +32,6 @@ module Airbrake
       end
 
       exception_list
-    end
-
-    def parse_backtrace(exception)
-      return if exception.backtrace.nil? || exception.backtrace.none?
-      Backtrace.parse(exception)
     end
   end
 end

--- a/spec/nested_exception_spec.rb
+++ b/spec/nested_exception_spec.rb
@@ -68,8 +68,8 @@ RSpec.describe Airbrake::NestedException do
           exceptions = nested_exception.as_json
 
           expect(exceptions.size).to eq(2)
-          expect(exceptions[0][:backtrace]).to be_nil
-          expect(exceptions[1][:backtrace]).to be_nil
+          expect(exceptions[0][:backtrace]).to be_empty
+          expect(exceptions[1][:backtrace]).to be_empty
         end
       end
     end


### PR DESCRIPTION
While working on https://github.com/airbrake/airbrake/pull/479 I
stumbled upon a bug in Airbrake Ruby where the default filter couldn't
process error payload because `:backtrace` was `nil`. Returning an
empty array in case the real backtrace is missing seems to be a more
secure approach.