### PR TITLE
gemspec: set webmock to '~> 2.3'

### DIFF
--- a/airbrake-ruby.gemspec
+++ b/airbrake-ruby.gemspec
@@ -30,6 +30,6 @@ DESC
   s.add_development_dependency 'rspec', '~> 3'
   s.add_development_dependency 'rake', '~> 10'
   s.add_development_dependency 'pry', '~> 0'
-  s.add_development_dependency 'webmock', '~> 2'
+  s.add_development_dependency 'webmock', '~> 2.3'
   s.add_development_dependency 'benchmark-ips', '~> 2'
 end

--- a/spec/notifier_spec/options_spec.rb
+++ b/spec/notifier_spec/options_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe Airbrake::Notifier do
       it "is being used if configured" do
         @airbrake.notify_sync(ex)
 
-        proxied_request = requests.pop
+        proxied_request = requests.pop(true)
 
         expect(proxied_request.header['proxy-authorization'].first).
           to eq('Basic dXNlcjpwYXNzd29yZA==')


### PR DESCRIPTION
I had a stale webmock and proxy tests were hanging on ruby-2.4.0. Newer
webmock adds support for ruby-2.4.0 and fixes tests.

Bonus change: these tests will now be raising a ThreadError in case this
error reoccurs in the future.