### PR TITLE
Send notice time as part of its context

### DIFF
--- a/lib/airbrake-ruby/notice.rb
+++ b/lib/airbrake-ruby/notice.rb
@@ -55,6 +55,7 @@ module Airbrake
     HOSTNAME = Socket.gethostname.freeze
 
     def initialize(config, exception, params = {})
+      @now = Time.now.utc
       @config = config
 
       @payload = {
@@ -153,7 +154,10 @@ module Airbrake
         action: params.delete(:action),
 
         # Make sure we always send hostname.
-        hostname: HOSTNAME
+        hostname: HOSTNAME,
+
+        # Make sure we always send the time of the exception.
+        time: @now.to_s
       }
 
       ctx.merge(CONTEXT).delete_if { |_key, val| val.nil? || val.empty? }


### PR DESCRIPTION
Is it not useful to send through the time of the exception? As far as I can tell, otherwise, the exception's time will show in whichever interface as the time it was received by the API.