### PR TITLE
notice: deprecate context/action compatibility code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Airbrake Ruby Changelog
   ([#146](https://github.com/airbrake/airbrake/pull/146))
 * **IMPORTANT:** added the promise API
   ([#143](https://github.com/airbrake/airbrake-ruby/pull/143))
+* **IMPORTANT:** deprecated the `component/action` API (when setting through
+  `params`) ([#151](https://github.com/airbrake/airbrake-ruby/pull/151))
 * Improved JRuby parsing of frames which include classloader
   ([#140](https://github.com/airbrake/airbrake-ruby/pull/140))
 * Fixed bug in the `host` option, when it is configured with a slug

--- a/lib/airbrake-ruby/notice.rb
+++ b/lib/airbrake-ruby/notice.rb
@@ -140,6 +140,17 @@ module Airbrake
     private
 
     def context(params)
+      # DEPRECATION: remove the following code in the next MINOR release.
+      if params.key?(:component) || params.key?(:action)
+        @config.logger.warn(
+          "#{LOG_LABEL} passing component/action keys in the params hash is " \
+          "deprecated and will be removed soon. Please update your code to use " \
+          "`Airbrake.build_notice` and set these keys like this:\n" \
+          "  notice[:context][:component] = 'mycomponent'\n" \
+          "  notice[:context][:action] = 'myaction'"
+        )
+      end
+
       ctx = {
         version: @config.app_version,
         # We ensure that root_directory is always a String, so it can always be
@@ -148,6 +159,7 @@ module Airbrake
         rootDirectory: @config.root_directory.to_s,
         environment: @config.environment,
 
+        # DEPRECATION: remove the following code in the next MINOR release.
         # Legacy Airbrake v4 behaviour.
         component: params.delete(:component),
         action: params.delete(:action),


### PR DESCRIPTION
This was needed to ease transition from v4 to v5, but now we don't
want to support this special case due to the ability to `build_notice`
and assign `component/action` to the notice directly. It was also
impossible to have `component/action` as a normal param key.

Deprecating it first, so it can be removed in the next release. I wasn't
careful enough, so some of our integrations use this legacy API.