### PR TITLE
Encode components in filter_url_params

### DIFF
--- a/lib/airbrake-ruby/filters/keys_filter.rb
+++ b/lib/airbrake-ruby/filters/keys_filter.rb
@@ -55,7 +55,13 @@ module Airbrake
 
       def filter_url_params(url)
         url.query = Hash[URI.decode_www_form(url.query)].map do |key, val|
-          should_filter?(key) ? "#{key}=[Filtered]" : "#{key}=#{val}"
+          # Ruby < 2.2 raises InvalidComponentError if the query contains
+          # invalid characters, so be sure to escape individual components.
+          if should_filter?(key)
+            "#{URI.encode_www_form_component(key)}=[Filtered]"
+          else
+            "#{URI.encode_www_form_component(key)}=#{URI.encode_www_form_component(val)}"
+          end
         end.join('&')
 
         url.to_s

--- a/spec/notifier_spec.rb
+++ b/spec/notifier_spec.rb
@@ -539,13 +539,13 @@ RSpec.describe Airbrake::Notifier do
       @airbrake.blacklist_keys(%w(bish))
 
       notice = @airbrake.build_notice(ex)
-      notice[:context][:url] = 'http://localhost:3000/crash?foo=bar&baz=bongo&bish=bash'
+      notice[:context][:url] = 'http://localhost:3000/crash?foo=bar&baz=bongo&bish=bash&color=%23FFAAFF'
 
       @airbrake.notify_sync(notice)
 
       # rubocop:disable Metrics/LineLength
       expected_body =
-        %r("context":{.*"url":"http://localhost:3000/crash\?foo=bar&baz=bongo&bish=\[Filtered\]".*})
+        %r("context":{.*"url":"http://localhost:3000/crash\?foo=bar&baz=bongo&bish=\[Filtered\]&color=%23FFAAFF".*})
       # rubocop:enable Metrics/LineLength
 
       expect(


### PR DESCRIPTION
I was having problems on Ruby 2.1.5 where airbrake would fail to report errors if the URL contained something like `bg_color=%23FF00FF` - filter_url_params would try to assign `url.query = "bg_color=#FF00FF"`, which raises URI::InvalidComponentError.

(Interestingly, ruby 2.2 no longer raises in this case)

WDYT?