### PR TITLE
backtrace: fix JRuby exceptions support that are non-throwables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Airbrake Ruby Changelog
   ([#176](https://github.com/airbrake/airbrake-ruby/pull/176))
 * Fixed default `root_directory` not resolving symlinks
   ([#180](https://github.com/airbrake/airbrake-ruby/pull/180))
+* Fixed parsing JRuby exceptions that don't subclass `Java::JavaLang::Throwable`
+  ([#184](https://github.com/airbrake/airbrake-ruby/pull/184))
 
 ### [v1.8.0][v1.8.0] (February 23, 2017)
 

--- a/lib/airbrake-ruby/backtrace.rb
+++ b/lib/airbrake-ruby/backtrace.rb
@@ -128,8 +128,14 @@ module Airbrake
     # @param [Exception] exception
     # @return [Boolean]
     def self.java_exception?(exception)
-      defined?(Java::JavaLang::Throwable) &&
-        exception.is_a?(Java::JavaLang::Throwable)
+      if defined?(Java::JavaLang::Throwable) &&
+         exception.is_a?(Java::JavaLang::Throwable)
+        return true
+      end
+
+      return false unless exception.respond_to?(:backtrace)
+
+      (Patterns::JAVA =~ exception.backtrace.first) != nil
     end
 
     class << self


### PR DESCRIPTION
Fixes #183 (Can’t parse JRuby backtrace)

The problem is that that exception appears not to be subclassed from
`Java::JavaLang::Throwable` like all other JRuby exceptions, so our
algorithm returns a pattern for an MRI exception.

The fix is naive, but it still should cover most of the cases.