### PR TITLE
filters/keys_filter: ignore bad URLs 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Airbrake Ruby Changelog
 
 ### master
 
+* Fixed `URI::InvalidURIError` while trying to filter non-standard URLs
+  ([#70](https://github.com/airbrake/airbrake-ruby/pull/70))
+
 ### [v1.2.2][v1.2.2] (April 5, 2016)
 
 * Fixed bug in `Notifier#notify` where the `params` Hash is ignored if the first

--- a/lib/airbrake-ruby/filters/keys_filter.rb
+++ b/lib/airbrake-ruby/filters/keys_filter.rb
@@ -37,10 +37,7 @@ module Airbrake
         end
 
         return unless notice[:context][:url]
-        url = URI(notice[:context][:url])
-        return if url.nil? || url.query.nil?
-
-        notice[:context][:url] = filter_url_params(url)
+        filter_url(notice)
       end
 
       ##
@@ -73,6 +70,17 @@ module Airbrake
         end.join('&')
 
         url.to_s
+      end
+
+      def filter_url(notice)
+        begin
+          url = URI(notice[:context][:url])
+        rescue URI::InvalidURIError
+          return
+        end
+
+        return unless url.query
+        notice[:context][:url] = filter_url_params(url)
       end
     end
   end


### PR DESCRIPTION
Fixes #69 (send_notice raises URI::InvalidURIError with invalid URIs)

We lose the ability to filter query params, but the good thing is that
we can deliver unmodified URL.