### PR TITLE
Release v1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Airbrake Ruby Changelog
 
 ### master
 
+### [v1.7.0][v1.7.0] (January 20, 2017)
+
 * **IMPORTANT:** support for Ruby 1.9.2, 1.9.3 & JRuby (1.9-mode) is dropped
   ([#146](https://github.com/airbrake/airbrake/pull/146))
 * **IMPORTANT:** added the promise API
@@ -230,3 +232,4 @@ Airbrake Ruby Changelog
 [v1.4.6]: https://github.com/airbrake/airbrake-ruby/releases/tag/v1.4.6
 [v1.5.0]: https://github.com/airbrake/airbrake-ruby/releases/tag/v1.5.0
 [v1.6.0]: https://github.com/airbrake/airbrake-ruby/releases/tag/v1.6.0
+[v1.7.0]: https://github.com/airbrake/airbrake-ruby/releases/tag/v1.7.0

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Installation
 Add the Airbrake Ruby gem to your Gemfile:
 
 ```ruby
-gem 'airbrake-ruby', '~> 1.6'
+gem 'airbrake-ruby', '~> 1.7'
 ```
 
 ### Manual

--- a/lib/airbrake-ruby/version.rb
+++ b/lib/airbrake-ruby/version.rb
@@ -4,5 +4,5 @@
 module Airbrake
   ##
   # @return [String] the library version
-  AIRBRAKE_RUBY_VERSION = '1.6.0'.freeze
+  AIRBRAKE_RUBY_VERSION = '1.7.0'.freeze
 end


### PR DESCRIPTION
Next planned release is either `v1.7.1` (if we need minor fixups) or
`v2.0.0`, it'll remove the deprecated `component/action` API that we
deprecate in this release.

I know this is minor, but we want to adhere semver:
http://semver.org/#how-should-i-handle-deprecating-functionality