### PR TITLE
notifier: don't try to construct a notice if the current env is ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Airbrake Ruby Changelog
 
 ### master
 
+* Fixed bug when the library raises unwanted exception, when current environment
+  is ignored and a notifier is given an exception with bad backtrace
+  ([#85](https://github.com/airbrake/airbrake-ruby/pull/85))
+
 ### [v1.3.1][v1.3.1] (May 13, 2016)
 
 * Fixed infinite loop bug while trying to truncate a notice

--- a/lib/airbrake-ruby/filter_chain.rb
+++ b/lib/airbrake-ruby/filter_chain.rb
@@ -33,10 +33,6 @@ module Airbrake
     def initialize(config)
       @filters = []
 
-      if config.ignore_environments.any?
-        add_filter(env_filter(config.environment, config.ignore_environments))
-      end
-
       [SYSTEM_EXIT_FILTER, GEM_ROOT_FILTER].each do |filter|
         add_filter(filter)
       end
@@ -74,12 +70,6 @@ module Airbrake
             frame[:file].sub!(/\A#{root_directory}/, '[PROJECT_ROOT]'.freeze)
           end
         end
-      end
-    end
-
-    def env_filter(environment, ignore_environments)
-      proc do |notice|
-        notice.ignore! if ignore_environments.include?(environment)
       end
     end
   end

--- a/lib/airbrake-ruby/notifier.rb
+++ b/lib/airbrake-ruby/notifier.rb
@@ -143,6 +143,10 @@ module Airbrake
     end
 
     def send_notice(exception, params, sender = default_sender)
+      if @config.ignore_environments.any?
+        return if @config.ignore_environments.include?(@config.environment)
+      end
+
       notice = build_notice(exception, params)
       @filter_chain.refine(notice)
       return if notice.ignored?

--- a/spec/notifier_spec/options_spec.rb
+++ b/spec/notifier_spec/options_spec.rb
@@ -205,6 +205,14 @@ RSpec.describe Airbrake::Notifier do
         }
 
         include_examples 'ignored notice', params
+
+        it "returns early and doesn't try to parse the given exception" do
+          airbrake = described_class.new(airbrake_params.merge(params))
+
+          expect(Airbrake::Notice).not_to receive(:new)
+          expect(airbrake.notify_sync(ex)).to be_nil
+          expect(a_request(:post, endpoint)).not_to have_been_made
+        end
       end
 
       context "when the current env is not set and notify envs are present" do


### PR DESCRIPTION
Fixes https://github.com/airbrake/airbrake/issues/554 (Pipeline + React
stopping Airbrake with non-descript Error instead of Explanitory Rails
Error.)

We want to return as early as possible, so we don't try to parse the
given exception, which ensures we never have to deal with bad
backtraces.