### PR TITLE
gemspec: lock dependency on webmock v2.2.0

### DIFF
--- a/airbrake-ruby.gemspec
+++ b/airbrake-ruby.gemspec
@@ -29,10 +29,8 @@ DESC
   s.add_development_dependency 'rake', '~> 10'
   s.add_development_dependency 'pry', '~> 0'
 
-  s.add_development_dependency 'webmock', '~> 2'
-  # This is a webmock dependency recent versions of which don't support
-  # Ruby 1.9.3. We lock it to the last version which supports it.
-  s.add_development_dependency 'public_suffix', '~> 1.4.6'
+  # We still support Ruby 1.9.2+, but webmock 2.2.0+ doesn't.
+  s.add_development_dependency 'webmock', '= 2.2.0'
 
   s.add_development_dependency 'benchmark-ips', '~> 2'
 end


### PR DESCRIPTION
So we can still test old Rubies.