### PR TITLE
filters/thread_filter: don't serialise IO objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Airbrake Ruby Changelog
 
 ### master
 
+* Fixed segfault on Ruby 2.1 while using the thread filter
+  ([#206](https://github.com/airbrake/airbrake-ruby/pull/206))
+
 ### [v2.2.0][v2.2.0] (May 1, 2017)
 
 * Make `notify/notify_sync` accept a block, which yields an `Airbrake::Notice`

--- a/lib/airbrake-ruby/filters/thread_filter.rb
+++ b/lib/airbrake-ruby/filters/thread_filter.rb
@@ -38,12 +38,17 @@ module Airbrake
 
       def thread_variables(th)
         th.thread_variables.map.with_object({}) do |var, h|
-          h[var] = th.thread_variable_get(var).inspect
+          next if (value = th.thread_variable_get(var)).is_a?(IO)
+          h[var] = value
         end
       end
 
       def fiber_variables(th)
-        th.keys.map.with_object({}) { |key, h| h[key] = th[key].inspect }
+        th.keys.map.with_object({}) do |key, h|
+          next if key == :__recursive_key__
+          next if (value = th[key]).is_a?(IO)
+          h[key] = value
+        end
       end
 
       def add_thread_info(th, thread_info)


### PR DESCRIPTION
Fixes #204 (Airbrake gem segfaults on Circle CI)

I stumbled upon an edge case while running the thread filter against a
Rails app. The app would stuck because `io_obj.to_json` would never
return. The `io_obj` was open. Closed IO objects raise IOError, which
we already handle.

To make sure we avoid any kind of segfaults, we ignore
`:__recursive_key__`, which holds data for PrettyPrint.