### PR TITLE
Don't change Net::HTTP's default of using the environment proxy

### DIFF
--- a/lib/airbrake-ruby/sync_sender.rb
+++ b/lib/airbrake-ruby/sync_sender.rb
@@ -59,10 +59,12 @@ module Airbrake
     end
 
     def proxy_params
-      [@config.proxy[:host],
-       @config.proxy[:port],
-       @config.proxy[:user],
-       @config.proxy[:password]]
+      if @config.proxy.key?(:host)
+        [@config.proxy[:host],
+         @config.proxy[:port],
+         @config.proxy[:user],
+         @config.proxy[:password]]
+      end
     end
   end
 end


### PR DESCRIPTION
http_proxy and https_proxy are respected by default.