### PR TITLE
config: allow setting String numbers as project_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Airbrake Ruby Changelog
 
 ### master
 
+* Allow passing a String for `project_id`
+  ([#89](https://github.com/airbrake/airbrake-ruby/pull/89))
+
 ### [v1.4.0][v1.4.0] (June 6, 2016)
 
 * Stopped raising error when the notifier lacks either project ID or project key

--- a/lib/airbrake-ruby/config.rb
+++ b/lib/airbrake-ruby/config.rb
@@ -130,7 +130,7 @@ module Airbrake
     #   otherwise
     def valid?
       return true if ignored_environment?
-      return false unless project_id.is_a?(Integer)
+      return false if project_id.to_i.zero?
       project_key.is_a?(String) && !project_key.empty?
     end
 

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -120,12 +120,21 @@ RSpec.describe Airbrake::Config do
       end
     end
 
-    context "when the project_id value is not an Integer" do
+    context "when the project_id value is not an number" do
+      it "returns false" do
+        config.project_id = 'bingo'
+        config.project_key = '321'
+
+        expect(config).not_to be_valid
+      end
+    end
+
+    context "when the project_id value is a String number" do
       it "returns false" do
         config.project_id = '123'
         config.project_key = '321'
 
-        expect(config).not_to be_valid
+        expect(config).to be_valid
       end
     end
 

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe Airbrake::Config do
       end
     end
 
-    context "when the project_id value is not an number" do
+    context "when the project_id value is not a number" do
       it "returns false" do
         config.project_id = 'bingo'
         config.project_key = '321'
@@ -130,7 +130,7 @@ RSpec.describe Airbrake::Config do
     end
 
     context "when the project_id value is a String number" do
-      it "returns false" do
+      it "returns true" do
         config.project_id = '123'
         config.project_key = '321'
 


### PR DESCRIPTION
It was a bad idea to restrict this option to Integers. People often
configure this option via ENV variables, so the value would be a
String.