### PR TITLE
notice: fix infinite loop when truncating payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Airbrake Ruby Changelog
 
 ### master
 
+* Fixed infinite loop bug while trying to truncate a notice
+  ([#83](https://github.com/airbrake/airbrake-ruby/pull/83))
+
 ### [v1.3.0][v1.3.0] (May 10, 2016)
 
 * **IMPORTANT:** stopped raising the `the 'default' notifier isn't configured`

--- a/lib/airbrake-ruby/sync_sender.rb
+++ b/lib/airbrake-ruby/sync_sender.rb
@@ -23,6 +23,14 @@ module Airbrake
     def send(notice, endpoint = @config.endpoint)
       response = nil
       req = build_post_request(endpoint, notice)
+
+      if req.body.nil?
+        @config.logger.error(
+          "#{LOG_LABEL} notice was not sent because of missing body"
+        )
+        return
+      end
+
       https = build_https(endpoint)
 
       begin

--- a/spec/payload_truncator_spec.rb
+++ b/spec/payload_truncator_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Airbrake::PayloadTruncator do
     @truncator = described_class.new(max_size, Logger.new('/dev/null'))
   end
 
-  describe ".truncate_error" do
+  describe "#truncate_error" do
     let(:error) do
       { type: 'AirbrakeTestError', message: 'App crashed!', backtrace: [] }
     end
@@ -89,7 +89,7 @@ RSpec.describe Airbrake::PayloadTruncator do
     end
   end
 
-  describe ".truncate_object" do
+  describe "#truncate_object" do
     describe "given a hash with short values" do
       let(:params) do
         { bingo: 'bango', bongo: 'bish', bash: 'bosh' }


### PR DESCRIPTION
Fixes #82 (Airbrake-ruby stuck in an infinite loop)

This is the first step to fix the problem. Firstly, we must identify
the bad payload piece, then we will be able to decide what to do next.

This PR at least fixes the infinite loop. Apparently we forget to
filter something, so we reduce truncator's `max_size` and eventually
it becomes `0`. This is a sign things went wrong, so we can return
early.