### PR TITLE
backtrace: fix NoMethodError on Ruby 2.0.*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ Airbrake Ruby Changelog
 * Added support for blacklisting/whitelisting using procs
   ([#108](https://github.com/airbrake/airbrake-ruby/pull/108))
 * Deleted deprecated public API methods (whitelisting, blacklisting)
-  ([#123](https://github.com/airbrake/airbrake-ruby/pull/113))
+  ([#125](https://github.com/airbrake/airbrake-ruby/pull/125))
+* Fixed support for Ruby 2.0.* not being able to report ExecJS exceptions
+  ([#130](https://github.com/airbrake/airbrake-ruby/pull/130))
 
 ### [v1.5.0][v1.5.0] (September 9, 2016)
 

--- a/lib/airbrake-ruby.rb
+++ b/lib/airbrake-ruby.rb
@@ -70,6 +70,11 @@ module Airbrake
   RUBY_19 = RUBY_VERSION.start_with?('1.9')
 
   ##
+  # @return [Boolean] true if current Ruby is Ruby 2.0.*. The result is used
+  #   for special cases where we need to work around older implementations
+  RUBY_20 = RUBY_VERSION.start_with?('2.0')
+
+  ##
   # A Hash that holds all notifiers. The keys of the Hash are notifier
   # names, the values are Airbrake::Notifier instances.
   @notifiers = {}

--- a/lib/airbrake-ruby/backtrace.rb
+++ b/lib/airbrake-ruby/backtrace.rb
@@ -151,7 +151,7 @@ module Airbrake
         return false unless defined?(ExecJS::RuntimeError)
         return true if exception.is_a?(ExecJS::RuntimeError)
 
-        if Airbrake::RUBY_19
+        if Airbrake::RUBY_19 || Airbrake::RUBY_20
           # Ruby 1.9 doesn't support Exception#cause. We work around this by
           # parsing backtraces. It's slow, so we check only a few first frames.
           exception.backtrace[0..2].each do |frame|


### PR DESCRIPTION
Fixes https://github.com/airbrake/airbrake/issues/609
(NoMethodError: undefined method `cause' - Airbrake 5.5.0 - Rails)

It was my oversight. I forgot that `Exception#cause` was introduced
only in Ruby 2.1.0.