### PR TITLE
Errbit fix

### DIFF
--- a/lib/airbrake-ruby/config/validator.rb
+++ b/lib/airbrake-ruby/config/validator.rb
@@ -43,7 +43,7 @@ module Airbrake
       ##
       # @return [Boolean]
       def valid_project_id?
-        valid = @config.project_id.to_i > 0
+        valid = @config.project_id.to_i != 0
         @error_message = REQUIRED_ID_MSG unless valid
         valid
       end


### PR DESCRIPTION
Errbit by default has project_id equals -1

Airbrake example config
```
Airbrake.configure do |config|
  config.host = 'some_url'
  config.project_id = -1
  config.project_key = 'some_project_key'
end
```