### PR TITLE
notice: don't send unwanted 'private' payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Airbrake Ruby Changelog
   ([#125](https://github.com/airbrake/airbrake-ruby/pull/125))
 * Fixed support for Ruby 2.0.* not being able to report ExecJS exceptions
   ([#130](https://github.com/airbrake/airbrake-ruby/pull/130))
+* Reduced notice size (small improvement, which affects every single notice)
+  ([#132](https://github.com/airbrake/airbrake-ruby/pull/132))
 
 ### [v1.5.0][v1.5.0] (September 9, 2016)
 

--- a/README.md
+++ b/README.md
@@ -550,8 +550,7 @@ notice.ignored? #=> false
 
 #### Notice#[] & Notice#[]=
 
-Accesses a notice's modifiable payload, which can be read or
-filtered. Modifiable payload includes:
+Accesses a notice's payload, which can be read or filtered. Payload includes:
 
 * `:errors`
 * `:context`

--- a/lib/airbrake-ruby/filters/keys_blacklist.rb
+++ b/lib/airbrake-ruby/filters/keys_blacklist.rb
@@ -2,7 +2,7 @@ module Airbrake
   module Filters
     ##
     # A default Airbrake notice filter. Filters only specific keys listed in the
-    # list of parameters in the modifiable payload of a notice.
+    # list of parameters in the payload of a notice.
     #
     # @example
     #   filter = Airbrake::Filters::KeysBlacklist.new(:email, /credit/i, 'password')

--- a/lib/airbrake-ruby/filters/keys_whitelist.rb
+++ b/lib/airbrake-ruby/filters/keys_whitelist.rb
@@ -1,8 +1,8 @@
 module Airbrake
   module Filters
     ##
-    # A default Airbrake notice filter. Filters everything in the modifiable
-    # payload of a notice, but specified keys.
+    # A default Airbrake notice filter. Filters everything in the payload of a
+    # notice, but specified keys.
     #
     # @example
     #   filter = Airbrake::Filters::KeysWhitelist.new(:email, /user/i, 'account_id')


### PR DESCRIPTION
This bug was present ever since we released v5. The context/notifier
payload was also appended to the root of the payload, so every notice
carried the same information twice. The API only wants context/notifier.