### PR TITLE
notice: rescue SystemStackError and JSONify inside ThreadFilter

### DIFF
--- a/lib/airbrake-ruby/notice.rb
+++ b/lib/airbrake-ruby/notice.rb
@@ -4,6 +4,7 @@ module Airbrake
   # Airbrake or ignored completely.
   #
   # @since v1.0.0
+  # rubocop:disable Metrics/ClassLength
   class Notice
     ##
     # @return [Hash{Symbol=>String}] the information about the notifier library
@@ -38,7 +39,8 @@ module Airbrake
       IOError,
       NotImplementedError,
       JSON::GeneratorError,
-      Encoding::UndefinedConversionError
+      Encoding::UndefinedConversionError,
+      SystemStackError
     ].freeze
 
     # @return [Array<Symbol>] the list of keys that can be be overwritten with
@@ -220,4 +222,5 @@ module Airbrake
       end
     end
   end
+  # rubocop:enable Metrics/ClassLength
 end

--- a/spec/filters/thread_filter_spec.rb
+++ b/spec/filters/thread_filter_spec.rb
@@ -16,29 +16,13 @@ RSpec.describe Airbrake::Filters::ThreadFilter do
     end.join
   end
 
-  shared_examples "fiber variable ignore" do |key|
-    it "ignores the :#{key} fiber variable" do
-      new_thread do |th|
-        th[key] = :bingo
-        subject.call(notice)
-      end
-
-      fiber_variables = notice[:params][:thread][:fiber_variables]
-      expect(fiber_variables[key]).to be_nil
-    end
-  end
-
-  %i[__recursive_key__ __rspec].each do |key|
-    include_examples "fiber variable ignore", key
-  end
-
   it "appends thread variables" do
     new_thread do |th|
       th.thread_variable_set(:bingo, :bango)
       subject.call(notice)
     end
 
-    expect(notice[:params][:thread][:thread_variables][:bingo]).to eq(:bango)
+    expect(notice[:params][:thread][:thread_variables][:bingo]).to eq('"bango"')
   end
 
   it "appends fiber variables" do
@@ -47,7 +31,7 @@ RSpec.describe Airbrake::Filters::ThreadFilter do
       subject.call(notice)
     end
 
-    expect(notice[:params][:thread][:fiber_variables][:bingo]).to eq(:bango)
+    expect(notice[:params][:thread][:fiber_variables][:bingo]).to eq('"bango"')
   end
 
   it "appends name", skip: !Thread.current.respond_to?(:name) do


### PR DESCRIPTION
Hopefully fixes airbrake/airbrake#743
(Airbrake.notify() broken)

Most likely this error comes from `ThreadFilter`.  Sometimes, Rails'
`active_support` gets confused how to parse certain objects.  More info
here: #208

Unfortunately, we can't rely on the `rescue` inside the Notice class
because if a thread variable fails to be converted to JSON, the whole
notice will be rejected. Thread variables live long enough, so if there
a "bad" variable sticks to a thread, then all further notices would be
rejected as well.

To solve the problem and send thread variables nevertheless,
we perform an [ugly] conversion to JSON inside `ThreadFilter`, with
individual `rescue`'s.