### PR TITLE
gemspec: update the webmock gem

### DIFF
--- a/airbrake-ruby.gemspec
+++ b/airbrake-ruby.gemspec
@@ -28,6 +28,6 @@ DESC
   s.add_development_dependency 'rspec', '~> 3'
   s.add_development_dependency 'rake', '~> 10'
   s.add_development_dependency 'pry', '~> 0'
-  s.add_development_dependency 'webmock', '~> 1'
+  s.add_development_dependency 'webmock', '~> 2'
   s.add_development_dependency 'benchmark-ips', '~> 2'
 end


### PR DESCRIPTION
This eliminates all the Ruby warnings (finally).