### PR TITLE
airbrake-ruby: deprecate `notifier_name` argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Airbrake Ruby Changelog
 
 ### master
 
+* **IMPORTANT:** Deprecated `notifier_name` argument for all public API methods
+  such as `Airbrake.notify('oops', {}, :my_notifier)`
+  ([#168](https://github.com/airbrake/airbrake/pull/168))
+
 ### [v1.7.1][v1.7.1] (February 3, 2017)
 
 * **IMPORTANT:** fixed bug when `blacklist_keys/whitelist_keys` does not filter

--- a/README.md
+++ b/README.md
@@ -129,13 +129,13 @@ end
 params = { time: Time.now }
 
 # Send an exception to Project A.
-Airbrake.notify('Oops!', params, :project_a)
+Airbrake[:project_a].notify('Oops!', params)
 
 # Send an exception to Project B.
-Airbrake.notify('Oops!', params, :project_b)
+Airbrake[:project_b].notify('Oops!', params)
 
 # Wait for the notifiers to finish their work and make them inactive.
-%i(project_a project_b).each { |notifier| Airbrake.close(notifier) }
+%i(project_a project_b).each { |notifier_name| Airbrake[notifier_name].close }
 ```
 
 Configuration
@@ -401,6 +401,14 @@ API
 
 ### Airbrake
 
+#### Airbrake.[]
+
+Retrieves a configured notifier.
+
+```ruby
+Airbrake[:my_notifier] #=> Airbrake::Notifier
+```
+
 #### Airbrake.notify
 
 Sends an exception to Airbrake asynchronously.
@@ -545,7 +553,7 @@ at_exit do
   Airbrake.close
 
   # Closes a named notifier.
-  Airbrake.close(:my_notifier)
+  Airbrake[:my_notifier].close
 end
 ```
 

--- a/lib/airbrake-ruby.rb
+++ b/lib/airbrake-ruby.rb
@@ -53,7 +53,7 @@ require 'airbrake-ruby/notifier'
 #
 #   # Send an exception via other configured notifier.
 #   params = {}
-#   Airbrake.notify('Oops', params, :my_other_project)
+#   Airbrake[:my_other_project].notify('Oops', params)
 #
 # @see Airbrake::Notifier
 # @since v1.0.0
@@ -77,6 +77,18 @@ module Airbrake
   @notifiers = {}
 
   class << self
+    ##
+    # Retrieves configured notifiers.
+    #
+    # @example
+    #   Airbrake[:my_notifier].notify('oops')
+    #
+    # @return [Airbrake::Notifier, nil]
+    # @since v1.8.0
+    def [](notifier_name)
+      @notifiers[notifier_name]
+    end
+
     ##
     # Configures a new +notifier+ with the given name. If the name is not given,
     # configures the default notifier.
@@ -139,7 +151,8 @@ module Airbrake
     #   tab in your project's dashboard
     # @return [Airbrake::Promise]
     # @see .notify_sync
-    def notify(exception, params = {}, notifier = :default)
+    def notify(exception, params = {}, notifier = (no_arg = true && :default))
+      deprecation_warn(__method__, notifier) unless no_arg
       call_notifier(notifier, __method__, exception, params)
     end
 
@@ -153,7 +166,8 @@ module Airbrake
     #
     # @return [Hash{String=>String}] the reponse from the server
     # @see .notify
-    def notify_sync(exception, params = {}, notifier = :default)
+    def notify_sync(exception, params = {}, notifier = (no_arg = true && :default))
+      deprecation_warn(__method__, notifier) unless no_arg
       call_notifier(notifier, __method__, exception, params)
     end
 
@@ -184,7 +198,8 @@ module Airbrake
     # @yieldreturn [void]
     # @return [void]
     # @note Once a filter was added, there's no way to delete it
-    def add_filter(filter = nil, notifier = :default, &block)
+    def add_filter(filter = nil, notifier = (no_arg = true && :default), &block)
+      deprecation_warn(__method__, notifier) unless no_arg
       call_notifier(notifier, __method__, filter, &block)
     end
 
@@ -204,7 +219,8 @@ module Airbrake
     # @param [Hash] params The additional params attached to the notice
     # @return [Airbrake::Notice] the notice built with help of the given
     #   arguments
-    def build_notice(exception, params = {}, notifier = :default)
+    def build_notice(exception, params = {}, notifier = (no_arg = true && :default))
+      deprecation_warn(__method__, notifier) unless no_arg
       call_notifier(notifier, __method__, exception, params)
     end
 
@@ -219,7 +235,8 @@ module Airbrake
     #   Airbrake.notify('App crashed!') #=> raises Airbrake::Error
     #
     # @return [void]
-    def close(notifier = :default)
+    def close(notifier = (no_arg = true && :default))
+      deprecation_warn(__method__, notifier) unless no_arg
       call_notifier(notifier, __method__)
     end
 
@@ -235,7 +252,8 @@ module Airbrake
     # @option deploy_params [Symbol] :revision
     # @option deploy_params [Symbol] :version
     # @return [void]
-    def create_deploy(deploy_params, notifier = :default)
+    def create_deploy(deploy_params, notifier = (no_arg = true && :default))
+      deprecation_warn(__method__, notifier) unless no_arg
       call_notifier(notifier, __method__, deploy_params)
     end
 
@@ -251,6 +269,16 @@ module Airbrake
 
     def configured?(notifier)
       @notifiers.key?(notifier)
+    end
+
+    def deprecation_warn(method, notifier)
+      warn(
+        "#{LOG_LABEL} `Airbrake.#{method}` method signature was changed. " \
+        "Passing `notifier_name` is deprecated and will be removed in the " \
+        "next MAJOR release.\n" \
+        "Use `Airbrake[:#{notifier}]` to access the :#{notifier} notifier " \
+        "and call same methods directly on it."
+      )
     end
   end
 end

--- a/lib/airbrake-ruby/notifier.rb
+++ b/lib/airbrake-ruby/notifier.rb
@@ -4,7 +4,6 @@ module Airbrake
   # synchronous and asynchronous delivery.
   #
   # @see Airbrake::Config The list of options
-  # @api private
   # @since v1.0.0
   class Notifier
     ##


### PR DESCRIPTION
Partially resolves #165 (Get rid of third argument in public API
methods)