### PR TITLE
notifier: disallow sending of notices ignored inside notify blocks

### DIFF
--- a/lib/airbrake-ruby/notifier.rb
+++ b/lib/airbrake-ruby/notifier.rb
@@ -118,12 +118,11 @@ module Airbrake
 
       notice = build_notice(exception, params)
       @filter_chain.refine(notice)
+      yield notice if block_given? && !notice.ignored?
 
       if notice.ignored?
         return promise.reject("#{notice} was marked as ignored")
       end
-
-      yield notice if block_given?
 
       sender.send(notice, promise)
     end

--- a/spec/notifier_spec.rb
+++ b/spec/notifier_spec.rb
@@ -387,7 +387,7 @@ RSpec.describe Airbrake::Notifier do
         end
       end
 
-      context "when a notice is ignored" do
+      context "when a notice is ignored before entering the block" do
         it "doesn't call the given block" do
           @airbrake.add_filter(&:ignore!)
           @airbrake.notify_sync(ex) { |n| n[:params][:bingo] = :bango }
@@ -395,6 +395,13 @@ RSpec.describe Airbrake::Notifier do
             a_request(:post, endpoint).
             with(body: /params":{.*"bingo":"bango".*}/)
           ).not_to have_been_made
+        end
+      end
+
+      context "and when a notice is ignored inside the block" do
+        it "doesn't send the notice" do
+          @airbrake.notify_sync(ex, &:ignore!)
+          expect(a_request(:post, endpoint)).not_to have_been_made
         end
       end
     end


### PR DESCRIPTION
Related: https://github.com/airbrake/airbrake-ruby/pull/226

Before this change if a notice is ignored inside an `Airbrake.notify`
block, such notice would be sent with `null` body. This fix makes sure
that we don't send anything at all.