### PR TITLE
rubocop: disable Performance/RegexpMatch

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -115,3 +115,6 @@ Metrics/BlockLength:
     - '**/*.rake'
     - 'spec/**/*.rb'
     - 'airbrake-ruby.gemspec'
+
+Performance/RegexpMatch:
+  Enabled: false


### PR DESCRIPTION
Fixes the following failure:

```
lib/airbrake-ruby/backtrace.rb:160:28:
C: Performance/RegexpMatch: Use match? instead of =~ when MatchData is not used.
            return true if frame =~ Patterns::EXECJS_SIMPLIFIED
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

It's a new cop. We cannot use its suggestion because we support older
rubies, which don't support the new method.