### PR TITLE
filters/thread_filter: ignore the `__rspec` key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Airbrake Ruby Changelog
 
 ### master
 
+* Fixed `SystemStackError` while using the thread filter with RSpec
+  ([#208](https://github.com/airbrake/airbrake-ruby/pull/208))
+
 ### [v2.2.1][v2.2.1] (May 4, 2017)
 
 * Fixed segfault on Ruby 2.1 while using the thread filter

--- a/lib/airbrake-ruby/filters/thread_filter.rb
+++ b/lib/airbrake-ruby/filters/thread_filter.rb
@@ -8,6 +8,16 @@ module Airbrake
       # @return [Integer]
       attr_reader :weight
 
+      ##
+      # @return [Array<Symbol>] the list of ignored fiber variables
+      IGNORED_FIBER_VARIABLES = [
+        # https://github.com/airbrake/airbrake-ruby/issues/204
+        :__recursive_key__,
+
+        # https://github.com/rails/rails/issues/28996
+        :__rspec
+      ].freeze
+
       def initialize
         @weight = 110
       end
@@ -45,7 +55,7 @@ module Airbrake
 
       def fiber_variables(th)
         th.keys.map.with_object({}) do |key, h|
-          next if key == :__recursive_key__
+          next if IGNORED_FIBER_VARIABLES.any? { |v| v == key }
           next if (value = th[key]).is_a?(IO)
           h[key] = value
         end


### PR DESCRIPTION
RSpec puts current example into a fiber variable. When we fetch it
and try to convert it to JSON with ActiveSupport's version of
`#to_json`, the library crashes with a `SystemStackError`.

The fix for this will probably be here:
https://github.com/rails/rails/issues/28996