### PR TITLE
circle: update Rubinius versions and fix build

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -18,10 +18,10 @@ dependencies:
             rvm-exec 2.3.0 bundle install --path=vendor
             ;;
           3)
-            rvm-exec rbx-2.2.10 bundle install --path=vendor
+            rvm-exec rbx-2.11 bundle install --path=vendor
             ;;
           4)
-            rvm-exec rbx-2.5.2 bundle install --path=vendor
+            rvm-exec rbx-3.19 bundle install --path=vendor
             ;;
           5)
             JRUBY_OPTS="--dev -Xcompile.invokedynamic=false -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-noverify -Xcompile.mode=OFF" rvm-exec jruby-1.7.19 bundle install --path=vendor
@@ -48,10 +48,10 @@ test:
             rvm-exec 2.3.0 bundle exec rake
             ;;
           3)
-            rvm-exec rbx-2.2.10 bundle exec rake
+            rvm-exec rbx-2.11 bundle exec rake
             ;;
           4)
-            rvm-exec rbx-2.5.2 bundle exec rake
+            rvm-exec rbx-3.19 bundle exec rake
             ;;
           5)
             JRUBY_OPTS="--dev -Xcompile.invokedynamic=false -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-noverify -Xcompile.mode=OFF" rvm-exec jruby-1.7.19 bundle exec rake


### PR DESCRIPTION
The fix ensures that the build passes on newer Rubinius versions, which
fail with "NoMethodError: undefined method `join' on nil:NilClass." due
to (apparently) a race condition.

The fix is copied from https://github.com/puma/puma/pull/809.