### PR TITLE
filter_chain: simplify class and tests

### DIFF
--- a/lib/airbrake-ruby/filter_chain.rb
+++ b/lib/airbrake-ruby/filter_chain.rb
@@ -19,33 +19,9 @@ module Airbrake
     # @return [Integer]
     DEFAULT_WEIGHT = 0
 
-    ##
-    # @param [Airbrake::Config] config
-    def initialize(config)
+    def initialize
       @filters = []
-
       DEFAULT_FILTERS.each { |f| add_filter(f.new) }
-
-      if config.whitelist_keys.any?
-        add_filter(
-          Airbrake::Filters::KeysWhitelist.new(
-            config.logger,
-            config.whitelist_keys
-          )
-        )
-      end
-
-      if config.blacklist_keys.any?
-        add_filter(
-          Airbrake::Filters::KeysBlacklist.new(
-            config.logger,
-            config.blacklist_keys
-          )
-        )
-      end
-
-      return unless (root_directory = config.root_directory)
-      add_filter(Airbrake::Filters::RootDirectoryFilter.new(root_directory))
     end
 
     ##

--- a/spec/filter_chain_spec.rb
+++ b/spec/filter_chain_spec.rb
@@ -1,222 +1,46 @@
 require 'spec_helper'
 
 RSpec.describe Airbrake::FilterChain do
-  before do
-    @chain = described_class.new(config)
+  let(:notice) do
+    Airbrake::Notice.new(Airbrake::Config.new, AirbrakeTestError.new)
   end
 
-  let(:config) { Airbrake::Config.new }
-
   describe "#refine" do
-    describe "execution order" do
-      let(:notice) do
-        Airbrake::Notice.new(config, AirbrakeTestError.new)
-      end
+    let(:filter) do
+      Class.new do
+        attr_reader :weight
 
-      it "executes keys filters last" do
-        notice[:params] = { bingo: 'bango' }
-        config.blacklist_keys = [:bingo]
-        @chain = described_class.new(config)
-
-        @chain.add_filter(
-          proc do |notice|
-            expect(notice[:params][:bingo]).to eq('bango')
-          end
-        )
-
-        @chain.refine(notice)
-        expect(notice[:params][:bingo]).to eq('[Filtered]')
-      end
-
-      describe "filter weight" do
-        let(:filter) do
-          Class.new do
-            attr_reader :weight
-
-            def initialize(weight)
-              @weight = weight
-            end
-
-            def call(notice)
-              notice[:params][:bingo] << @weight
-            end
-          end
+        def initialize(weight)
+          @weight = weight
         end
 
-        it "executes filters from heaviest to lightest" do
-          notice[:params][:bingo] = []
-
-          (0...3).reverse_each do |i|
-            @chain.add_filter(filter.new(i))
-          end
-          @chain.refine(notice)
-
-          expect(notice[:params][:bingo]).to eq([2, 1, 0])
-        end
-
-        it "stops execution once a notice was ignored" do
-          f2 = filter.new(2)
-          expect(f2).to receive(:call)
-
-          f1 = proc { |notice| notice.ignore! }
-
-          f0 = filter.new(-1)
-          expect(f0).not_to receive(:call)
-
-          [f2, f1, f0].each { |f| @chain.add_filter(f) }
-
-          @chain.refine(notice)
+        def call(notice)
+          notice[:params][:bingo] << @weight
         end
       end
     end
 
-    describe "default backtrace filters" do
-      let(:ex) { AirbrakeTestError.new.tap { |e| e.set_backtrace(backtrace) } }
-      let(:notice) { Airbrake::Notice.new(config, ex) }
+    it "executes filters from heaviest to lightest" do
+      notice[:params][:bingo] = []
 
-      before do
-        Gem.path << '/my/gem/root' << '/my/other/gem/root'
-        @chain.refine(notice)
-        @bt = notice[:errors].first[:backtrace].map { |frame| frame[:file] }
-      end
+      (0...3).reverse_each { |i| subject.add_filter(filter.new(i)) }
+      subject.refine(notice)
 
-      shared_examples 'root directories' do |root_directory, bt, expected_bt|
-        let(:backtrace) { bt }
-
-        before do
-          config = Airbrake::Config.new(root_directory: root_directory)
-          chain = described_class.new(config)
-          chain.refine(notice)
-          @bt = notice[:errors].first[:backtrace].map { |frame| frame[:file] }
-        end
-
-        it "filters it out" do
-          expect(@bt).to eq(expected_bt)
-        end
-      end
-
-      # rubocop:disable Metrics/LineLength
-      context "gem root" do
-        bt = [
-          "/home/kyrylo/code/airbrake/ruby/spec/spec_helper.rb:23:in `<top (required)>'",
-          "/my/gem/root/gems/rspec-core-3.3.2/lib/rspec/core/configuration.rb:1327:in `load'",
-          "/opt/rubies/ruby-2.2.2/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'",
-          "/my/other/gem/root/gems/rspec-core-3.3.2/exe/rspec:4:in `<main>'"
-        ]
-
-        expected_bt = [
-          "/home/kyrylo/code/airbrake/ruby/spec/spec_helper.rb",
-          "[GEM_ROOT]/gems/rspec-core-3.3.2/lib/rspec/core/configuration.rb",
-          "/opt/rubies/ruby-2.2.2/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb",
-          "[GEM_ROOT]/gems/rspec-core-3.3.2/exe/rspec"
-        ]
-
-        include_examples 'root directories', nil, bt, expected_bt
-      end
-
-      context "root directory" do
-        context "when normal string path" do
-          bt = [
-            "/home/kyrylo/code/airbrake/ruby/spec/spec_helper.rb:23:in `<top (required)>'",
-            "/var/www/project/gems/rspec-core-3.3.2/lib/rspec/core/configuration.rb:1327:in `load'",
-            "/opt/rubies/ruby-2.2.2/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'",
-            "/var/www/project/gems/rspec-core-3.3.2/exe/rspec:4:in `<main>'"
-          ]
-
-          expected_bt = [
-            "/home/kyrylo/code/airbrake/ruby/spec/spec_helper.rb",
-            "[PROJECT_ROOT]/gems/rspec-core-3.3.2/lib/rspec/core/configuration.rb",
-            "/opt/rubies/ruby-2.2.2/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb",
-            "[PROJECT_ROOT]/gems/rspec-core-3.3.2/exe/rspec"
-          ]
-
-          include_examples 'root directories', '/var/www/project', bt, expected_bt
-        end
-
-        context "when equals to a part of filename" do
-          bt = [
-            "/home/kyrylo/code/airbrake/ruby/spec/spec_helper.rb:23:in `<top (required)>'",
-            "/var/www/gems/gems/rspec-core-3.3.2/lib/rspec/core/configuration.rb:1327:in `load'",
-            "/opt/rubies/ruby-2.2.2/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'",
-            "/var/www/gems/gems/rspec-core-3.3.2/exe/rspec:4:in `<main>'"
-          ]
-
-          expected_bt = [
-            "/home/kyrylo/code/airbrake/ruby/spec/spec_helper.rb",
-            "[PROJECT_ROOT]/gems/rspec-core-3.3.2/lib/rspec/core/configuration.rb",
-            "/opt/rubies/ruby-2.2.2/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb",
-            "[PROJECT_ROOT]/gems/rspec-core-3.3.2/exe/rspec"
-          ]
-
-          include_examples 'root directories', '/var/www/gems', bt, expected_bt
-        end
-
-        context "when normal pathname path" do
-          bt = [
-            "/home/kyrylo/code/airbrake/ruby/spec/spec_helper.rb:23:in `<top (required)>'",
-            "/var/www/project/gems/rspec-core-3.3.2/lib/rspec/core/configuration.rb:1327:in `load'",
-            "/opt/rubies/ruby-2.2.2/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'",
-            "/var/www/project/gems/rspec-core-3.3.2/exe/rspec:4:in `<main>'"
-          ]
-
-          expected_bt = [
-            "/home/kyrylo/code/airbrake/ruby/spec/spec_helper.rb",
-            "[PROJECT_ROOT]/gems/rspec-core-3.3.2/lib/rspec/core/configuration.rb",
-            "/opt/rubies/ruby-2.2.2/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb",
-            "[PROJECT_ROOT]/gems/rspec-core-3.3.2/exe/rspec"
-          ]
-
-          include_examples 'root directories',
-                           Pathname.new('/var/www/project'), bt, expected_bt
-        end
-      end
-      # rubocop:enable Metrics/LineLength
+      expect(notice[:params][:bingo]).to eq([2, 1, 0])
     end
 
-    describe "default ignore filters" do
-      context "system exit filter" do
-        it "marks SystemExit exceptions as ignored" do
-          notice = Airbrake::Notice.new(config, SystemExit.new)
-          expect { @chain.refine(notice) }.
-            to(change { notice.ignored? }.from(false).to(true))
-        end
-      end
+    it "stops execution once a notice was ignored" do
+      f2 = filter.new(2)
+      expect(f2).to receive(:call)
 
-      context "gem root filter" do
-        let(:ex) do
-          AirbrakeTestError.new.tap do |error|
-            error.set_backtrace(['(unparseable/frame.rb:23)'])
-          end
-        end
+      f1 = proc { |notice| notice.ignore! }
 
-        it "does not filter file if it is nil" do
-          config.logger = Logger.new('/dev/null')
-          notice = Airbrake::Notice.new(config, ex)
+      f0 = filter.new(-1)
+      expect(f0).not_to receive(:call)
 
-          expect(notice[:errors].first[:file]).to be_nil
-          expect { @chain.refine(notice) }.
-            not_to(change { notice[:errors].first[:file] })
-        end
-      end
+      [f2, f1, f0].each { |f| subject.add_filter(f) }
 
-      context "root directory filter" do
-        let(:ex) do
-          AirbrakeTestError.new.tap do |error|
-            error.set_backtrace(['(unparseable/frame.rb:23)'])
-          end
-        end
-
-        it "does not filter file if it is nil" do
-          config.logger = Logger.new('/dev/null')
-          config.root_directory = '/bingo/bango'
-          notice = Airbrake::Notice.new(config, ex)
-          filter_chain = described_class.new(config)
-
-          expect(notice[:errors].first[:file]).to be_nil
-          expect { filter_chain.refine(notice) }.
-            not_to(change { notice[:errors].first[:file] })
-        end
-      end
+      subject.refine(notice)
     end
   end
 end

--- a/spec/filters/gem_root_filter_spec.rb
+++ b/spec/filters/gem_root_filter_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+RSpec.describe Airbrake::Filters::GemRootFilter do
+  let(:notice) do
+    Airbrake::Notice.new(Airbrake::Config.new, AirbrakeTestError.new)
+  end
+
+  let(:root1) { '/my/gem/root' }
+  let(:root2) { '/my/other/gem/root' }
+
+  before { Gem.path << root1 << root2 }
+  after { 2.times { Gem.path.pop } }
+
+  it "replaces gem root in the backtrace with a label" do
+    # rubocop:disable Metrics/LineLength
+    notice[:errors].first[:backtrace] = [
+      { file: "/home/kyrylo/code/airbrake/ruby/spec/spec_helper.rb" },
+      { file: "#{root1}/gems/rspec-core-3.3.2/lib/rspec/core/configuration.rb" },
+      { file: "/opt/rubies/ruby-2.2.2/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb" },
+      { file: "#{root2}/gems/rspec-core-3.3.2/exe/rspec" }
+    ]
+    # rubocop:enable Metrics/LineLength
+
+    subject.call(notice)
+
+    # rubocop:disable Metrics/LineLength
+    expect(notice[:errors].first[:backtrace]).to(
+      eq(
+        [
+          { file: "/home/kyrylo/code/airbrake/ruby/spec/spec_helper.rb" },
+          { file: "[GEM_ROOT]/gems/rspec-core-3.3.2/lib/rspec/core/configuration.rb" },
+          { file: "/opt/rubies/ruby-2.2.2/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb" },
+          { file: "[GEM_ROOT]/gems/rspec-core-3.3.2/exe/rspec" }
+        ]
+      )
+    )
+    # rubocop:enable Metrics/LineLength
+  end
+
+  it "does not filter file when it is nil" do
+    expect(notice[:errors].first[:file]).to be_nil
+    expect { subject.call(notice) }.not_to(
+      change { notice[:errors].first[:file] }
+    )
+  end
+end

--- a/spec/filters/keys_blacklist_spec.rb
+++ b/spec/filters/keys_blacklist_spec.rb
@@ -1,22 +1,18 @@
 require 'spec_helper'
 
 RSpec.describe Airbrake::Filters::KeysBlacklist do
-  subject do
-    described_class.new(Logger.new('/dev/null'), patterns)
+  subject { described_class.new(Logger.new('/dev/null'), patterns) }
+
+  let(:notice) do
+    Airbrake::Notice.new(Airbrake::Config.new, AirbrakeTestError.new)
   end
 
-  describe "#call" do
-    let(:notice) do
-      Airbrake::Notice.new(Airbrake::Config.new, AirbrakeTestError.new)
-    end
+  context "when a pattern is a regexp and when a key is a hash" do
+    let(:patterns) { [/bango/] }
 
-    context "when a pattern is a regexp and when a key is a hash" do
-      let(:patterns) { [/bango/] }
-
-      it "doesn't fail" do
-        notice[:params] = { bingo: { {} => 'unfiltered' } }
-        expect { subject.call(notice) }.not_to raise_error
-      end
+    it "doesn't fail" do
+      notice[:params] = { bingo: { {} => 'unfiltered' } }
+      expect { subject.call(notice) }.not_to raise_error
     end
   end
 end

--- a/spec/filters/root_directory_filter_spec.rb
+++ b/spec/filters/root_directory_filter_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+RSpec.describe Airbrake::Filters::RootDirectoryFilter do
+  subject { described_class.new(root_directory) }
+
+  let(:root_directory) { '/var/www/project' }
+
+  let(:notice) do
+    Airbrake::Notice.new(Airbrake::Config.new, AirbrakeTestError.new)
+  end
+
+  it "replaces root directory in the backtrace with a label" do
+    # rubocop:disable Metrics/LineLength
+    notice[:errors].first[:backtrace] = [
+      { file: "/home/kyrylo/code/airbrake/ruby/spec/spec_helper.rb" },
+      { file: "#{root_directory}/gems/rspec-core-3.3.2/lib/rspec/core/configuration.rb " },
+      { file: "/opt/rubies/ruby-2.2.2/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb" },
+      { file: "#{root_directory}/gems/rspec-core-3.3.2/exe/rspec" }
+    ]
+    # rubocop:enable Metrics/LineLength
+
+    subject.call(notice)
+
+    # rubocop:disable Metrics/LineLength
+    expect(notice[:errors].first[:backtrace]).to(
+      eq(
+        [
+          { file: "/home/kyrylo/code/airbrake/ruby/spec/spec_helper.rb" },
+          { file: "[PROJECT_ROOT]/gems/rspec-core-3.3.2/lib/rspec/core/configuration.rb " },
+          { file: "/opt/rubies/ruby-2.2.2/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb" },
+          { file: "[PROJECT_ROOT]/gems/rspec-core-3.3.2/exe/rspec" }
+        ]
+      )
+    )
+    # rubocop:enable Metrics/LineLength
+  end
+
+  it "does not filter file when it is nil" do
+    expect(notice[:errors].first[:file]).to be_nil
+    expect { subject.call(notice) }.not_to(
+      change { notice[:errors].first[:file] }
+    )
+  end
+end

--- a/spec/filters/system_exit_filter_spec.rb
+++ b/spec/filters/system_exit_filter_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+RSpec.describe Airbrake::Filters::SystemExitFilter do
+  it "marks SystemExit exceptions as ignored" do
+    notice = Airbrake::Notice.new(Airbrake::Config.new, SystemExit.new)
+    expect { subject.call(notice) }.to(
+      change { notice.ignored? }.from(false).to(true)
+    )
+  end
+
+  it "doesn't mark non SystemExit exceptions as ignored" do
+    notice = Airbrake::Notice.new(Airbrake::Config.new, AirbrakeTestError.new)
+    expect(notice).not_to be_ignored
+    expect { subject.call(notice) }.not_to(change { notice.ignored? })
+  end
+end


### PR DESCRIPTION
`FilterChain` has tight coupling with `Airbrake::Config` without a good
reason. In this refactoring I uncouple it and append filters in the
`Notifier` class instead.

Bonus point: I refactored filter tests, and they're much easier to read
now.