### PR TITLE
Send thread information by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Airbrake Ruby Changelog
 * Fixed the order of invokation of library & user defined filters, so the user
   filters are always invoked after all the library filters
   ([#195](https://github.com/airbrake/airbrake-ruby/pull/195))
+* Started attaching current thread information (including thread & fiber
+  variables) ([#198](https://github.com/airbrake/airbrake-ruby/pull/198))
 
 ### [v2.0.0][v2.0.0] (March 21, 2017)
 

--- a/lib/airbrake-ruby.rb
+++ b/lib/airbrake-ruby.rb
@@ -23,6 +23,7 @@ require 'airbrake-ruby/filters/keys_blacklist'
 require 'airbrake-ruby/filters/gem_root_filter'
 require 'airbrake-ruby/filters/system_exit_filter'
 require 'airbrake-ruby/filters/root_directory_filter'
+require 'airbrake-ruby/filters/thread_filter'
 require 'airbrake-ruby/filter_chain'
 require 'airbrake-ruby/notifier'
 
@@ -73,6 +74,11 @@ module Airbrake
   # @return [Boolean] true if current Ruby is Ruby 2.0.*. The result is used
   #   for special cases where we need to work around older implementations
   RUBY_20 = RUBY_VERSION.start_with?('2.0')
+
+  ##
+  # @return [Boolean] true if current Ruby is JRuby. The result is used for
+  #  special cases where we need to work around older implementations
+  JRUBY = (RUBY_ENGINE == 'jruby')
 
   ##
   # A Hash that holds all notifiers. The keys of the Hash are notifier

--- a/lib/airbrake-ruby/filter_chain.rb
+++ b/lib/airbrake-ruby/filter_chain.rb
@@ -28,7 +28,8 @@ module Airbrake
       @keys_filters = []
 
       [Airbrake::Filters::SystemExitFilter,
-       Airbrake::Filters::GemRootFilter].each do |filter|
+       Airbrake::Filters::GemRootFilter,
+       Airbrake::Filters::ThreadFilter].each do |filter|
         @filters << filter.new
       end
 

--- a/lib/airbrake-ruby/filters/thread_filter.rb
+++ b/lib/airbrake-ruby/filters/thread_filter.rb
@@ -1,0 +1,50 @@
+module Airbrake
+  module Filters
+    ##
+    # Attaches thread & fiber local variables along with general thread
+    # information.
+    class ThreadFilter
+      def call(notice)
+        th = Thread.current
+        thread_info = {}
+
+        if (vars = thread_variables(th)).any?
+          thread_info[:thread_variables] = vars
+        end
+
+        if (vars = fiber_variables(th)).any?
+          thread_info[:fiber_variables] = vars
+        end
+
+        # Present in Ruby 2.3+.
+        if th.respond_to?(:name) && (name = th.name)
+          thread_info[:name] = name
+        end
+
+        add_thread_info(th, thread_info)
+
+        notice[:params][:thread] = thread_info
+      end
+
+      private
+
+      def thread_variables(th)
+        th.thread_variables.map.with_object({}) do |var, h|
+          h[var] = th.thread_variable_get(var).inspect
+        end
+      end
+
+      def fiber_variables(th)
+        th.keys.map.with_object({}) { |key, h| h[key] = th[key].inspect }
+      end
+
+      def add_thread_info(th, thread_info)
+        thread_info[:self] = th.inspect
+        thread_info[:group] = th.group.list.map(&:inspect)
+        thread_info[:priority] = th.priority
+
+        thread_info[:safe_level] = th.safe_level unless Airbrake::JRUBY
+      end
+    end
+  end
+end

--- a/spec/airbrake_spec.rb
+++ b/spec/airbrake_spec.rb
@@ -128,11 +128,11 @@ RSpec.describe Airbrake do
       filter_chain = notifier.instance_variable_get(:@filter_chain)
       filters = filter_chain.instance_variable_get(:@filters)
 
-      expect(filters.size).to eq(3)
+      expect(filters.size).to eq(4)
 
       described_class.add_filter {}
 
-      expect(filters.size).to eq(4)
+      expect(filters.size).to eq(5)
       expect(filters.last).to be_a(Proc)
     end
   end

--- a/spec/filters/thread_filter_spec.rb
+++ b/spec/filters/thread_filter_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+RSpec.describe Airbrake::Filters::ThreadFilter do
+  subject { described_class.new }
+
+  let(:notice) { Airbrake::Notice.new(Airbrake::Config.new, AirbrakeTestError.new) }
+  let(:th) { Thread.current }
+
+  it "appends thread variables" do
+    th.thread_variable_set(:bingo, :bango)
+    subject.call(notice)
+    th.thread_variable_set(:bingo, nil)
+
+    expect(notice[:params][:thread][:thread_variables][:bingo]).to eq(':bango')
+  end
+
+  it "appends fiber variables" do
+    th[:bingo] = :bango
+    subject.call(notice)
+    th[:bingo] = nil
+
+    expect(notice[:params][:thread][:fiber_variables][:bingo]).to eq(':bango')
+  end
+
+  it "appends name", skip: !Thread.current.respond_to?(:name) do
+    th.name = 'bingo'
+    subject.call(notice)
+    th.name = nil
+
+    expect(notice[:params][:thread][:name]).to eq('bingo')
+  end
+
+  it "appends thread inspect (self)" do
+    subject.call(notice)
+    expect(notice[:params][:thread][:self]).to match(/\A#<Thread:.+ run>\z/)
+  end
+
+  it "appends thread group" do
+    subject.call(notice)
+    expect(notice[:params][:thread][:group][0]).to match(/\A#<Thread:.+ run>\z/)
+  end
+
+  it "appends priority" do
+    subject.call(notice)
+    expect(notice[:params][:thread][:priority]).to eq(0)
+  end
+
+  it "appends safe_level", skip: Airbrake::JRUBY do
+    subject.call(notice)
+    expect(notice[:params][:thread][:safe_level]).to eq(0)
+  end
+end

--- a/spec/notifier_spec.rb
+++ b/spec/notifier_spec.rb
@@ -154,8 +154,12 @@ RSpec.describe Airbrake::Notifier do
 
         it "features 'params'" do
           expect_a_request_with_body(
-            /"params":{"bingo":\["bango"\],"bongo":"bish"}/
+            /"params":{"bingo":\["bango"\],"bongo":"bish".*}/
           )
+        end
+
+        it "features 'params/thread'" do
+          expect_a_request_with_body(/"params":{.*"thread":{.*}/)
         end
       end
     end
@@ -360,7 +364,7 @@ RSpec.describe Airbrake::Notifier do
           include_examples(
             'truncation',
             params,
-            /"params":{"bingo":{"bango":{"bongo":".+ObjectWithIoIvars.+"}}}/
+            /"params":{"bingo":{"bango":{"bongo":".+ObjectWithIoIvars.+"}}.*}/
           )
         end
 
@@ -369,7 +373,7 @@ RSpec.describe Airbrake::Notifier do
           include_examples(
             'truncation',
             params,
-            /"params":{"bingo":\[\[".+ObjectWithIoIvars.+"\]\]}/
+            /"params":{"bingo":\[\[".+ObjectWithIoIvars.+"\]\].*}/
           )
         end
       end
@@ -382,7 +386,7 @@ RSpec.describe Airbrake::Notifier do
 
       sleep 1
 
-      expect_a_request_with_body(/params":{"bingo":"bango"}/)
+      expect_a_request_with_body(/params":{"bingo":"bango".*}/)
     end
 
     it "returns a promise" do
@@ -441,7 +445,7 @@ RSpec.describe Airbrake::Notifier do
 
       expect(
         a_request(:post, endpoint).
-        with(body: /params":{"password":"\[Filtered\]"}/)
+        with(body: /params":{"password":"\[Filtered\]".*}/)
       ).to have_been_made.once
     end
 
@@ -455,7 +459,7 @@ RSpec.describe Airbrake::Notifier do
       @airbrake.notify_sync(ex, bingo: ['bango'], bongo: 'bish', bash: 'bosh')
 
       # rubocop:disable Metrics/LineLength
-      body = /"params":{"bingo":"\[Filtered\]","bongo":"\[Filtered\]","bash":"\[Filtered\]"}/
+      body = /"params":{"bingo":"\[Filtered\]","bongo":"\[Filtered\]","bash":"\[Filtered\]".*}/
       # rubocop:enable Metrics/LineLength
 
       expect(

--- a/spec/notifier_spec/blacklist_keys_spec.rb
+++ b/spec/notifier_spec/blacklist_keys_spec.rb
@@ -49,28 +49,28 @@ RSpec.describe "Airbrake::Notifier blacklist_keys" do
   end
 
   context "when blacklisting with a Regexp" do
-    let(:expected_body) { /"params":{"bingo":"\[Filtered\]"}/ }
+    let(:expected_body) { /"params":{"bingo":"\[Filtered\]".*}/ }
     include_examples('blacklisting', [/\Abin/], bingo: 'bango')
   end
 
   context "when blacklisting with a Symbol" do
-    let(:expected_body) { /"params":{"bingo":"\[Filtered\]"}/ }
+    let(:expected_body) { /"params":{"bingo":"\[Filtered\]".*}/ }
     include_examples('blacklisting', [:bingo], bingo: 'bango')
   end
 
   context "when blacklisting with a String" do
-    let(:expected_body) { /"params":{"bingo":"\[Filtered\]"}/ }
+    let(:expected_body) { /"params":{"bingo":"\[Filtered\]".*}/ }
     include_examples('blacklisting', ['bingo'], bingo: 'bango')
   end
 
   context "when payload has a hash" do
     context "and it is a non-recursive hash" do
-      let(:expected_body) { /"params":{"bongo":{"bish":"\[Filtered\]"}}/ }
+      let(:expected_body) { /"params":{"bongo":{"bish":"\[Filtered\]"}.*}/ }
       include_examples('blacklisting', ['bish'], bongo: { bish: 'bash' })
     end
 
     context "and it is a recursive hash" do
-      let(:expected_body) { /"params":{"bingo":{"bango":"\[Filtered\]"}}/ }
+      let(:expected_body) { /"params":{"bingo":{"bango":"\[Filtered\]"}.*}/ }
 
       bongo = { bingo: {} }
       bongo[:bingo][:bango] = bongo
@@ -88,13 +88,13 @@ RSpec.describe "Airbrake::Notifier blacklist_keys" do
   end
 
   context "when there was a proc provided, which returns an array of keys" do
-    let(:expected_body) { /"params":{"bingo":"\[Filtered\]","bongo":"bish"}/ }
+    let(:expected_body) { /"params":{"bingo":"\[Filtered\]","bongo":"bish".*}/ }
     include_examples('blacklisting', [proc { 'bingo' }], bingo: 'bango', bongo: 'bish')
   end
 
   context "when there was a proc provided along with normal keys" do
     let(:expected_body) do
-      /"params":{"bingo":"bango","bongo":"\[Filtered\]","bash":"\[Filtered\]"}/
+      /"params":{"bingo":"bango","bongo":"\[Filtered\]","bash":"\[Filtered\]".*}/
     end
 
     include_examples(
@@ -117,7 +117,7 @@ RSpec.describe "Airbrake::Notifier blacklist_keys" do
 
       notifier.notify_sync(ex, bingo: 'bango', bongo: 'bish')
 
-      expect_a_request_with_body(/"params":{"bingo":"bango","bongo":"bish"}/)
+      expect_a_request_with_body(/"params":{"bingo":"bango","bongo":"bish".*}/)
     end
   end
 
@@ -139,7 +139,7 @@ RSpec.describe "Airbrake::Notifier blacklist_keys" do
         notifier.notify_sync(ex, bingo: 'bango', bongo: 'bish')
 
         expect_a_request_with_body(
-          /"params":{"bingo":"\[Filtered\]","bongo":"bish"}/
+          /"params":{"bingo":"\[Filtered\]","bongo":"bish".*}/
         )
       end
     end

--- a/spec/notifier_spec/whitelist_keys_spec.rb
+++ b/spec/notifier_spec/whitelist_keys_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe "Airbrake::Notifier whitelist_keys" do
 
   context "when whitelisting with a Regexp" do
     let(:expected_body) do
-      /"params":{"bingo":"bango","bongo":"\[Filtered\]","bash":"\[Filtered\]"}/
+      /"params":{"bingo":"bango","bongo":"\[Filtered\]","bash":"\[Filtered\]".*}/
     end
 
     include_examples(
@@ -62,7 +62,7 @@ RSpec.describe "Airbrake::Notifier whitelist_keys" do
 
   context "when whitelisting with a Symbol" do
     let(:expected_body) do
-      /"params":{"bingo":"\[Filtered\]","bongo":"bish","bash":"\[Filtered\]"}/
+      /"params":{"bingo":"\[Filtered\]","bongo":"bish","bash":"\[Filtered\]".*}/
     end
 
     include_examples(
@@ -75,7 +75,7 @@ RSpec.describe "Airbrake::Notifier whitelist_keys" do
   context "when whitelisting with a String" do
     let(:expected_body) do
       /"params":{"bingo":"\[Filtered\]","bongo":"\[Filtered\]",
-         "bash":"bosh","bbashh":"\[Filtered\]"}/x
+         "bash":"bosh","bbashh":"\[Filtered\]".*}/x
     end
 
     include_examples(
@@ -87,7 +87,9 @@ RSpec.describe "Airbrake::Notifier whitelist_keys" do
 
   context "when payload has a hash" do
     context "and it is a non-recursive hash" do
-      let(:expected_body) { /"params":{"bingo":"\[Filtered\]","bongo":{"bish":"bash"}}/ }
+      let(:expected_body) do
+        /"params":{"bingo":"\[Filtered\]","bongo":{"bish":"bash"}.*}/
+      end
 
       include_examples(
         'whitelisting',
@@ -129,7 +131,7 @@ RSpec.describe "Airbrake::Notifier whitelist_keys" do
 
   context "when there was a proc provided, which returns an array of keys" do
     let(:expected_body) do
-      /"params":{"bingo":"\[Filtered\]","bongo":"bish","bash":"\[Filtered\]"}/
+      /"params":{"bingo":"\[Filtered\]","bongo":"bish","bash":"\[Filtered\]".*}/
     end
 
     include_examples(
@@ -141,7 +143,7 @@ RSpec.describe "Airbrake::Notifier whitelist_keys" do
 
   context "when there was a proc provided along with normal keys" do
     let(:expected_body) do
-      /"params":{"bingo":"\[Filtered\]","bongo":"bish","bash":"bosh"}/
+      /"params":{"bingo":"\[Filtered\]","bongo":"bish","bash":"bosh".*}/
     end
 
     include_examples(
@@ -169,7 +171,7 @@ RSpec.describe "Airbrake::Notifier whitelist_keys" do
         notifier.notify_sync(ex, bingo: 'bango', bongo: 'bish')
 
         expect_a_request_with_body(
-          /"params":{"bingo":"bango","bongo":"\[Filtered\]"}/
+          /"params":{"bingo":"bango","bongo":"\[Filtered\]".*}/
         )
       end
     end
@@ -189,7 +191,7 @@ RSpec.describe "Airbrake::Notifier whitelist_keys" do
       notifier.notify_sync(ex, bingo: 'bango', bongo: 'bish')
 
       expect_a_request_with_body(
-        /"params":{"bingo":"\[Filtered\]","bongo":"\[Filtered\]"}/
+        /"params":{"bingo":"\[Filtered\]","bongo":"\[Filtered\]".*}/
       )
     end
   end


### PR DESCRIPTION
Fixes #187 (Save context of a current thread)
Replaces #194

Instead of providing an abstraction over `Thread.thread_variable_set`,
simply send everything we know about current thread.