### PR TITLE
config: do not rely on types when trying to compare environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Airbrake Ruby Changelog
 
 ### master
 
+* Made types of the `ignore_environments` and `environment` option values not to
+  rely on each other when deciding if the current environment is ignored
+  ([#93](https://github.com/airbrake/airbrake-ruby/pull/92))
+
 ### [v1.4.2][v1.4.2] (June 8, 2016)
 
 * Print warning when the `environment` option is not configured, but

--- a/lib/airbrake-ruby/config.rb
+++ b/lib/airbrake-ruby/config.rb
@@ -143,7 +143,7 @@ module Airbrake
                     "'ignore_environments' has no effect")
       end
 
-      ignore_environments.include?(environment)
+      ignore_environments.map(&:to_s).include?(environment.to_s)
     end
 
     private

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -188,5 +188,29 @@ RSpec.describe Airbrake::Config do
         end
       end
     end
+
+    describe "environment value types" do
+      context "when 'environment' is a String" do
+        context "and when 'ignore_environments' contains Symbols" do
+          it "returns true" do
+            config.environment = 'bango'
+            config.ignore_environments = [:bango]
+
+            expect(config.ignored_environment?).to be_truthy
+          end
+        end
+      end
+
+      context "when 'environment' is a Symbol" do
+        context "and when 'ignore_environments' contains Strings" do
+          it "returns true" do
+            config.environment = :bango
+            config.ignore_environments = %w(bango)
+
+            expect(config.ignored_environment?).to be_truthy
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/airbrake/airbrake/issues/558 (Airbrake
reports during rspec)

This is also a tiny wart, which confused many people. Relaxing this
restriction doesn't harm anyone.