### PR TITLE
notifier: add the ability to append params when passing a Notice object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Airbrake Ruby Changelog
 
 ### master
 
+* Fixed bug in `Notifier#notify` where the `params` Hash is ignored if the first
+  argument is an `Airbrake::Notice`
+  ([#66](https://github.com/airbrake/airbrake-ruby/pull/66))
+
 ### [v1.2.1][v1.2.1] (March 21, 2016)
 
 * Fixed bug with regard to proxy configuration, when the library unintentionally

--- a/lib/airbrake-ruby/notifier.rb
+++ b/lib/airbrake-ruby/notifier.rb
@@ -102,6 +102,7 @@ module Airbrake
       end
 
       if exception.is_a?(Airbrake::Notice)
+        exception[:params].merge!(params)
         exception
       else
         Notice.new(@config, convert_to_exception(exception), params)

--- a/spec/notifier_spec.rb
+++ b/spec/notifier_spec.rb
@@ -81,6 +81,13 @@ RSpec.describe Airbrake::Notifier do
             with(body: expected_body)
           ).to have_been_made.once
         end
+
+        it "appends provided params to the notice" do
+          notice = @airbrake.build_notice(ex)
+          @airbrake.notify_sync(notice, bingo: 'bango')
+
+          expect_a_request_with_body(/"params":{.*"bingo":"bango".*}/)
+        end
       end
     end
 


### PR DESCRIPTION
A customer who wanted to use `notify_airbrake` from the `airbrake` gem
with own params couldn't see the params because they are never
appended. This commit fixes the bug, so you can use `notify_airbrake`
or the notify methods from this library as intended.