### PR TITLE
backtrace: add support for JRuby classloaders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Airbrake Ruby Changelog
   ([#115](https://github.com/airbrake/airbrake-ruby/pull/115))
 * Fixed error while filtering unparseable backtraces
   ([#120](https://github.com/airbrake/airbrake-ruby/pull/120))
+* Improved support for parsing JRuby backtraces
+  ([#119](https://github.com/airbrake/airbrake-ruby/pull/119))
 
 ### [v1.4.6][v1.4.6] (August 18, 2016)
 

--- a/lib/airbrake-ruby/backtrace.rb
+++ b/lib/airbrake-ruby/backtrace.rb
@@ -26,14 +26,18 @@ module Airbrake
       ##
       # @return [Regexp] the pattern that matches JRuby Java stack frames, such
       #  as org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
-      JAVA = /\A
-        (?<function>.+)  # Matches 'org.jruby.ast.NewlineNode.interpret
+      JAVA = %r{\A
+        (?<function>.+)  # Matches 'org.jruby.ast.NewlineNode.interpret'
         \(
-          (?<file>[^:]+) # Matches 'NewlineNode.java'
+          (?<file>
+            (?:uri:classloader:/.+(?=:)) # Matches '/META-INF/jruby.home/protocol.rb'
+            |
+            [^:]+        # Matches 'NewlineNode.java'
+          )
           :?
           (?<line>\d+)?  # Matches '105'
         \)
-      \z/x
+      \z}x
 
       ##
       # @return [Regexp] the pattern that tries to assume what a generic stack


### PR DESCRIPTION
Fixes #116 (Can't parse crazy JRuby backtrace line)