### PR TITLE
airbrake-ruby: reraise SystemExit instead of raising Airbrak::Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Airbrake Ruby Changelog
   ([#21](https://github.com/airbrake/airbrake-ruby/pull/21))
 * Made the asynchronous delivery mechanism more robust
   ([#26](https://github.com/airbrake/airbrake-ruby/pull/26))
+* Improved `SystemExit` handling by ignoring it on a different level, which
+  fixed issues with the Rake integration for the [airbrake gem][airbrake-gem]
+  gem ([#32](https://github.com/airbrake/airbrake-ruby/pull/32))
 
 ### [v1.0.2][v1.0.2] (January 3, 2016)
 


### PR DESCRIPTION
Fixes #28 ("Airbrake::Error: the 'default' notifier isn't configured"
thrown after unsuccessful specs)

This fixes issues with the Rake integration. There was a [similar
issue][1] to a bug with the Rake integration reported a couple of weeks
ago. The change presented here fixes both issues by reraising
`SystemExit`, which propagates it and gets handled by Ruby.

[1]: https://github.com/airbrake/airbrake-ruby/issues/13