### PR TITLE
Add option always_async

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,18 @@ Airbrake.configure do |c|
 end
 ```
 
+#### always_async
+
+Always send errors asynchronously. The default value is false.
+If Airbrake.notify is called but no asynchronous workers are alive, the default behaviour is
+to send the error synchronously. Set always_async to true to prevent this behaviour.
+
+```ruby
+Airbrake.configure do |c|
+  c.always_async = true
+end
+```
+
 API
 ---
 

--- a/lib/airbrake-ruby/config.rb
+++ b/lib/airbrake-ruby/config.rb
@@ -58,6 +58,11 @@ module Airbrake
     attr_accessor :timeout
 
     ##
+    # @return [Boolean] If true, we will never fallback to synchronous delivery
+    #   of errors, as it happens by default when there are no async workers alive
+    attr_accessor :always_async
+
+    ##
     # @param [Hash{Symbol=>Object}] user_config the hash to be used to build the
     #   config
     def initialize(user_config = {})
@@ -75,6 +80,8 @@ module Airbrake
       self.ignore_environments = []
 
       self.timeout = user_config[:timeout]
+
+      self.always_async = false
 
       merge(user_config)
     end

--- a/lib/airbrake-ruby/notifier.rb
+++ b/lib/airbrake-ruby/notifier.rb
@@ -127,7 +127,7 @@ module Airbrake
     end
 
     def default_sender
-      return @async_sender if @async_sender.has_workers?
+      return @async_sender if @config.always_async || @async_sender.has_workers?
 
       @config.logger.warn(
         "#{LOG_LABEL} falling back to sync delivery because there are no " \


### PR DESCRIPTION
This adds the option "always_async" that enforces that the synchronous sender is never used.

This translates into avoiding falling back to synchronous sender when all workers in the asynchronous sender are dead.

Without this option, if the Errbit server is down and dropping packets, the async workers die after the network timeout, the notifier falls back to use the synchronous sender and finally the sync sender starts blocking the application trying to deliver the errors during the timeout time.

I think it would be better that this was the default behaviour. When you read that the gem delivers errors asynchronously you don't expect a not-so-impossible scenarios (Aibrake/Errbit server down) to make the gem to start behaving synchronously, potentially blocking your application.
In this case, a 'sync_fallback' option, defaulting to false, could be added for the people that know what are they doing and want this behaviour.

But doing so should probably be considered a change of behaviour and trigger a major version increase, which seems to much for such a change. 