### PR TITLE
notifier: make 'notify/notify_sync' accept a block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Airbrake Ruby Changelog
 
 ### master
 
+* Make `notify/notify_sync` accept a block, which yields an `Airbrake::Notice`
+  ([#201](https://github.com/airbrake/airbrake-ruby/pull/201))
+
 ### [v2.1.0][v2.1.0] (April 27, 2017)
 
 * Return `Airbrake::NilNotifier` when no notifiers are configured and

--- a/README.md
+++ b/README.md
@@ -438,6 +438,14 @@ Airbrake.notify('App crashed!', {
 })
 ```
 
+Accepts a block, which yields an `Airbrake::Notice`:
+
+```ruby
+Airbrake.notify('App crashed') do |notice|
+  notice[:params][:foo] = :bar
+end
+```
+
 Returns an [`Airbrake::Promise`](#promise), which can be used to read Airbrake
 error ids.
 
@@ -535,6 +543,8 @@ notice = Airbrake.build_notice('App crashed!')
 notice[:params][:username] = user.name
 airbrake.notify_sync(notice)
 ```
+
+See the block form of [`Airbrake.notify`](#airbrakenotify) for shorter syntax.
 
 #### Airbrake.close
 

--- a/lib/airbrake-ruby.rb
+++ b/lib/airbrake-ruby.rb
@@ -153,10 +153,13 @@ module Airbrake
     # @param [Hash] params The additional payload to be sent to Airbrake. Can
     #   contain any values. The provided values will be displayed in the Params
     #   tab in your project's dashboard
+    # @yield [notice] The notice to filter
+    # @yieldparam [Airbrake::Notice]
+    # @yieldreturn [void]
     # @return [Airbrake::Promise]
     # @see .notify_sync
-    def notify(exception, params = {})
-      @notifiers[:default].notify(exception, params)
+    def notify(exception, params = {}, &block)
+      @notifiers[:default].notify(exception, params, &block)
     end
 
     ##
@@ -166,10 +169,18 @@ module Airbrake
     #   Airbrake.notify_sync('App crashed!')
     #   #=> {"id"=>"123", "url"=>"https://airbrake.io/locate/321"}
     #
+    # @param [Exception, String, Airbrake::Notice] exception The exception to be
+    #   sent to Airbrake
+    # @param [Hash] params The additional payload to be sent to Airbrake. Can
+    #   contain any values. The provided values will be displayed in the Params
+    #   tab in your project's dashboard
+    # @yield [notice] The notice to filter
+    # @yieldparam [Airbrake::Notice]
+    # @yieldreturn [void]
     # @return [Hash{String=>String}] the reponse from the server
     # @see .notify
-    def notify_sync(exception, params = {})
-      @notifiers[:default].notify_sync(exception, params)
+    def notify_sync(exception, params = {}, &block)
+      @notifiers[:default].notify_sync(exception, params, &block)
     end
 
     ##

--- a/lib/airbrake-ruby/notifier.rb
+++ b/lib/airbrake-ruby/notifier.rb
@@ -47,14 +47,14 @@ module Airbrake
 
     ##
     # @macro see_public_api_method
-    def notify(exception, params = {})
-      send_notice(exception, params, default_sender)
+    def notify(exception, params = {}, &block)
+      send_notice(exception, params, default_sender, &block)
     end
 
     ##
     # @macro see_public_api_method
-    def notify_sync(exception, params = {})
-      send_notice(exception, params, @sync_sender).value
+    def notify_sync(exception, params = {}, &block)
+      send_notice(exception, params, @sync_sender, &block).value
     end
 
     ##
@@ -119,6 +119,8 @@ module Airbrake
 
       notice = build_notice(exception, params)
       @filter_chain.refine(notice)
+      yield notice if block_given?
+
       if notice.ignored?
         return promise.reject("#{notice} was marked as ignored")
       end

--- a/spec/airbrake_spec.rb
+++ b/spec/airbrake_spec.rb
@@ -41,6 +41,19 @@ RSpec.describe Airbrake do
       sleep 2
       expect(a_request(:post, endpoint)).to have_been_made.once
     end
+
+    it "yields a notice" do
+      described_class.notify('bongo') do |notice|
+        notice[:params][:bingo] = :bango
+      end
+
+      sleep 1
+
+      expect(
+        a_request(:post, endpoint).
+        with(body: /params":{.*"bingo":"bango".*}/)
+      ).to have_been_made.once
+    end
   end
 
   describe ".notify_sync" do
@@ -49,6 +62,17 @@ RSpec.describe Airbrake do
     it "sends exceptions synchronously" do
       expect(described_class.notify_sync('bingo')).to be_a(Hash)
       expect(a_request(:post, endpoint)).to have_been_made.once
+    end
+
+    it "yields a notice" do
+      described_class.notify_sync('bongo') do |notice|
+        notice[:params][:bingo] = :bango
+      end
+
+      expect(
+        a_request(:post, endpoint).
+        with(body: /params":{.*"bingo":"bango".*}/)
+      ).to have_been_made.once
     end
 
     describe "clean backtrace" do

--- a/spec/notifier_spec.rb
+++ b/spec/notifier_spec.rb
@@ -378,6 +378,13 @@ RSpec.describe Airbrake::Notifier do
         end
       end
     end
+
+    describe "block argument" do
+      it "yields a notice" do
+        @airbrake.notify_sync(ex) { |notice| notice[:params][:bingo] = :bango }
+        expect_a_request_with_body(/params":{.*"bingo":"bango".*}/)
+      end
+    end
   end
 
   describe "#notify" do


### PR DESCRIPTION
This simplifies public API, so users don't have to use `build_notice`
manually anymore. This change will be especially useful for setting
severity like this:

```ruby
Airbrake.notify('oops') do |notice|
  notice[:context][:severity] = 'emergency'
end
```