### PR TITLE
filters: filter context payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Airbrake Ruby Changelog
 
 ### master
 
+* Started filtering the context payload
+  ([#55](https://github.com/airbrake/airbrake-ruby/pull/55))
 * Fixed bug when similar keys would be filtered out using non-regexp values for
   `Airbrake.blacklist/whitelist_keys`
   ([#54](https://github.com/airbrake/airbrake-ruby/pull/54))

--- a/lib/airbrake-ruby/filters/keys_filter.rb
+++ b/lib/airbrake-ruby/filters/keys_filter.rb
@@ -10,6 +10,10 @@ module Airbrake
     # @see KeysBlacklist
     module KeysFilter
       ##
+      # @return [String] The label to replace real values of filtered payload
+      FILTERED = '[Filtered]'.freeze
+
+      ##
       # Creates a new KeysBlacklist or KeysWhitelist filter that uses the given
       # +patterns+ for filtering a notice's payload.
       #
@@ -27,6 +31,10 @@ module Airbrake
       # @see FilterChain
       def call(notice)
         FILTERABLE_KEYS.each { |key| filter_hash(notice[key]) }
+
+        if notice[:context][:user] && should_filter?(:user)
+          notice[:context][:user] = FILTERED
+        end
 
         return unless notice[:context][:url]
         url = URI(notice[:context][:url])
@@ -46,7 +54,7 @@ module Airbrake
       def filter_hash(hash)
         hash.each_key do |key|
           if should_filter?(key)
-            hash[key] = '[Filtered]'.freeze
+            hash[key] = FILTERED
           elsif hash[key].is_a?(Hash)
             filter_hash(hash[key])
           end

--- a/spec/notifier_spec.rb
+++ b/spec/notifier_spec.rb
@@ -553,6 +553,17 @@ RSpec.describe Airbrake::Notifier do
         with(body: expected_body)
       ).to have_been_made.once
     end
+
+    it "filters out user" do
+      @airbrake.blacklist_keys('user')
+
+      notice = @airbrake.build_notice(ex)
+      notice[:context][:user] = { id: 1337, name: 'Bingo Bango' }
+
+      @airbrake.notify_sync(notice)
+
+      expect_a_request_with_body(/"user":"\[Filtered\]"/)
+    end
   end
 
   describe "#whitelist_keys" do


### PR DESCRIPTION
A user reported that it's not possible to filter context/user. It's a
reasonable request given that the user information has been moved to
context recently.