### PR TITLE
Full async

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Installation
 Add the Airbrake Ruby gem to your Gemfile:
 
 ```ruby
-gem 'airbrake-ruby', '~> 1.0'
+gem 'airbrake-ruby', '~> 1.1'
 ```
 
 ### Manual

--- a/lib/airbrake-ruby/notifier.rb
+++ b/lib/airbrake-ruby/notifier.rb
@@ -127,13 +127,8 @@ module Airbrake
     end
 
     def default_sender
-      return @async_sender if @async_sender.has_workers?
-
-      @config.logger.warn(
-        "#{LOG_LABEL} falling back to sync delivery because there are no " \
-        "running async workers"
-      )
-      @sync_sender
+      # Always send asynchronously to avoid blocking
+      return @async_sender
     end
 
     def clean_backtrace


### PR DESCRIPTION
Avoid falling back to synchronous behaviour when async workers have died. The error will be just logged or lost, but we won't block the parent application.

Using this while we merge something better in the official airbrake-ruby gem.