### PR TITLE
config: allow using URL slugs for 'host'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Airbrake Ruby Changelog
   ([#143](https://github.com/airbrake/airbrake-ruby/pull/143))
 * Improved JRuby parsing of frames which include classloader
   ([#140](https://github.com/airbrake/airbrake-ruby/pull/140))
+* Fixed bug in the `host` option, when it is configured with a slug
+  ([#145](https://github.com/airbrake/airbrake-ruby/pull/145))
 
 ### [v1.6.0][v1.6.0] (October 18, 2016)
 

--- a/lib/airbrake-ruby/config.rb
+++ b/lib/airbrake-ruby/config.rb
@@ -103,7 +103,7 @@ module Airbrake
       @endpoint ||=
         begin
           self.host = ('https://' << host) if host !~ %r{\Ahttps?://}
-          api = "/api/v3/projects/#{project_id}/notices?key=#{project_key}"
+          api = "api/v3/projects/#{project_id}/notices?key=#{project_key}"
           URI.join(host, api)
         end
     end
@@ -162,11 +162,6 @@ module Airbrake
       __send__("#{option}=", value)
     rescue NoMethodError
       raise Airbrake::Error, "unknown option '#{option}'"
-    end
-
-    def set_endpoint(id, key, host)
-      host = ('https://' << host) if host !~ %r{\Ahttps?://}
-      @endpoint = URI.join(host, "/api/v3/projects/#{id}/notices?key=#{key}")
     end
   end
 end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -229,4 +229,29 @@ RSpec.describe Airbrake::Config do
       end
     end
   end
+
+  describe "#endpoint" do
+    context "when host is configured with a URL with a slug" do
+      before do
+        config.project_id = 1
+        config.project_key = '2'
+      end
+
+      context "and with a trailing slash" do
+        it "sets the endpoint with the slug" do
+          config.host = 'https://localhost/bingo/'
+          expect(config.endpoint.to_s).
+            to eq('https://localhost/bingo/api/v3/projects/1/notices?key=2')
+        end
+      end
+
+      context "and without a trailing slash" do
+        it "sets the endpoint without the slug" do
+          config.host = 'https://localhost/bingo'
+          expect(config.endpoint.to_s).
+            to eq('https://localhost/api/v3/projects/1/notices?key=2')
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes #144 (Can't reach a host with a subpath)