### PR TITLE
backtrace: add support for PL/SQL exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Airbrake Ruby Changelog
 
 ### master
 
+* Added support for PL/SQL exceptions raised by
+  [ruby-oci8](https://github.com/kubo/ruby-oci8)
+  ([#99](https://github.com/airbrake/airbrake-ruby/pull/99))
+
 ### [v1.4.3][v1.4.3] (June 10, 2016)
 
 * Made types of the `ignore_environments` and `environment` option values not to

--- a/lib/airbrake-ruby/nested_exception.rb
+++ b/lib/airbrake-ruby/nested_exception.rb
@@ -8,15 +8,16 @@ module Airbrake
     #   can unwrap. Exceptions that have a longer cause chain will be ignored
     MAX_NESTED_EXCEPTIONS = 3
 
-    def initialize(exception)
+    def initialize(exception, logger)
       @exception = exception
+      @logger = logger
     end
 
     def as_json
       unwind_exceptions.map do |exception|
         { type: exception.class.name,
           message: exception.message,
-          backtrace: Backtrace.parse(exception) }
+          backtrace: Backtrace.parse(exception, @logger) }
       end
     end
 

--- a/lib/airbrake-ruby/notice.rb
+++ b/lib/airbrake-ruby/notice.rb
@@ -60,7 +60,7 @@ module Airbrake
       }.freeze
 
       @modifiable_payload = {
-        errors: NestedException.new(exception).as_json,
+        errors: NestedException.new(exception, @config.logger).as_json,
         context: context(params),
         environment: {},
         session: {},

--- a/spec/backtrace_spec.rb
+++ b/spec/backtrace_spec.rb
@@ -146,5 +146,32 @@ RSpec.describe Airbrake::Backtrace do
         expect(described_class.parse(ex)).to eq(parsed_backtrace)
       end
     end
+
+    context "given an Oracle backtrace" do
+      let(:bt) do
+        [%(ORA-06512: at "STORE.LI_LICENSES_PACK", line 1945),
+         %(ORA-06512: at "ACTIVATION.LI_ACT_LICENSES_PACK", line 101),
+         %(ORA-06512: at line 2),
+         %(from stmt.c:243:in oci8lib_220.bundle)]
+      end
+
+      let(:ex) do
+        OCIError = AirbrakeTestError
+        OCIError.new.tap { |e| e.set_backtrace(bt) }
+      end
+
+      after { Object.__send__(:remove_const, :OCIError) }
+
+      let(:parsed_backtrace) do
+        [{ file: nil, line: 1945, function: 'STORE.LI_LICENSES_PACK' },
+         { file: nil, line: 101, function: 'ACTIVATION.LI_ACT_LICENSES_PACK' },
+         { file: nil, line: 2, function: nil },
+         { file: 'stmt.c', line: 243, function: 'oci8lib_220.bundle' }]
+      end
+
+      it "returns a properly formatted array of hashes" do
+        expect(described_class.parse(ex)).to eq(parsed_backtrace)
+      end
+    end
   end
 end

--- a/spec/nested_exception_spec.rb
+++ b/spec/nested_exception_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Airbrake::NestedException do
             Ruby21Error.raise_error('bingo')
           end
         rescue Ruby21Error => ex
-          nested_exception = described_class.new(ex)
+          nested_exception = described_class.new(ex, Logger.new('/dev/null'))
           exceptions = nested_exception.as_json
 
           expect(exceptions.size).to eq(2)
@@ -40,7 +40,7 @@ RSpec.describe Airbrake::NestedException do
             end
           end
         rescue Ruby21Error => ex
-          nested_exception = described_class.new(ex)
+          nested_exception = described_class.new(ex, Logger.new('/dev/null'))
           exceptions = nested_exception.as_json
 
           expect(exceptions.size).to eq(3)
@@ -64,7 +64,7 @@ RSpec.describe Airbrake::NestedException do
           end
         rescue Ruby21Error => ex1
           ex1.set_backtrace([])
-          nested_exception = described_class.new(ex1)
+          nested_exception = described_class.new(ex1, Logger.new('/dev/null'))
           exceptions = nested_exception.as_json
 
           expect(exceptions.size).to eq(2)


### PR DESCRIPTION
Fixes #98
(Airbrake throws away information for incompatible backtraces)