### PR TITLE
Do a shallow copy of params hash in Notifier#build_notice

### DIFF
--- a/lib/airbrake-ruby/notifier.rb
+++ b/lib/airbrake-ruby/notifier.rb
@@ -74,7 +74,7 @@ module Airbrake
         exception[:params].merge!(params)
         exception
       else
-        Notice.new(@config, convert_to_exception(exception), params)
+        Notice.new(@config, convert_to_exception(exception), params.dup)
       end
     end
 

--- a/spec/notifier_spec.rb
+++ b/spec/notifier_spec.rb
@@ -525,7 +525,8 @@ RSpec.describe Airbrake::Notifier do
       it "prevents mutation of passed-in params hash" do
         params = { only_this_item: true }
         notice = @airbrake.build_notice(RuntimeError.new('bingo'), params)
-        expect(params.object_id).not_to eq(notice[:params].object_id)
+        notice[:params][:extra_item] = :not_in_original_params
+        expect(params).to eq(only_this_item: true)
       end
 
       it "returns the internal frames nevertheless" do

--- a/spec/notifier_spec.rb
+++ b/spec/notifier_spec.rb
@@ -522,6 +522,12 @@ RSpec.describe Airbrake::Notifier do
     end
 
     context "given a non-exception with calculated internal frames only" do
+      it "prevents mutation of passed-in params hash" do
+        params = { only_this_item: true }
+        notice = @airbrake.build_notice(RuntimeError.new('bingo'), params)
+        expect(params.object_id).not_to eq(notice[:params].object_id)
+      end
+
       it "returns the internal frames nevertheless" do
         backtrace = [
           "/airbrake-ruby/lib/airbrake-ruby/notifier.rb:84:in `build_notice'",


### PR DESCRIPTION
Ran into a problem in a recent Airbrake upgrade where a call to Airbrake.notify
was (unexpectedly!) mutating the params hash.

This is one approach to fix.

At various points in the filter call chains of building up an Airbrake
notice, the code mutates the params hash that is passed in (adding
keys like :priority and safe_level). A simple dup means the calling
code no longer has to worry about that params hash mutating.