### PR TITLE
filters: compare non-regexp keys exactly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Airbrake Ruby Changelog
 
 ### master
 
+* Fixed bug when similar keys would be filtered out using non-regexp values for
+  `Airbrake.blacklist/whitelist_keys`
+  ([#54](https://github.com/airbrake/airbrake-ruby/pull/54))
+
 ### [v1.1.0][v1.1.0] (February 25, 2016)
 
 * Fixed bug in Ruby < 2.2, when trying to encode components while filtering

--- a/lib/airbrake-ruby/filters/keys_blacklist.rb
+++ b/lib/airbrake-ruby/filters/keys_blacklist.rb
@@ -30,7 +30,13 @@ module Airbrake
       # @return [Boolean] true if the key matches at least one pattern, false
       #   otherwise
       def should_filter?(key)
-        @patterns.any? { |pattern| key.to_s.match(pattern) }
+        @patterns.any? do |pattern|
+          if pattern.is_a?(Regexp)
+            key.match(pattern)
+          else
+            key.to_s == pattern.to_s
+          end
+        end
       end
     end
   end

--- a/lib/airbrake-ruby/filters/keys_filter.rb
+++ b/lib/airbrake-ruby/filters/keys_filter.rb
@@ -15,7 +15,7 @@ module Airbrake
       #
       # @param [Array<String,Regexp,Symbol>] patterns
       def initialize(*patterns)
-        @patterns = patterns.map(&:to_s)
+        @patterns = patterns
       end
 
       ##

--- a/lib/airbrake-ruby/filters/keys_whitelist.rb
+++ b/lib/airbrake-ruby/filters/keys_whitelist.rb
@@ -30,7 +30,13 @@ module Airbrake
       # @return [Boolean] true if the key doesn't match any pattern, false
       #   otherwise.
       def should_filter?(key)
-        @patterns.none? { |pattern| key.to_s.match(pattern) }
+        @patterns.none? do |pattern|
+          if pattern.is_a?(Regexp)
+            key.match(pattern)
+          else
+            key.to_s == pattern.to_s
+          end
+        end
       end
     end
   end

--- a/spec/notifier_spec.rb
+++ b/spec/notifier_spec.rb
@@ -495,11 +495,11 @@ RSpec.describe Airbrake::Notifier do
       it "accepts strings" do
         @airbrake.blacklist_keys('bingo')
 
-        @airbrake.notify_sync(ex, bingo: 'bango')
+        @airbrake.notify_sync(ex, bingo: 'bango', bbingoo: 'bbangoo')
 
         expect(
           a_request(:post, endpoint).
-          with(body: /"params":{"bingo":"\[Filtered\]"}/)
+          with(body: /"params":{"bingo":"\[Filtered\]","bbingoo":"bbangoo"}/)
         ).to have_been_made.once
       end
     end
@@ -586,13 +586,20 @@ RSpec.describe Airbrake::Notifier do
       it "accepts strings" do
         @airbrake.whitelist_keys('bash')
 
-        @airbrake.notify_sync(ex, bingo: 'bango', bongo: 'bish', bash: 'bosh')
-
-        body = /"params":{"bingo":"\[Filtered\]","bongo":"\[Filtered\]","bash":"bosh"}/
+        @airbrake.notify_sync(
+          ex,
+          bingo: 'bango',
+          bongo: 'bish',
+          bash: 'bosh',
+          bbashh: 'bboshh'
+        )
 
         expect(
           a_request(:post, endpoint).
-          with(body: body)
+          with(
+            body: /"params":{"bingo":"\[Filtered\]","bongo":"\[Filtered\]",
+                   "bash":"bosh","bbashh":"\[Filtered\]"}/x
+          )
         ).to have_been_made.once
       end
     end


### PR DESCRIPTION
Users reported a bug when a string key would filter out other matching
keys. For example `Airbrake.blacklist_keys([:boom])` would also filter
out `:boombastic` key. The presented change makes sure that we compare
Strings and Symbols exactly.