### PR TITLE
notice: attach hostname information by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Airbrake Ruby Changelog
 
 ### master
 
+* Started attaching the hostname information by default
+  ([#41](https://github.com/airbrake/airbrake-ruby/pull/41))
+
 ### [v1.0.3][v1.0.3] (January 18, 2016)
 
 * Improved parsing of backtraces

--- a/lib/airbrake-ruby.rb
+++ b/lib/airbrake-ruby.rb
@@ -4,6 +4,7 @@ require 'json'
 require 'thread'
 require 'set'
 require 'English'
+require 'socket'
 
 require 'airbrake-ruby/version'
 require 'airbrake-ruby/config'

--- a/lib/airbrake-ruby/notice.rb
+++ b/lib/airbrake-ruby/notice.rb
@@ -48,6 +48,10 @@ module Airbrake
       :params
     ].freeze
 
+    ##
+    # @return [String] the name of the host machine
+    HOSTNAME = Socket.gethostname.freeze
+
     def initialize(config, exception, params = {})
       @config = config
 
@@ -145,7 +149,10 @@ module Airbrake
 
         # Legacy Airbrake v4 behaviour.
         component: params.delete(:component),
-        action: params.delete(:action)
+        action: params.delete(:action),
+
+        # Make sure we always send hostname.
+        hostname: HOSTNAME
       }.merge(CONTEXT).delete_if { |_key, val| val.nil? || val.empty? }
     end
 

--- a/spec/notice_spec.rb
+++ b/spec/notice_spec.rb
@@ -105,6 +105,11 @@ RSpec.describe Airbrake::Notice do
       expect(notice.to_json).
         to match(/"notifier":{"name":"airbrake-ruby","version":".+","url":".+"}/)
     end
+
+    it "always contains context/hostname" do
+      expect(notice.to_json).
+        to match(/"context":{.*"hostname":".+".*}/)
+    end
   end
 
   describe "#[]" do


### PR DESCRIPTION
The hostname information has to be present in many of our integrations
from the Airbrake gem. This information is just too useful and it
should be retreived by default.