### PR TITLE
circle: update rubies

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -15,20 +15,22 @@ dependencies:
             ;;
           1)
             rvm-exec 2.0.0-p645 bundle install --path=vendor
-            rvm-exec 2.1.8 bundle install --path=vendor
+            rvm-exec 2.1.10 bundle install --path=vendor
             ;;
           2)
-            rvm-exec 2.2.4 bundle install --path=vendor
-            rvm-exec 2.3.0 bundle install --path=vendor
+            rvm-exec 2.2.5 bundle install --path=vendor
+            rvm-exec 2.3.1 bundle install --path=vendor
             ;;
           3)
-            rvm-exec rbx-2.11 bundle install --path=vendor
+            rvm-exec 2.4.0-preview2 bundle install --path=vendor
             ;;
           4)
-            rvm-exec rbx-3.19 bundle install --path=vendor
+            # End of support is in the end of 2016
+            # https://github.com/jruby/jruby/issues/4112
+            JRUBY_OPTS="--dev -Xcompile.invokedynamic=false -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-noverify -Xcompile.mode=OFF" rvm-exec jruby-1.7.19 bundle install --path=vendor
             ;;
           5)
-            JRUBY_OPTS="--dev -Xcompile.invokedynamic=false -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-noverify -Xcompile.mode=OFF" rvm-exec jruby-1.7.19 bundle install --path=vendor
+            JRUBY_OPTS="--dev -Xcompile.invokedynamic=false -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-noverify -Xcompile.mode=OFF" rvm-exec jruby-9.0.5.0 bundle install --path=vendor
             ;;
         esac
       :
@@ -46,20 +48,20 @@ test:
             ;;
           1)
             rvm-exec 2.0.0-p645 bundle exec rake
-            rvm-exec 2.1.8 bundle exec rake
+            rvm-exec 2.1.10 bundle exec rake
             ;;
           2)
-            rvm-exec 2.2.4 bundle exec rake
-            rvm-exec 2.3.0 bundle exec rake
+            rvm-exec 2.2.5 bundle exec rake
+            rvm-exec 2.3.1 bundle exec rake
             ;;
           3)
-            rvm-exec rbx-2.11 bundle exec rake
+            rvm-exec 2.4.0-preview2 bundle exec rake
             ;;
           4)
-            rvm-exec rbx-3.19 bundle exec rake
+            JRUBY_OPTS="--dev -Xcompile.invokedynamic=false -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-noverify -Xcompile.mode=OFF" rvm-exec jruby-1.7.19 bundle exec rake
             ;;
           5)
-            JRUBY_OPTS="--dev -Xcompile.invokedynamic=false -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-noverify -Xcompile.mode=OFF" rvm-exec jruby-1.7.19 bundle exec rake
+            JRUBY_OPTS="--dev -Xcompile.invokedynamic=false -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-noverify -Xcompile.mode=OFF" rvm-exec jruby-9.0.5.0 bundle exec rake
             ;;
         esac
       :


### PR DESCRIPTION
* Update all TEENY version of Rubies
* Test against JRuby 9.0.5.0
* Test against MRI 2.4.0-preview2
* Stop testing against Rubinius
  This was a hard decision, but Rubinius is least stable Ruby
  implementation. I am not even sure whether anybody uses it in
  production. We often have build failures because of it. The nail in
  the coffin is its current state. Out of thin air our [builds have
  started failing on Rubinius][1]. The reason is that Rubinius wants a
  modern LLVM. I've failed to configure it to use modern LLVM (was
  getting some segfaults). Given little interest in this implementation
  in the Ruby community and the amount of time I've spent to make it
  work, I think moving on would be the best solution.

[1]: https://circleci.com/gh/airbrake/airbrake-ruby/468