### PR TITLE
Remove support for Ruby 1.9.2 & 1.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Airbrake Ruby Changelog
 
 ### master
 
+* **IMPORTANT:** support for Ruby 1.9.2, 1.9.3 & JRuby (1.9-mode) is dropped
+  ([#146](https://github.com/airbrake/airbrake/pull/146))
 * **IMPORTANT:** added the promise API
   ([#143](https://github.com/airbrake/airbrake-ruby/pull/143))
 * Improved JRuby parsing of frames which include classloader

--- a/README.md
+++ b/README.md
@@ -673,8 +673,8 @@ end
 Supported Rubies
 ----------------
 
-* CRuby >= 1.9.2
-* JRuby >= 1.9-mode
+* CRuby >= 2.0.0
+* JRuby >= 9k
 * Rubinius >= 2.2.10
 
 Contact

--- a/airbrake-ruby.gemspec
+++ b/airbrake-ruby.gemspec
@@ -25,12 +25,11 @@ DESC
   s.files        = ['lib/airbrake-ruby.rb', *Dir.glob('lib/**/*')]
   s.test_files   = Dir.glob('spec/**/*')
 
+  s.required_ruby_version = '>= 2.0'
+
   s.add_development_dependency 'rspec', '~> 3'
   s.add_development_dependency 'rake', '~> 10'
   s.add_development_dependency 'pry', '~> 0'
-
-  # We still support Ruby 1.9.2+, but webmock 2.2.0+ doesn't.
-  s.add_development_dependency 'webmock', '= 2.2.0'
-
+  s.add_development_dependency 'webmock', '~> 2'
   s.add_development_dependency 'benchmark-ips', '~> 2'
 end

--- a/circle.yml
+++ b/circle.yml
@@ -10,8 +10,6 @@ dependencies:
     - ? |
         case $CIRCLE_NODE_INDEX in
           0)
-            rvm-exec 1.9.2-p330 bundle install --path=vendor
-            rvm-exec 1.9.3-p551 bundle install --path=vendor
             ;;
           1)
             rvm-exec 2.0.0-p645 bundle install --path=vendor
@@ -25,9 +23,6 @@ dependencies:
             rvm-exec 2.4.0-preview3 bundle install --path=vendor
             ;;
           4)
-            # End of support is in the end of 2016
-            # https://github.com/jruby/jruby/issues/4112
-            JRUBY_OPTS="--dev -Xcompile.invokedynamic=false -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-noverify -Xcompile.mode=OFF" rvm-exec jruby-1.7.26 bundle install --path=vendor
             ;;
           5)
             JRUBY_OPTS="--dev -Xcompile.invokedynamic=false -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-noverify -Xcompile.mode=OFF" rvm-exec jruby-9.1.6.0 bundle install --path=vendor
@@ -43,8 +38,6 @@ test:
         set -e
         case $CIRCLE_NODE_INDEX in
           0)
-            rvm-exec 1.9.2-p330 bundle exec rake
-            rvm-exec 1.9.3-p551 bundle exec rake
             ;;
           1)
             rvm-exec 2.0.0-p645 bundle exec rake
@@ -58,7 +51,6 @@ test:
             rvm-exec 2.4.0-preview3 bundle exec rake
             ;;
           4)
-            JRUBY_OPTS="--dev -Xcompile.invokedynamic=false -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-noverify -Xcompile.mode=OFF" rvm-exec jruby-1.7.26 bundle exec rake
             ;;
           5)
             JRUBY_OPTS="--dev -Xcompile.invokedynamic=false -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-noverify -Xcompile.mode=OFF" rvm-exec jruby-9.1.6.0 bundle exec rake

--- a/lib/airbrake-ruby.rb
+++ b/lib/airbrake-ruby.rb
@@ -66,11 +66,6 @@ module Airbrake
   LOG_LABEL = '**Airbrake:'.freeze
 
   ##
-  # @return [Boolean] true if current Ruby is Ruby 1.9.*. The result is used
-  #   for special cases where we need to work around older implementations
-  RUBY_19 = RUBY_VERSION.start_with?('1.9')
-
-  ##
   # @return [Boolean] true if current Ruby is Ruby 2.0.*. The result is used
   #   for special cases where we need to work around older implementations
   RUBY_20 = RUBY_VERSION.start_with?('2.0')

--- a/lib/airbrake-ruby/backtrace.rb
+++ b/lib/airbrake-ruby/backtrace.rb
@@ -153,8 +153,8 @@ module Airbrake
         return false unless defined?(ExecJS::RuntimeError)
         return true if exception.is_a?(ExecJS::RuntimeError)
 
-        if Airbrake::RUBY_19 || Airbrake::RUBY_20
-          # Ruby 1.9 doesn't support Exception#cause. We work around this by
+        if Airbrake::RUBY_20
+          # Ruby <2.1 doesn't support Exception#cause. We work around this by
           # parsing backtraces. It's slow, so we check only a few first frames.
           exception.backtrace[0..2].each do |frame|
             return true if frame =~ Patterns::EXECJS_SIMPLIFIED

--- a/lib/airbrake-ruby/payload_truncator.rb
+++ b/lib/airbrake-ruby/payload_truncator.rb
@@ -10,7 +10,7 @@ module Airbrake
     ##
     # @return [String] the temporary encoding to be used when fixing invalid
     #   strings with +ENCODING_OPTIONS+
-    TEMP_ENCODING = (RUBY_VERSION == '1.9.2' ? 'iso-8859-1' : 'utf-16')
+    TEMP_ENCODING = 'utf-16'.freeze
 
     ##
     # @param [Integer] max_size maximum size of hashes, arrays and strings
@@ -98,12 +98,6 @@ module Airbrake
 
     ##
     # Replaces invalid characters in string with arbitrary encoding.
-    #
-    # For Ruby 1.9.2 the method converts encoding of +str+ to +iso-8859-1+ to
-    # avoid a bug when encoding options are no-op, when `#encode` is given the
-    # same encoding as the receiver's encoding.
-    #
-    # For modern Rubies we use UTF-16 as a safe alternative.
     #
     # @param [String] str The string to replace characters
     # @return [String] a UTF-8 encoded string

--- a/spec/backtrace_spec.rb
+++ b/spec/backtrace_spec.rb
@@ -246,12 +246,12 @@ RSpec.describe Airbrake::Backtrace do
            function: 'realtime' }]
       end
 
-      context "when not on Ruby 1.9" do
+      context "when not on Ruby 2.0" do
         let(:ex) { ExecJS::RuntimeError.new.tap { |e| e.set_backtrace(bt) } }
 
         it "returns a properly formatted array of hashes" do
           stub_const('ExecJS::RuntimeError', AirbrakeTestError)
-          stub_const('Airbrake::RUBY_19', false)
+          stub_const('Airbrake::RUBY_20', false)
 
           expect(
             described_class.parse(ex, Logger.new('/dev/null'))
@@ -259,7 +259,7 @@ RSpec.describe Airbrake::Backtrace do
         end
       end
 
-      context "when on Ruby 1.9" do
+      context "when on Ruby 2.0" do
         context "and when exception's class isn't ExecJS" do
           let(:ex) do
             ActionView::Template::Error.new.tap { |e| e.set_backtrace(bt) }
@@ -268,7 +268,7 @@ RSpec.describe Airbrake::Backtrace do
           it "returns a properly formatted array of hashes" do
             stub_const('ActionView::Template::Error', AirbrakeTestError)
             stub_const('ExecJS::RuntimeError', NameError)
-            stub_const('Airbrake::RUBY_19', true)
+            stub_const('Airbrake::RUBY_20', true)
 
             expect(
               described_class.parse(ex, Logger.new('/dev/null'))

--- a/spec/payload_truncator_spec.rb
+++ b/spec/payload_truncator_spec.rb
@@ -409,12 +409,7 @@ RSpec.describe Airbrake::PayloadTruncator do
           @truncator.truncate_object(params)
 
           expect(params[:unicode].length).to eq(max_len - 1)
-
-          if RUBY_VERSION == '1.9.2'
-            expect(params[:unicode]).to match(/\A?{#{max_size - 1}}\[Truncated\]\z/)
-          else
-            expect(params[:unicode]).to match(/\A€{#{max_size - 1}}\[Truncated\]\z/)
-          end
+          expect(params[:unicode]).to match(/\A€{#{max_size - 1}}\[Truncated\]\z/)
         end
       end
 
@@ -425,12 +420,7 @@ RSpec.describe Airbrake::PayloadTruncator do
         it "converts strings to valid UTF-8" do
           @truncator.truncate_object(params)
 
-          if RUBY_VERSION == '1.9.2'
-            expect(params[:unicode]).to eq('bad string??')
-          else
-            expect(params[:unicode]).to match(/\Abad string€[�\?]\z/)
-          end
-
+          expect(params[:unicode]).to match(/\Abad string€[�\?]\z/)
           expect { params.to_json }.not_to raise_error
         end
 


### PR DESCRIPTION
* Remove support for 1.9.2 (official support ended on 2014-07-31)
* Remove support for 1.9.3 (official support ended on 2015-02-23)
* Remove support for JRuby 1.7.X (quote from JRuby: "The primary goal of
  1.7 point releases is to fill out any missing compatibility issues
  with Ruby 1.9.3)