### PR TITLE
filters/thread_filter: fixed segfault on Ruby 2.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Airbrake Ruby Changelog
 
 ### master
 
+* Fixed segfault in `ThreadFilter` on Ruby 2.1.3
+  ([#231](https://github.com/airbrake/airbrake-ruby/pull/231))
+
 ### [v2.2.5][v2.2.5] (May 23, 2017)
 
 * Fixed bug when the block form of `notify` would run its block for ignored

--- a/lib/airbrake-ruby/filters/thread_filter.rb
+++ b/lib/airbrake-ruby/filters/thread_filter.rb
@@ -21,6 +21,12 @@ module Airbrake
         Numeric
       ].freeze
 
+      ##
+      # Variables starting with this prefix are not attached to a notice.
+      # @see https://github.com/airbrake/airbrake-ruby/issues/229
+      # @return [String]
+      IGNORE_PREFIX = '_'.freeze
+
       def initialize
         @weight = 110
       end
@@ -51,12 +57,14 @@ module Airbrake
 
       def thread_variables(th)
         th.thread_variables.map.with_object({}) do |var, h|
+          next if var.to_s.start_with?(IGNORE_PREFIX)
           h[var] = sanitize_value(th.thread_variable_get(var))
         end
       end
 
       def fiber_variables(th)
         th.keys.map.with_object({}) do |key, h|
+          next if key.to_s.start_with?(IGNORE_PREFIX)
           h[key] = sanitize_value(th[key])
         end
       end

--- a/spec/filters/thread_filter_spec.rb
+++ b/spec/filters/thread_filter_spec.rb
@@ -119,6 +119,18 @@ RSpec.describe Airbrake::Filters::ThreadFilter do
         )
       end
     end
+
+    it "ignores thread variables starting with an underscore" do
+      var = :__recursive_key__
+
+      new_thread do |th|
+        th.thread_variable_set(var, :bingo)
+        subject.call(notice)
+      end
+
+      thread_variables = notice[:params][:thread][:thread_variables]
+      expect(thread_variables).to be_nil
+    end
   end
 
   describe "fiber variables" do
@@ -253,5 +265,17 @@ RSpec.describe Airbrake::Filters::ThreadFilter do
   it "appends safe_level", skip: Airbrake::JRUBY do
     subject.call(notice)
     expect(notice[:params][:thread][:safe_level]).to eq(0)
+  end
+
+  it "ignores fiber variables starting with an underscore" do
+    key = :__recursive_key__
+
+    new_thread do |th|
+      th[key] = :bingo
+      subject.call(notice)
+    end
+
+    fiber_variables = notice[:params][:thread][:fiber_variables]
+    expect(fiber_variables[key]).to be_nil
   end
 end


### PR DESCRIPTION
Fixes #229 (Another segfault report)

Ruby segfaults whenever it tries to access `:__recursive_key__`.
Unfortunately, there's no other good way to avoid this segfault.
`:__recursive_key__` is set by PrettyPrint, so it's very common.