### PR TITLE
response: fix parsing of errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Airbrake Ruby Changelog
 
 ### master
 
+* Fix response parser not parsing errors
+  ([#239](https://github.com/airbrake/airbrake-ruby/pull/239))
+
 ### [v2.3.0][v2.3.0] (June 6, 2017)
 
 * Added a new helper method `Airbrake.configured?`

--- a/lib/airbrake-ruby/response.rb
+++ b/lib/airbrake-ruby/response.rb
@@ -28,7 +28,7 @@ module Airbrake
           parsed_body
         when 400, 401, 403, 429
           parsed_body = JSON.parse(body)
-          logger.error("#{LOG_LABEL} #{parsed_body['error']}")
+          logger.error("#{LOG_LABEL} #{parsed_body['message']}")
           parsed_body
         else
           body_msg = truncated_body(body)

--- a/spec/notifier_spec.rb
+++ b/spec/notifier_spec.rb
@@ -184,8 +184,8 @@ RSpec.describe Airbrake::Notifier do
           expect(@stdout.string).to match(expected_output)
           expect(response).to be_a Hash
 
-          if response['error']
-            expect(response['error']).to satisfy do |error|
+          if response['message']
+            expect(response['message']).to satisfy do |error|
               error.is_a?(Exception) || error.is_a?(String)
             end
           end
@@ -215,18 +215,18 @@ RSpec.describe Airbrake::Notifier do
       end
 
       context "error 400" do
-        include_examples 'HTTP codes', 400, '{"error": "Invalid Content-Type header."}',
+        include_examples 'HTTP codes', 400, '{"message": "Invalid Content-Type header."}',
                          /ERROR -- : .+ Invalid Content-Type header\./
       end
 
       context "error 401" do
         include_examples 'HTTP codes', 401,
-                         '{"error":"Project not found or access denied."}',
+                         '{"message":"Project not found or access denied."}',
                          /ERROR -- : .+ Project not found or access denied./
       end
 
       context "the rate-limit message" do
-        include_examples 'HTTP codes', 429, '{"error": "Project is rate limited."}',
+        include_examples 'HTTP codes', 429, '{"message": "Project is rate limited."}',
                          /ERROR -- : .+ Project is rate limited.+/
       end
 


### PR DESCRIPTION
Fixes https://github.com/airbrake/airbrake/issues/768
(blank errors not reported)

The API response format has changed, so the library needs an adjustment.