### PR TITLE
resolve symlinked roots since that is what is shown in backtraces

### DIFF
--- a/lib/airbrake-ruby/config.rb
+++ b/lib/airbrake-ruby/config.rb
@@ -96,9 +96,9 @@ module Airbrake
       self.blacklist_keys = []
       self.whitelist_keys = []
 
-      self.root_directory = (
+      self.root_directory = File.realpath(
         (defined?(Bundler) && Bundler.root) ||
-        File.expand_path(Dir.pwd)
+        Dir.pwd
       )
 
       merge(user_config)

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Airbrake::Config do
       end
 
       it "sets the default root_directory" do
-        expect(config.root_directory).to eq Bundler.root
+        expect(config.root_directory).to eq Bundler.root.realpath.to_s
       end
 
       it "doesn't set the default environment" do


### PR DESCRIPTION
Many of our apps are deployed in symlinked root directories, for example: `/deploys/foo/current` which points to `/deploys/foo/releases/20170316121212`. Rubies backtraces always include the fully resolved path, for example '/deploys/foo/releases/20170316121212/app/models/foo.rb:12' ... so removing the symlinked root from it does not work and results in us reporting errors that cannot be grouped together.

Fix: resolve root to it's real path and the matching works.

(Tested that realpath works with strings and Pathnames)