### PR TITLE
Captures all StandardError Exceptions at sync_sender

### DIFF
--- a/lib/airbrake-ruby/sync_sender.rb
+++ b/lib/airbrake-ruby/sync_sender.rb
@@ -9,18 +9,6 @@ module Airbrake
     CONTENT_TYPE = 'application/json'.freeze
 
     ##
-    # @return [Array] the errors to be rescued and logged during an HTTP request
-    HTTP_ERRORS = [
-      Timeout::Error,
-      Net::HTTPBadResponse,
-      Net::HTTPHeaderSyntaxError,
-      Errno::ECONNRESET,
-      Errno::ECONNREFUSED,
-      EOFError,
-      OpenSSL::SSL::SSLError
-    ].freeze
-
-    ##
     # @param [Airbrake::Config] config
     def initialize(config)
       @config = config
@@ -39,7 +27,7 @@ module Airbrake
 
       begin
         response = https.request(req)
-      rescue *HTTP_ERRORS => ex
+      rescue => ex
         @config.logger.error("#{LOG_LABEL} HTTP error: #{ex}")
         return
       end

--- a/spec/sync_sender_spec.rb
+++ b/spec/sync_sender_spec.rb
@@ -10,4 +10,18 @@ RSpec.describe Airbrake::SyncSender do
       expect(https.read_timeout).to eq(10)
     end
   end
+
+  describe "#send" do
+    it "catches exceptions raised when sending" do
+      stdout = StringIO.new
+      config = Airbrake::Config.new(logger: Logger.new(stdout))
+      sender = described_class.new config
+      notice = Airbrake::Notice.new(config, AirbrakeTestError.new)
+      https = double("foo")
+      allow(sender).to receive(:build_https).and_return(https)
+      allow(https).to receive(:request).and_raise(StandardError.new('foo'))
+      expect(sender.send(notice)).to be_nil
+      expect(stdout.string).to match(/ERROR -- : .+ HTTP error: foo/)
+    end
+  end
 end


### PR DESCRIPTION
This exception is generated when the asynchronous worker times out trying to connect to the Airbrake server, if it's not captured, the worker dies.