### PR TITLE
rubocop: configure the new Metrics/BlockLength cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -106,3 +106,12 @@ Style/VariableNumber:
 
 Style/SafeNavigation:
   Enabled: false
+
+Metrics/BlockLength:
+  CountComments: false
+  Max: 25
+  Exclude:
+    - 'Rakefile'
+    - '**/*.rake'
+    - 'spec/**/*.rb'
+    - 'airbrake-ruby.gemspec'


### PR DESCRIPTION
Fixes failing build.
The cop was introduced by:
https://github.com/bbatsov/rubocop/commit/96f308b4f5601f4642fadc5c5e2826d90df0c0f5