### PR TITLE
Release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Airbrake Ruby Changelog
 
 ### master
 
+### [v1.1.0][v1.1.0] (February 25, 2016)
+
 * Fixed bug in Ruby < 2.2, when trying to encode components while filtering
   ([#45](https://github.com/airbrake/airbrake-ruby/pull/45))
 * Stopped blocking on full queue when sending errors asynchronously
@@ -56,3 +58,4 @@ Airbrake Ruby Changelog
 [v1.0.2]: https://github.com/airbrake/airbrake-ruby/releases/tag/v1.0.2
 [v1.0.3]: https://github.com/airbrake/airbrake-ruby/releases/tag/v1.0.3
 [v1.0.4]: https://github.com/airbrake/airbrake-ruby/releases/tag/v1.0.4
+[v1.1.0]: https://github.com/airbrake/airbrake-ruby/releases/tag/v1.1.0

--- a/README.md
+++ b/README.md
@@ -560,6 +560,6 @@ The project uses the MIT License. See LICENSE.md for details.
 [keysblacklist]: https://github.com/airbrake/airbrake-ruby/blob/master/lib/airbrake-ruby/filters/keys_blacklist.rb
 [keyswhitelist]: https://github.com/airbrake/airbrake-ruby/blob/master/lib/airbrake-ruby/filters/keys_whitelist.rb
 [golang]: https://golang.org/
-[semver]: https://img.shields.io/:semver-1.0.4-brightgreen.svg?style=flat
+[semver]: https://img.shields.io/:semver-1.1.0-brightgreen.svg?style=flat
 [yard-api]: http://www.rubydoc.info/gems/airbrake-ruby
 [arthur-ruby]: https://s3.amazonaws.com/airbrake-github-assets/airbrake-ruby/arthur-ruby.jpg

--- a/lib/airbrake-ruby/version.rb
+++ b/lib/airbrake-ruby/version.rb
@@ -3,5 +3,5 @@
 module Airbrake
   ##
   # @return [String] the library version
-  AIRBRAKE_RUBY_VERSION = '1.0.4'.freeze
+  AIRBRAKE_RUBY_VERSION = '1.1.0'.freeze
 end


### PR DESCRIPTION
> Minor version Y (x.Y.z | x > 0) MUST be incremented if new, backwards
  compatible functionality is introduced to the public API.

We introduced the `timeout` option in this release.