### PR TITLE
airbrake-ruby: don't report unhandled exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,10 @@ Airbrake Ruby Changelog
     c.whitelist_keys = [:page_id, 'user']
   end
   ```
-
+* **IMPORTANT**: dropped support for reporting critical exceptions that
+  terminate the process. This bit of functionality was moved to the
+  [airbrake gem](https://github.com/airbrake/airbrake/pull/526) instead
+  ([#61](https://github.com/airbrake/airbrake-ruby/pull/61))
 * Started filtering the context payload
   ([#55](https://github.com/airbrake/airbrake-ruby/pull/55))
 * Fixed bug when similar keys would be filtered out using non-regexp values for
@@ -74,7 +77,6 @@ Airbrake Ruby Changelog
 
 * Initial release
 
-[airbrake-gem]: https://github.com/airbrake/airbrake
 [v1.0.0.rc.1]: https://github.com/airbrake/airbrake-ruby/releases/tag/v1.0.0.rc.1
 [v1.0.0]: https://github.com/airbrake/airbrake-ruby/releases/tag/v1.0.0
 [v1.0.1]: https://github.com/airbrake/airbrake-ruby/releases/tag/v1.0.1

--- a/README.md
+++ b/README.md
@@ -535,6 +535,19 @@ In order to run benchmarks against `master`, add the `lib` directory to your
 ruby -Ilib benchmarks/notify_async_vs_sync.rb
 ```
 
+### Reporting critical exceptions
+
+Critical exceptions are unhandled exceptions that terminate your program. By
+default, the library doesn't report them. However, you can either depend on the
+[airbrake gem][airbrake-gem] instead, which supports them, or you can add
+the following code somewhere in your app:
+
+```ruby
+at_exit do
+  Airbrake.notify_sync($!) if $!
+end
+```
+
 Supported Rubies
 ----------------
 

--- a/lib/airbrake-ruby.rb
+++ b/lib/airbrake-ruby.rb
@@ -3,7 +3,6 @@ require 'logger'
 require 'json'
 require 'thread'
 require 'set'
-require 'English'
 require 'socket'
 
 require 'airbrake-ruby/version'
@@ -292,9 +291,4 @@ module Airbrake
       end
     end
   end
-end
-
-# Notify of unhandled exceptions, if there were any, but ignore SystemExit.
-at_exit do
-  Airbrake.notify_sync($ERROR_INFO) if $ERROR_INFO
 end


### PR DESCRIPTION
Fixes #58 (Configuration setting for unhandled exceptions)

Although we delete this, it is still useful. Therefore, this
functionality is going to be moved to the Airbrake gem instead.