### PR TITLE
Fix capistrano airbrake:deploy task

### DIFF
--- a/lib/airbrake-ruby/notifier.rb
+++ b/lib/airbrake-ruby/notifier.rb
@@ -89,12 +89,9 @@ module Airbrake
     # @macro see_public_api_method
     def create_deploy(deploy_params)
       deploy_params[:environment] ||= @config.environment
-
-      host = @config.host
       path = "api/v4/projects/#{@config.project_id}/deploys?key=#{@config.project_key}"
-
       promise = Airbrake::Promise.new
-      @sync_sender.send(deploy_params, promise, URI.join(host, path))
+      @sync_sender.send(deploy_params, promise, URI.join(@config.host, path))
       promise
     end
 

--- a/lib/airbrake-ruby/notifier.rb
+++ b/lib/airbrake-ruby/notifier.rb
@@ -90,7 +90,7 @@ module Airbrake
     def create_deploy(deploy_params)
       deploy_params[:environment] ||= @config.environment
 
-      host = @config.endpoint.to_s.split(@config.endpoint.path).first
+      host = @config.host
       path = "api/v4/projects/#{@config.project_id}/deploys?key=#{@config.project_key}"
 
       promise = Airbrake::Promise.new

--- a/lib/airbrake-ruby/notifier.rb
+++ b/lib/airbrake-ruby/notifier.rb
@@ -94,7 +94,6 @@ module Airbrake
       path = "api/v4/projects/#{@config.project_id}/deploys?key=#{@config.project_key}"
 
       promise = Airbrake::Promise.new
-      p URI.join(host, path)
       @sync_sender.send(deploy_params, promise, URI.join(host, path))
       promise
     end

--- a/lib/airbrake-ruby/notifier.rb
+++ b/lib/airbrake-ruby/notifier.rb
@@ -94,6 +94,7 @@ module Airbrake
       path = "api/v4/projects/#{@config.project_id}/deploys?key=#{@config.project_key}"
 
       promise = Airbrake::Promise.new
+      p URI.join(host, path)
       @sync_sender.send(deploy_params, promise, URI.join(host, path))
       promise
     end

--- a/lib/airbrake-ruby/notifier.rb
+++ b/lib/airbrake-ruby/notifier.rb
@@ -91,7 +91,7 @@ module Airbrake
       deploy_params[:environment] ||= @config.environment
 
       host = @config.endpoint.to_s.split(@config.endpoint.path).first
-      path = "/api/v4/projects/#{@config.project_id}/deploys?key=#{@config.project_key}"
+      path = "api/v4/projects/#{@config.project_id}/deploys?key=#{@config.project_key}"
 
       promise = Airbrake::Promise.new
       @sync_sender.send(deploy_params, promise, URI.join(host, path))

--- a/spec/notifier_spec.rb
+++ b/spec/notifier_spec.rb
@@ -539,25 +539,25 @@ RSpec.describe Airbrake::Notifier do
       "https://airbrake.io/api/v4/projects/#{project_id}/deploys?key=#{project_key}"
     end
 
-    it "sends a request to the deploy API" do
+    before do
       stub_request(:post, deploy_endpoint).to_return(status: 201, body: '{"id":"123"}')
+    end
+
+    it "sends a request to the deploy API" do
       @airbrake.create_deploy({})
       expect(a_request(:post, deploy_endpoint)).to have_been_made.once
     end
 
-    describe "when a host contains subdirectories" do
-      let(:deploy_host) do
-        "https://airbrake.io/subdir/"
-      end
+    context "when a host contains paths" do
+      let(:deploy_host) { "https://example.net/errbit/" }
 
       let(:deploy_endpoint) do
         "#{deploy_host}api/v4/projects/#{project_id}/deploys?key=#{project_key}"
       end
 
       it "sends a request to the deploy API" do
-        @airbrake.instance_variable_get(:@config).host = deploy_host
-        stub_request(:post, deploy_endpoint).to_return(status: 201, body: '{"id":"123"}')
-        @airbrake.create_deploy({})
+        airbrake = described_class.new(airbrake_params.merge(host: deploy_host))
+        airbrake.create_deploy({})
         expect(a_request(:post, deploy_endpoint)).to have_been_made.once
       end
     end

--- a/spec/notifier_spec.rb
+++ b/spec/notifier_spec.rb
@@ -544,5 +544,22 @@ RSpec.describe Airbrake::Notifier do
       @airbrake.create_deploy({})
       expect(a_request(:post, deploy_endpoint)).to have_been_made.once
     end
+
+    describe "when a host contains subdirectories" do
+      let(:deploy_host) do
+        "https://airbrake.io/subdir/"
+      end
+
+      let(:deploy_endpoint) do
+        "#{deploy_host}api/v4/projects/#{project_id}/deploys?key=#{project_key}"
+      end
+
+      it "sends a request to the deploy API" do
+        @airbrake.instance_variable_get(:@config).host = deploy_host
+        stub_request(:post, deploy_endpoint).to_return(status: 201, body: '{"id":"123"}')
+        @airbrake.create_deploy({})
+        expect(a_request(:post, deploy_endpoint)).to have_been_made.once
+      end
+    end
   end
 end


### PR DESCRIPTION
```ruby
URI.join("http://example.net/myapp/", "/api").to_s # => "http://example.net/api"
URI.join("http://example.net/myapp/", "api").to_s  # => "http://example.net/myapp/api"

```
`/myapp/` disappears when there is a slash
