### PR TITLE
Implement `Airbrake#configured?`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Airbrake Ruby Changelog
 
 ### master
 
+* Added a new helper method `Airbrake#configured?`
+  ([#237](https://github.com/airbrake/airbrake-ruby/pull/237))
+
 ### [v2.2.7][v2.2.7] (June 24, 2017)
 
 * Fixed unwanted mutation of `params` on `Airbrake.notify(ex, params)`

--- a/README.md
+++ b/README.md
@@ -600,6 +600,14 @@ Airbrake.create_deploy(
 )
 ```
 
+#### Airbrake.configured?
+
+Checks whether the notifier is configured or not:
+
+```ruby
+Airbrake.configured? #=> false
+```
+
 ### Notice
 
 #### Notice#ignore!

--- a/lib/airbrake-ruby.rb
+++ b/lib/airbrake-ruby.rb
@@ -136,6 +136,13 @@ module Airbrake
     end
 
     ##
+    # @return [Boolean] true if the notifier was configured, false otherwise
+    # @since 2.3.0
+    def configured?
+      @notifiers[:default].configured?
+    end
+
+    ##
     # Sends an exception to Airbrake asynchronously.
     #
     # @example Sending an exception

--- a/lib/airbrake-ruby/notifier.rb
+++ b/lib/airbrake-ruby/notifier.rb
@@ -94,6 +94,12 @@ module Airbrake
       promise
     end
 
+    ##
+    # @macro see_public_api_method
+    def configured?
+      @config.valid?
+    end
+
     private
 
     def convert_to_exception(ex)
@@ -184,5 +190,9 @@ module Airbrake
     def close; end
 
     def create_deploy(_deploy_params); end
+
+    def configured?
+      false
+    end
   end
 end

--- a/spec/airbrake_spec.rb
+++ b/spec/airbrake_spec.rb
@@ -145,6 +145,19 @@ RSpec.describe Airbrake do
     end
   end
 
+  describe ".configured?" do
+    before do
+      described_class.instance_variable_set(
+        :@notifiers,
+        Hash.new(Airbrake::NilNotifier.new)
+      )
+    end
+
+    it "returns false" do
+      expect(described_class).not_to be_configured
+    end
+  end
+
   describe ".add_filter" do
     include_examples 'non-configured notifier handling', :add_filter
 

--- a/spec/notifier_spec.rb
+++ b/spec/notifier_spec.rb
@@ -600,4 +600,9 @@ RSpec.describe Airbrake::Notifier do
       end
     end
   end
+
+  describe "#configured?" do
+    subject { described_class.new(airbrake_params) }
+    it { is_expected.to be_configured }
+  end
 end


### PR DESCRIPTION
This helper method is intended to simplify the following check:

```ruby
if Airbrake[:default].is_a?(Airbrake::NilNotifier)
  # ...
end
```

With the new API it looks like this:

```ruby
if Airbrake.configured?
  # ...
end
```