### PR TITLE
filters/keys_filter: handle hash keys that are not symbols/strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Airbrake Ruby Changelog
 
 ### master
 
+* Fixed bug in keys filters while trying to filter a non Symbol/String key when
+  there's a Regexp ignore pattern defined
+  ([#213](https://github.com/airbrake/airbrake-ruby/pull/213))
+
 ### [v2.2.2][v2.2.2] (May 5, 2017)
 
 * Fixed `SystemStackError` while using the thread filter with RSpec

--- a/lib/airbrake-ruby/filters/keys_filter.rb
+++ b/lib/airbrake-ruby/filters/keys_filter.rb
@@ -70,7 +70,7 @@ module Airbrake
 
       def filter_hash(hash)
         hash.each_key do |key|
-          if should_filter?(key)
+          if should_filter?(key.to_s)
             hash[key] = FILTERED
           elsif hash[key].is_a?(Hash)
             filter_hash(hash[key])

--- a/spec/filters/keys_blacklist_spec.rb
+++ b/spec/filters/keys_blacklist_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+RSpec.describe Airbrake::Filters::KeysBlacklist do
+  subject do
+    described_class.new(Logger.new('/dev/null'), patterns)
+  end
+
+  describe "#call" do
+    let(:notice) do
+      Airbrake::Notice.new(Airbrake::Config.new, AirbrakeTestError.new)
+    end
+
+    context "when a pattern is a regexp and when a key is a hash" do
+      let(:patterns) { [/bango/] }
+
+      it "doesn't fail" do
+        notice[:params] = { bingo: { {} => 'unfiltered' } }
+        expect { subject.call(notice) }.not_to raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/airbrake/airbrake/issues/739
(Error Handler Threw An Error - Sidekiq)