### PR TITLE
config: warn if ignore_environments is set, but environment isn't

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Airbrake Ruby Changelog
 
 ### master
 
+* Print warning when the `environment` option is not configured, but
+  `ignore_environments` is
+  ([#92](https://github.com/airbrake/airbrake-ruby/pull/92))
+
 ### [v1.4.1][v1.4.1] (June 6, 2016)
 
 * Allow passing a String for `project_id`

--- a/lib/airbrake-ruby/config.rb
+++ b/lib/airbrake-ruby/config.rb
@@ -138,6 +138,11 @@ module Airbrake
     # @return [Boolean] true if the config ignores current environment, false
     #   otherwise
     def ignored_environment?
+      if ignore_environments.any? && environment.nil?
+        logger.warn("#{LOG_LABEL} the 'environment' option is not set, " \
+                    "'ignore_environments' has no effect")
+      end
+
       ignore_environments.include?(environment)
     end
 

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -156,4 +156,37 @@ RSpec.describe Airbrake::Config do
       end
     end
   end
+
+  describe "#ignored_environment?" do
+    describe "warnings" do
+      let(:out) { StringIO.new }
+      let(:config) { described_class.new(logger: Logger.new(out)) }
+
+      context "when 'ignore_environments' is set and 'environment' isn't" do
+        it "prints a warning" do
+          config.ignore_environments = [:bingo]
+
+          expect(config.ignored_environment?).to be_falsey
+          expect(out.string).to match(/ignore_environments' has no effect/)
+        end
+      end
+
+      context "when 'ignore_environments' is set along with 'environment'" do
+        it "doesn't print a warning" do
+          config.environment = :bango
+          config.ignore_environments = [:bingo]
+
+          expect(config.ignored_environment?).to be_falsey
+          expect(out.string).to be_empty
+        end
+      end
+
+      context "when 'ignore_environments' isn't set and 'environment' isn't set too" do
+        it "doesn't print a warning" do
+          expect(config.ignored_environment?).to be_falsey
+          expect(out.string).to be_empty
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes #91 (Airbrake being run on test and development environments)

This is not the first time someone is confused about this behaviour.