### PR TITLE
notify only when there are notifiers

### DIFF
--- a/lib/airbrake-ruby.rb
+++ b/lib/airbrake-ruby.rb
@@ -296,5 +296,5 @@ end
 
 # Notify of unhandled exceptions, if there were any, but ignore SystemExit.
 at_exit do
-  Airbrake.notify_sync($ERROR_INFO) if $ERROR_INFO
+  Airbrake.notify_sync($ERROR_INFO) if $ERROR_INFO && @notifiers.any?
 end


### PR DESCRIPTION
When there are no notifiers, this at_exit hook will cause a new exception which masks the real underlying exception:
```
lib/airbrake-ruby.rb:288:in `call_notifier': the 'default' notifier isn't configured (Airbrake::Error)
```

This makes it a bit safer, although maybe this logic should go into notify_sync instead. Any thoughts?