### PR TITLE
airbrake-ruby: return nil instead of raising error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Airbrake Ruby Changelog
 
 ### master
 
+* **IMPORTANT:** stopped raising the `the 'default' notifier isn't configured`
+  error when Airbrake is not configured
+  ([#75](https://github.com/airbrake/airbrake-ruby/pull/75))
+
 ### [v1.2.4][v1.2.4] (May 4, 2016)
 
 * Fixed bug when trying to truncate frozen strings

--- a/lib/airbrake-ruby.rb
+++ b/lib/airbrake-ruby.rb
@@ -275,20 +275,15 @@ module Airbrake
     private
 
     ##
-    # Calls +method+ on +notifier+ with provided +args+.
-    #
-    # @raise [Airbrake::Error] if none of the notifiers exist
+    # Calls +method+ on +notifier+ with provided +args+. If +notifier+ is not
+    # configured, returns nil.
     def call_notifier(notifier, method, *args, &block)
-      if @notifiers.key?(notifier)
-        @notifiers[notifier].__send__(method, *args, &block)
-      else
-        # If we raise SystemExit, the Ruby process can gracefully quit without
-        # the unwanted Airbrake::Error.
-        raise args.first if args.first.class == SystemExit
+      return unless configured?(notifier)
+      @notifiers[notifier].__send__(method, *args, &block)
+    end
 
-        raise Airbrake::Error,
-              "the '#{notifier}' notifier isn't configured"
-      end
+    def configured?(notifier)
+      @notifiers.key?(notifier)
     end
   end
 end

--- a/spec/airbrake_spec.rb
+++ b/spec/airbrake_spec.rb
@@ -23,10 +23,7 @@ RSpec.describe Airbrake do
   shared_examples 'error handling' do |method|
     it "raises error if there is no notifier when using #{method}" do
       described_class.instance_variable_set(:@notifiers, {})
-
-      expect { described_class.__send__(method, 'bingo') }.
-        to raise_error(Airbrake::Error,
-                       "the 'default' notifier isn't configured")
+      expect(described_class.__send__(method, 'bingo')).to be_nil
     end
   end
 


### PR DESCRIPTION
Fixes https://github.com/airbrake/airbrake/issues/546
(Disable Airbrake when not configured?)

This is probably the most annoying thing about this library. People
often don't see the original error when we raise ours (the original
error becomes nested and it is hard to notice). Sometimes users also
want to disable Airbrake, but they can't do so because once the library
is required, it assumes that the user wants to configure it
immediately. So if you don't configure it, your app crashes.

The solution is to stop raising this error. If not the complaints, I
would probably leave it as is. The current behaviour makes a lot of
sense to me. However the amount of confusion is immense, so "we must
deal with it".
