### PR TITLE
Allow overriding airbrake configuration.

### DIFF
--- a/lib/airbrake-ruby/config.rb
+++ b/lib/airbrake-ruby/config.rb
@@ -4,6 +4,10 @@ module Airbrake
   # can use to configure an Airbrake instance.
   class Config
     ##
+    # @return [String, Symbol] the configured notifier name.
+    attr_accessor :notifier
+
+    ##
     # @return [Integer] the project identificator. This value *must* be set.
     attr_accessor :project_id
 

--- a/spec/airbrake_spec.rb
+++ b/spec/airbrake_spec.rb
@@ -161,6 +161,41 @@ RSpec.describe Airbrake do
     end
   end
 
+  describe ".with_overrides!" do
+    before do
+      described_class.instance_variable_set(:@notifiers, {})
+    end
+
+    it "allows to override options set in .configure block" do
+      described_class.with_overrides!(project_key: '000') do
+        described_class.configure do |c|
+          c.project_id = 123
+          c.project_key = '321'
+        end
+      end
+
+      notifiers = described_class.instance_variable_get(:@notifiers)
+      config = notifiers[:default].instance_variable_get(:@config)
+
+      expect(config.project_key).to eq('000')
+    end
+
+    it "resets the overrides after block exits" do
+      described_class.with_overrides!(project_key: '000') do
+        nil
+      end
+
+      described_class.configure do |c|
+        c.project_id = 123
+        c.project_key = '321'
+      end
+
+      notifiers = described_class.instance_variable_get(:@notifiers)
+      config = notifiers[:default].instance_variable_get(:@config)
+      expect(config.project_key).to eq('321')
+    end
+  end
+
   describe ".add_filter" do
     include_examples 'error handling', :add_filter
 

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -67,6 +67,10 @@ RSpec.describe Airbrake::Config do
         expect(config.timeout).to be_nil
       end
 
+      it "doesn't set default notifier name" do
+        expect(config.notifier).to be_nil
+      end
+
       it "doesn't set default blacklist" do
         expect(config.blacklist_keys).to be_empty
       end


### PR DESCRIPTION
This addresses issue #44

Given multiple application mounted in config.ru when each application
defines it's own Airbrake config server will crash with "the 'default'
notifier was already configured" error.

Example:

```
 # app1.rb
 Airbrake.configure do |c|
   #...
 end

 # app2.rb
 Airbrake.configure do |c|
   #...
 end

 # config.ru
 require 'app1'
 require 'app2' # => ERROR
```

Changes in this P/R allow the following workaround:

```
 # config.ru
 require 'airbrake'

 Airbrake.with_overrides!(notifier: :app1) do
   require 'app1'
 end

 require 'app2'
```

App1 will use :app1 notifier instead of :default now.

/cc @kyrylo 