### PR TITLE
filter_chain: separate keys filters and execute them last

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Airbrake Ruby Changelog
 
 ### master
 
+* **IMPORTANT:** fixed bug when `blacklist_keys/whitelist_keys` does not filter
+  keys at all ([#159](https://github.com/airbrake/airbrake/pull/159))
+
 ### [v1.7.0][v1.7.0] (January 20, 2017)
 
 * **IMPORTANT:** support for Ruby 1.9.2, 1.9.3 & JRuby (1.9-mode) is dropped

--- a/lib/airbrake-ruby.rb
+++ b/lib/airbrake-ruby.rb
@@ -15,12 +15,12 @@ require 'airbrake-ruby/response'
 require 'airbrake-ruby/nested_exception'
 require 'airbrake-ruby/notice'
 require 'airbrake-ruby/backtrace'
-require 'airbrake-ruby/filter_chain'
 require 'airbrake-ruby/payload_truncator'
 require 'airbrake-ruby/filters'
 require 'airbrake-ruby/filters/keys_filter'
 require 'airbrake-ruby/filters/keys_whitelist'
 require 'airbrake-ruby/filters/keys_blacklist'
+require 'airbrake-ruby/filter_chain'
 require 'airbrake-ruby/notifier'
 
 ##

--- a/spec/filter_chain_spec.rb
+++ b/spec/filter_chain_spec.rb
@@ -39,6 +39,21 @@ RSpec.describe Airbrake::FilterChain do
 
         expect(nums).to eq([0, 1, 2])
       end
+
+      it "executes keys filters last" do
+        notice[:params] = { bingo: 'bango' }
+        blacklist = Airbrake::Filters::KeysBlacklist.new(config.logger, :bingo)
+        @chain.add_filter(blacklist)
+
+        @chain.add_filter(
+          proc do |notice|
+            expect(notice[:params][:bingo]).to eq('bango')
+          end
+        )
+
+        @chain.refine(notice)
+        expect(notice[:params][:bingo]).to eq('[Filtered]')
+      end
     end
 
     describe "default backtrace filters" do


### PR DESCRIPTION
Fixes #158 (blacklist_keys does not remove sensitive information from
post bodies)

This ensures that blacklist/whitelist filters always execute last.
Without this change blacklist/whitelist filtering is broken in
`airbrake` v5.7.0.

Since `8b8af2c77ea42b70b949e3b85df6cce3c977ee40` in `airbrake/airbrake`
Rack filters are being added after blacklist/whitelist filters, which
means Rack requests are never filtered.

In general, this change makes sure we blacklist/whitelist after all
permutations on a notice are done.