### PR TITLE
Correctly handle a frozen string with invalid characters

### DIFF
--- a/lib/airbrake-ruby/payload_truncator.rb
+++ b/lib/airbrake-ruby/payload_truncator.rb
@@ -91,7 +91,7 @@ module Airbrake
     end
 
     def truncate_string(str)
-      replace_invalid_characters!(str)
+      str = replace_invalid_characters!(str)
       return str if str.length <= @max_size
       str.slice(0, @max_size) + '[Truncated]'.freeze
     end
@@ -106,14 +106,16 @@ module Airbrake
     # For modern Rubies we use UTF-16 as a safe alternative.
     #
     # @param [String] str The string to replace characters
-    # @return [void]
-    # @note This method mutates +str+ for speed
+    # @return [String] a UTF-8 encoded string
+    # @note This method mutates +str+ unless it's frozen,
+    #   in which case it creates a duplicate
     # @see https://github.com/flori/json/commit/3e158410e81f94dbbc3da6b7b35f4f64983aa4e3
     def replace_invalid_characters!(str)
       encoding = str.encoding
       utf8_string = (encoding == Encoding::UTF_8 || encoding == Encoding::ASCII)
       return str if utf8_string && str.valid_encoding?
 
+      str = str.dup if str.frozen?
       str.encode!(TEMP_ENCODING, ENCODING_OPTIONS) if utf8_string
       str.encode!('utf-8', ENCODING_OPTIONS)
     end

--- a/spec/payload_truncator_spec.rb
+++ b/spec/payload_truncator_spec.rb
@@ -445,6 +445,17 @@ RSpec.describe Airbrake::PayloadTruncator do
 
           expect(params[:unicode]).to match(/[�\?]{4}/)
         end
+
+        it "doesn't fail when string is frozen" do
+          encoded = Base64.encode64("\xD3\xE6\xBC\x9D\xBA").encode!('ASCII-8BIT')
+          bad_string = Base64.decode64(encoded).freeze
+
+          params = { unicode: bad_string }
+
+          @truncator.truncate_object(params)
+
+          expect(params[:unicode]).to match(/[�\?]{4}/)
+        end
       end
     end
 


### PR DESCRIPTION
This change fixes a `RuntimeError: can't modify frozen String` error that happens in Payload Truncator when a string with invalid characters is frozen