### PR TITLE
enforce code coverage and show what is not covered

### DIFF
--- a/airbrake-ruby.gemspec
+++ b/airbrake-ruby.gemspec
@@ -33,4 +33,5 @@ DESC
   s.add_development_dependency 'webmock', '~> 2.3'
   s.add_development_dependency 'benchmark-ips', '~> 2'
   s.add_development_dependency 'rubocop', '~> 0.47'
+  s.add_development_dependency 'single_cov', '~> 0'
 end

--- a/spec/airbrake_spec.rb
+++ b/spec/airbrake_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+SingleCov.covered! file: 'lib/airbrake-ruby.rb', uncovered: 2
+
 RSpec.describe Airbrake do
   let(:endpoint) do
     'https://airbrake.io/api/v3/projects/113743/notices?key=fd04e13d806a90f96614ad8e529b2822'

--- a/spec/async_sender_spec.rb
+++ b/spec/async_sender_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+SingleCov.covered! file: 'lib/airbrake-ruby/async_sender.rb'
+
 RSpec.describe Airbrake::AsyncSender do
   before do
     stub_request(:post, /.*/).to_return(status: 201, body: '{}')

--- a/spec/backtrace_spec.rb
+++ b/spec/backtrace_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+SingleCov.covered! file: 'lib/airbrake-ruby/backtrace.rb', uncovered: 2
+
 RSpec.describe Airbrake::Backtrace do
   describe ".parse" do
     context "UNIX backtrace" do

--- a/spec/config/validator_spec.rb
+++ b/spec/config/validator_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+SingleCov.covered! file: 'lib/airbrake-ruby/config/validator.rb'
+
 RSpec.describe Airbrake::Config::Validator do
   subject { described_class.new(config) }
 

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+SingleCov.covered! file: 'lib/airbrake-ruby/config.rb', uncovered: 1
+
 RSpec.describe Airbrake::Config do
   let(:config) { described_class.new }
 

--- a/spec/filter_chain_spec.rb
+++ b/spec/filter_chain_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+SingleCov.covered! file: 'lib/airbrake-ruby/filter_chain.rb'
+
 RSpec.describe Airbrake::FilterChain do
   before do
     @chain = described_class.new(config)

--- a/spec/nested_exception_spec.rb
+++ b/spec/nested_exception_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+SingleCov.covered! file: 'lib/airbrake-ruby/nested_exception.rb'
+
 RSpec.describe Airbrake::NestedException do
   let(:config) { Airbrake::Config.new }
 

--- a/spec/notice_spec.rb
+++ b/spec/notice_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+SingleCov.covered! file: 'lib/airbrake-ruby/notice.rb', uncovered: 1
+
 RSpec.describe Airbrake::Notice do
   let(:notice) do
     described_class.new(Airbrake::Config.new, AirbrakeTestError.new, bingo: '1')

--- a/spec/notifier_spec.rb
+++ b/spec/notifier_spec.rb
@@ -1,6 +1,8 @@
 # coding: utf-8
 require 'spec_helper'
 
+SingleCov.covered! file: 'lib/airbrake-ruby/notifier.rb', uncovered: 3
+
 RSpec.describe Airbrake::Notifier do
   def expect_a_request_with_body(body)
     expect(a_request(:post, endpoint).with(body: body)).to have_been_made.once
@@ -415,6 +417,7 @@ RSpec.describe Airbrake::Notifier do
       expect_a_request_with_body(/"bingo":"bango"/)
 
       pid = fork do
+        SingleCov.disable
         expect(notifier.instance_variable_get(:@async_sender)).to have_workers
         notifier.notify('bango', bongo: 'bish')
         sleep 1
@@ -527,7 +530,7 @@ RSpec.describe Airbrake::Notifier do
     context "at program exit when it was closed manually" do
       it "doesn't raise error", skip: RUBY_ENGINE == 'jruby' do
         expect do
-          Process.wait(fork { described_class.new(airbrake_params) })
+          Process.wait(fork { SingleCov.disable; described_class.new(airbrake_params) })
         end.not_to raise_error
       end
     end

--- a/spec/payload_truncator_spec.rb
+++ b/spec/payload_truncator_spec.rb
@@ -1,6 +1,8 @@
 # coding: utf-8
 require 'spec_helper'
 
+SingleCov.covered! file: 'lib/airbrake-ruby/payload_truncator.rb', uncovered: 2
+
 RSpec.describe Airbrake::PayloadTruncator do
   let(:max_size) { 1000 }
   let(:truncated_len) { '[Truncated]'.length }

--- a/spec/promise_spec.rb
+++ b/spec/promise_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+SingleCov.covered! file: 'lib/airbrake-ruby/promise.rb'
+
 RSpec.describe Airbrake::Promise do
   subject { described_class.new }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,8 @@
+require 'bundler/setup'
+
+require 'single_cov'
+SingleCov.setup :rspec
+
 require 'airbrake-ruby'
 
 require 'webmock'

--- a/spec/sync_sender_spec.rb
+++ b/spec/sync_sender_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+SingleCov.covered! file: 'lib/airbrake-ruby/sync_sender.rb', uncovered: 4
+
 RSpec.describe Airbrake::SyncSender do
   describe "#build_https" do
     it "overrides Net::HTTP's open_timeout and read_timeout if timeout is specified" do


### PR DESCRIPTION
[single_cov](https://github.com/grosser/single_cov) makes test run fail on uncovered code and shows exactly where coverage is missing.

```
...

Finished in 2.07 seconds (files took 0.4644 seconds to load)
14 examples, 0 failures

Randomized with seed 49008

lib/airbrake-ruby.rb new uncovered lines introduced (2 current vs 0 configured)
Lines missing coverage:
lib/airbrake-ruby.rb:223
lib/airbrake-ruby.rb:239
```