### PR TITLE
config: validate 'environment'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Airbrake Ruby Changelog
 
 * Added support for custom exception attributes
   ([#113](https://github.com/airbrake/airbrake-ruby/pull/113))
+* Started validating the 'environment' config option (a warning will be printed,
+  if it is misconfigured)
+  ([#115](https://github.com/airbrake/airbrake-ruby/pull/115))
 
 ### [v1.4.6][v1.4.6] (August 18, 2016)
 

--- a/lib/airbrake-ruby.rb
+++ b/lib/airbrake-ruby.rb
@@ -7,6 +7,7 @@ require 'socket'
 
 require 'airbrake-ruby/version'
 require 'airbrake-ruby/config'
+require 'airbrake-ruby/config/validator'
 require 'airbrake-ruby/sync_sender'
 require 'airbrake-ruby/async_sender'
 require 'airbrake-ruby/response'

--- a/lib/airbrake-ruby/config.rb
+++ b/lib/airbrake-ruby/config.rb
@@ -73,6 +73,8 @@ module Airbrake
     # @param [Hash{Symbol=>Object}] user_config the hash to be used to build the
     #   config
     def initialize(user_config = {})
+      @validator = Config::Validator.new(self)
+
       self.proxy = {}
       self.queue_size = 100
       self.workers = 1
@@ -130,8 +132,16 @@ module Airbrake
     #   otherwise
     def valid?
       return true if ignored_environment?
-      return false if project_id.to_i.zero?
-      project_key.is_a?(String) && !project_key.empty?
+
+      return false unless @validator.valid_project_id?
+      return false unless @validator.valid_project_key?
+      return false unless @validator.valid_environment?
+
+      true
+    end
+
+    def validation_error_message
+      @validator.error_message
     end
 
     ##

--- a/lib/airbrake-ruby/config/validator.rb
+++ b/lib/airbrake-ruby/config/validator.rb
@@ -1,0 +1,73 @@
+module Airbrake
+  class Config
+    ##
+    # Validates values of {Airbrake::Config} options.
+    #
+    # @api private
+    # @since v1.5.0
+    class Validator
+      ##
+      # @return [String]
+      REQUIRED_KEY_MSG = ':project_key is required'.freeze
+
+      ##
+      # @return [String]
+      REQUIRED_ID_MSG = ':project_id is required'.freeze
+
+      ##
+      # @return [String]
+      WRONG_ENV_TYPE_MSG = "the 'environment' option must be configured " \
+                           "with a Symbol (or String), but '%s' was provided: " \
+                           "%s".freeze
+
+      ##
+      # @return [Array<Class>] the list of allowed types to configure the
+      #   environment option
+      VALID_ENV_TYPES = [NilClass, String, Symbol].freeze
+
+      ##
+      # @return [String] error message, if validator was able to find any errors
+      #   in the config
+      attr_reader :error_message
+
+      ##
+      # Validates given config and stores error message, if any errors were
+      # found.
+      #
+      # @param config [Airbrake::Config] the config to validate
+      def initialize(config)
+        @config = config
+        @error_message = nil
+      end
+
+      ##
+      # @return [Boolean]
+      def valid_project_id?
+        valid = @config.project_id.to_i > 0
+        @error_message = REQUIRED_ID_MSG unless valid
+        valid
+      end
+
+      ##
+      # @return [Boolean]
+      def valid_project_key?
+        valid = @config.project_key.is_a?(String) && !@config.project_key.empty?
+        @error_message = REQUIRED_KEY_MSG unless valid
+        valid
+      end
+
+      ##
+      # @return [Boolean]
+      def valid_environment?
+        environment = @config.environment
+        valid = VALID_ENV_TYPES.any? { |type| environment.is_a?(type) }
+
+        unless valid
+          @error_message = format(WRONG_ENV_TYPE_MSG, environment.class, environment)
+        end
+
+        valid
+      end
+    end
+  end
+end

--- a/lib/airbrake-ruby/notifier.rb
+++ b/lib/airbrake-ruby/notifier.rb
@@ -31,7 +31,7 @@ module Airbrake
       @config = (user_config.is_a?(Config) ? user_config : Config.new(user_config))
 
       unless @config.valid?
-        raise Airbrake::Error, 'both :project_id and :project_key are required'
+        raise Airbrake::Error, @config.validation_error_message
       end
 
       @filter_chain = FilterChain.new(@config)

--- a/spec/config/validator_spec.rb
+++ b/spec/config/validator_spec.rb
@@ -1,0 +1,189 @@
+require 'spec_helper'
+
+RSpec.describe Airbrake::Config::Validator do
+  subject { described_class.new(config) }
+
+  describe "#valid_project_id?" do
+    context "when project id is zero" do
+      let(:config) { Airbrake::Config.new(project_id: 0) }
+
+      it "returns false" do
+        expect(subject.valid_project_id?).to be false
+      end
+
+      it "sets correct error message" do
+        expect { subject.valid_project_id? }.
+          to change { subject.error_message }.
+          to(/:project_id is required/)
+      end
+    end
+
+    context "when project_id is a String" do
+      let(:config) { Airbrake::Config.new(project_id: '000') }
+
+      context "and when it's zero" do
+        it "returns false" do
+          expect(subject.valid_project_id?).to be false
+        end
+
+        it "sets correct error message" do
+          expect { subject.valid_project_id? }.
+            to change { subject.error_message }.
+            to(/:project_id is required/)
+        end
+      end
+
+      context "and when it consists of letters" do
+        let(:config) { Airbrake::Config.new(project_id: 'bingo') }
+
+        it "returns false" do
+          expect(subject.valid_project_id?).to be false
+        end
+
+        it "sets correct error message" do
+          expect { subject.valid_project_id? }.
+            to change { subject.error_message }.
+            to(/:project_id is required/)
+        end
+      end
+
+      context "and when it's numerical" do
+        let(:config) { Airbrake::Config.new(project_id: '123') }
+
+        it "returns true" do
+          expect(subject.valid_project_id?).to be true
+        end
+
+        it "doesn't set the error message" do
+          expect { subject.valid_project_id? }.not_to change { subject.error_message }
+        end
+      end
+    end
+
+    context "when project id is non-zero" do
+      let(:config) { Airbrake::Config.new(project_id: 123) }
+
+      it "returns true" do
+        expect(subject.valid_project_id?).to be true
+      end
+
+      it "doesn't set the error message" do
+        expect { subject.valid_project_id? }.not_to change { subject.error_message }
+      end
+    end
+  end
+
+  describe "#valid_project_key?" do
+    context "when it's a String" do
+      context "and when it's empty" do
+        let(:config) { Airbrake::Config.new(project_key: '') }
+
+        it "returns false" do
+          expect(subject.valid_project_key?).to be false
+        end
+
+        it "sets correct error message" do
+          expect { subject.valid_project_key? }.
+            to change { subject.error_message }.
+            to(/:project_key is required/)
+        end
+      end
+
+      context "and when it's non-empty" do
+        let(:config) { Airbrake::Config.new(project_key: '123abc') }
+
+        it "returns true" do
+          expect(subject.valid_project_key?).to be true
+        end
+
+        it "doesn't set the error message" do
+          expect { subject.valid_project_key? }.not_to change { subject.error_message }
+        end
+      end
+    end
+
+    context "when it's not a String" do
+      let(:config) { Airbrake::Config.new(project_key: 123) }
+
+      it "returns false" do
+        expect(subject.valid_project_key?).to be false
+      end
+
+      it "sets correct error message" do
+        expect { subject.valid_project_key? }.
+          to change { subject.error_message }.
+          to(/:project_key is required/)
+      end
+    end
+  end
+
+  describe "#valid_environment?" do
+    context "when config.environment is not set" do
+      let(:config) { Airbrake::Config.new }
+
+      it "returns true" do
+        expect(subject.valid_environment?).to be true
+      end
+
+      it "doesn't set the error message" do
+        expect { subject.valid_environment? }.not_to change { subject.error_message }
+      end
+    end
+
+    context "when config.environment is set" do
+      context "and when it is not a Symbol or String" do
+        let(:config) { Airbrake::Config.new(environment: 123) }
+
+        it "returns false" do
+          expect(subject.valid_environment?).to be false
+        end
+
+        it "sets the error message" do
+          expect { subject.valid_environment? }.
+            to change { subject.error_message }.
+            to(/the 'environment' option must be configured with a Symbol/)
+        end
+      end
+
+      context "and when it is a Symbol" do
+        let(:config) { Airbrake::Config.new(environment: :bingo) }
+
+        it "returns true" do
+          expect(subject.valid_environment?).to be true
+        end
+
+        it "doesn't set the error message" do
+          expect { subject.valid_environment? }.not_to change { subject.error_message }
+        end
+      end
+
+      context "and when it is a String" do
+        let(:config) { Airbrake::Config.new(environment: 'bingo') }
+
+        it "returns true" do
+          expect(subject.valid_environment?).to be true
+        end
+
+        it "doesn't set the error message" do
+          expect { subject.valid_environment? }.not_to change { subject.error_message }
+        end
+      end
+
+      context "and when it is kind of a String" do
+        let(:string_inquirer) { Class.new(String) }
+
+        let(:config) do
+          Airbrake::Config.new(environment: string_inquirer.new('bingo'))
+        end
+
+        it "returns true" do
+          expect(subject.valid_environment?).to be true
+        end
+
+        it "doesn't set the error message" do
+          expect { subject.valid_environment? }.not_to change { subject.error_message }
+        end
+      end
+    end
+  end
+end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -155,6 +155,22 @@ RSpec.describe Airbrake::Config do
         expect(config).not_to be_valid
       end
     end
+
+    context "when the environment value is not a String" do
+      let(:out) { StringIO.new }
+      let(:config) { described_class.new(logger: Logger.new(out)) }
+
+      before do
+        config.project_id = 123
+        config.project_key = '321'
+
+        config.environment = ['bingo']
+      end
+
+      it "returns false" do
+        expect(config).not_to be_valid
+      end
+    end
   end
 
   describe "#ignored_environment?" do

--- a/spec/notifier_spec.rb
+++ b/spec/notifier_spec.rb
@@ -30,21 +30,18 @@ RSpec.describe Airbrake::Notifier do
   describe "#new" do
     context "raises error if" do
       example ":project_id is not provided" do
-        expect { described_class.new(project_id: project_id) }.
-          to raise_error(Airbrake::Error,
-                         'both :project_id and :project_key are required')
+        expect { described_class.new(project_key: project_key) }.
+          to raise_error(Airbrake::Error, ':project_id is required')
       end
 
       example ":project_key is not provided" do
-        expect { described_class.new(project_key: project_key) }.
-          to raise_error(Airbrake::Error,
-                         'both :project_id and :project_key are required')
+        expect { described_class.new(project_id: project_id) }.
+          to raise_error(Airbrake::Error, ':project_key is required')
       end
 
       example "neither :project_id nor :project_key are provided" do
         expect { described_class.new({}) }.
-          to raise_error(Airbrake::Error,
-                         'both :project_id and :project_key are required')
+          to raise_error(Airbrake::Error, ':project_id is required')
       end
     end
 


### PR DESCRIPTION
Our dashboard expects it to be a String. Now we validate it and permit
only allowed types.

I also refactored the config class and extracted validation steps to a
separate class.