### PR TITLE
notice: set context/severity to error and document severity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Airbrake Ruby Changelog
 
 * Make `notify/notify_sync` accept a block, which yields an `Airbrake::Notice`
   ([#201](https://github.com/airbrake/airbrake-ruby/pull/201))
+* Started sending `context/severity`, which is set to `error`
+  ([#202](https://github.com/airbrake/airbrake-ruby/pull/202))
 
 ### [v2.1.0][v2.1.0] (April 27, 2017)
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Key features
 * SSL support (all communication with Airbrake is encrypted by default)
 * Support for fatal exceptions (the ones that terminate your program)
 * Support for custom exception attributes<sup>[[link](#custom-exception-attributes)]</sup>
+* Severity support<sup>[[link](#setting-severity)]</sup>
 * Last but not least, we follow semantic versioning 2.0.0<sup>[[link][semver2]]</sup>
 
 Installation
@@ -449,6 +450,19 @@ end
 Returns an [`Airbrake::Promise`](#promise), which can be used to read Airbrake
 error ids.
 
+
+##### Setting severity
+
+[Severity][what-is-severity] allows categorizing how severe an error is. By
+default, it's set to `error`. To redefine severity, simply overwrite
+`context/severity` of a notice object. For example:
+
+```ruby
+Airbrake.notify do |notice|
+  notice[:context][:severity] = 'critical'
+end
+```
+
 #### Airbrake.notify_sync
 
 Sends an exception to Airbrake synchronously. Returns a Hash with an error ID
@@ -773,3 +787,4 @@ The project uses the MIT License. See LICENSE.md for details.
 [golang]: https://golang.org/
 [yard-api]: http://www.rubydoc.info/gems/airbrake-ruby
 [arthur-ruby]: https://s3.amazonaws.com/airbrake-github-assets/airbrake-ruby/arthur-ruby.jpg
+[what-is-severity]: https://airbrake.io/docs/airbrake-faq/what-is-severity/

--- a/lib/airbrake-ruby/notice.rb
+++ b/lib/airbrake-ruby/notice.rb
@@ -57,6 +57,10 @@ module Airbrake
     HOSTNAME = Socket.gethostname.freeze
 
     ##
+    # @return [String]
+    DEFAULT_SEVERITY = 'error'.freeze
+
+    ##
     # @since v1.7.0
     # @return [Hash{Symbol=>Object}] the hash with arbitrary objects to be used
     #   in filters
@@ -158,7 +162,9 @@ module Airbrake
         environment: @config.environment,
 
         # Make sure we always send hostname.
-        hostname: HOSTNAME
+        hostname: HOSTNAME,
+
+        severity: DEFAULT_SEVERITY
       }.merge(CONTEXT).delete_if { |_key, val| val.nil? || val.empty? }
     end
 

--- a/spec/notice_spec.rb
+++ b/spec/notice_spec.rb
@@ -200,6 +200,10 @@ RSpec.describe Airbrake::Notice do
       expect(notice.to_json).
         to match(/"context":{.*"hostname":".+".*}/)
     end
+
+    it "defaults to the error severity" do
+      expect(notice.to_json).to match(/"context":{.*"severity":"error".*}/)
+    end
   end
 
   describe "#[]" do


### PR DESCRIPTION
The link to the severity doc is handled by:
airbrake/airbrake-docs#115