### PR TITLE
Don't modify original params

### DIFF
--- a/lib/airbrake-ruby/notice.rb
+++ b/lib/airbrake-ruby/notice.rb
@@ -55,6 +55,7 @@ module Airbrake
     HOSTNAME = Socket.gethostname.freeze
 
     def initialize(config, exception, params = {})
+      params = params.dup
       @config = config
 
       @payload = {

--- a/spec/notice_spec.rb
+++ b/spec/notice_spec.rb
@@ -27,7 +27,10 @@ RSpec.describe Airbrake::Notice do
           config = Airbrake::Config.new(logger: Logger.new(out))
           notice = nil
 
-          expect { notice = described_class.new(config, ex) }.not_to raise_error
+          # Freeze params so modification will fail
+          params = {}.freeze
+
+          expect { notice = described_class.new(config, ex, params) }.not_to raise_error
           expect(out.string).to match(/#to_airbrake failed:.+Object.+must be a Hash/)
           expect(notice[:params]).to be_empty
         end


### PR DESCRIPTION
Ths params hash used by the Notice is modified in a few places. Notably, the component/action keys are deleted, and all hash values get JSON-stringified in the original hash. This PR duplicates the hash to remove that mutation of the original.

I found this because we pass our Rack `env` hash. The modifications to the hash broke one of our Rack middleware entries. We can easily work around that, but I noticed that one of the specs (the one I updated) mentioned "doesn't modify the payload", so I figured this was unintentional behavior.