### PR TITLE
set a default root_directory so source code highlighting works out of…

### DIFF
--- a/lib/airbrake-ruby/config.rb
+++ b/lib/airbrake-ruby/config.rb
@@ -96,6 +96,11 @@ module Airbrake
       self.blacklist_keys = []
       self.whitelist_keys = []
 
+      self.root_directory = (
+        (defined?(Bundler) && Bundler.root) ||
+        File.expand_path(Dir.pwd)
+      )
+
       merge(user_config)
     end
 

--- a/spec/airbrake_spec.rb
+++ b/spec/airbrake_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe Airbrake do
           # rubocop:disable Metrics/LineLength
           expected_body = %r|
             {"errors":\[{"type":"RuntimeError","message":"bingo","backtrace":\[
-            {"file":"[\w/\-\.]+spec/airbrake_spec.rb","line":\d+,"function":"[\w/\s\(\)<>]+"},
+            {"file":"\[PROJECT_ROOT\]/spec/airbrake_spec.rb","line":\d+,"function":"[\w/\s\(\)<>]+"},
             {"file":"\[GEM_ROOT\]/gems/rspec-core-.+/.+","line":\d+,"function":"[\w/\s\(\)<>]+"}
           |x
           # rubocop:enable Metrics/LineLength
@@ -167,11 +167,11 @@ RSpec.describe Airbrake do
       filter_chain = notifier.instance_variable_get(:@filter_chain)
       filters = filter_chain.instance_variable_get(:@filters)
 
-      expect(filters.size).to eq(2)
+      expect(filters.size).to eq(3)
 
       described_class.add_filter {}
 
-      expect(filters.size).to eq(3)
+      expect(filters.size).to eq(4)
       expect(filters.last).to be_a(Proc)
     end
   end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -51,8 +51,8 @@ RSpec.describe Airbrake::Config do
         expect(config.queue_size).to eq(100)
       end
 
-      it "doesn't set the default root_directory" do
-        expect(config.root_directory).to be_nil
+      it "sets the default root_directory" do
+        expect(config.root_directory).to eq Bundler.root
       end
 
       it "doesn't set the default environment" do


### PR DESCRIPTION
… the box

fixes https://github.com/airbrake/airbrake-ruby/issues/167