### PR TITLE
filter with raw exception instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,7 +497,7 @@ Instead, you can ignore notices based on some condition.
 
 ```ruby
 Airbrake.add_filter do |notice|
-  notice.ignore! if notice.exception.kind_of? StandardError
+  notice.ignore! if notice.exception.kind_of?(StandardError)
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -497,7 +497,7 @@ Instead, you can ignore notices based on some condition.
 
 ```ruby
 Airbrake.add_filter do |notice|
-  notice.ignore! if notice.exception.kind_of?(StandardError)
+  notice.ignore! if notice.stash[:exception].is_a?(StandardError)
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -497,9 +497,7 @@ Instead, you can ignore notices based on some condition.
 
 ```ruby
 Airbrake.add_filter do |notice|
-  if notice[:errors].any? { |error| error[:type] == 'StandardError' }
-    notice.ignore!
-  end
+  notice.ignore! if notice.exception.kind_of? StandardError
 end
 ```
 

--- a/lib/airbrake-ruby/notice.rb
+++ b/lib/airbrake-ruby/notice.rb
@@ -62,7 +62,11 @@ module Airbrake
     # @since v1.7.0
     # @return [Hash{Symbol=>Object}] the hash with arbitrary objects to be used
     #   in filters
-    attr_reader :stash, :exception
+    attr_reader :stash
+
+    ##
+    # @return [Exception] raw exception
+    attr_reader :exception
 
     def initialize(config, exception, params = {})
       @config = config

--- a/lib/airbrake-ruby/notice.rb
+++ b/lib/airbrake-ruby/notice.rb
@@ -74,7 +74,7 @@ module Airbrake
         session: {},
         params: params
       }
-      @stash = {exception: exception}
+      @stash = { exception: exception }
       @truncator = Airbrake::Truncator.new(PAYLOAD_MAX_SIZE)
 
       extract_custom_attributes(exception)

--- a/lib/airbrake-ruby/notice.rb
+++ b/lib/airbrake-ruby/notice.rb
@@ -64,10 +64,6 @@ module Airbrake
     #   in filters
     attr_reader :stash
 
-    ##
-    # @return [Exception] raw exception
-    attr_reader :exception
-
     def initialize(config, exception, params = {})
       @config = config
 
@@ -78,8 +74,7 @@ module Airbrake
         session: {},
         params: params
       }
-      @stash = {}
-      @exception = exception
+      @stash = {exception: exception}
       @truncator = Airbrake::Truncator.new(PAYLOAD_MAX_SIZE)
 
       extract_custom_attributes(exception)

--- a/lib/airbrake-ruby/notice.rb
+++ b/lib/airbrake-ruby/notice.rb
@@ -62,7 +62,7 @@ module Airbrake
     # @since v1.7.0
     # @return [Hash{Symbol=>Object}] the hash with arbitrary objects to be used
     #   in filters
-    attr_reader :stash
+    attr_reader :stash, :exception
 
     def initialize(config, exception, params = {})
       @config = config
@@ -75,6 +75,7 @@ module Airbrake
         params: params
       }
       @stash = {}
+      @exception = exception
       @truncator = Airbrake::Truncator.new(PAYLOAD_MAX_SIZE)
 
       extract_custom_attributes(exception)

--- a/spec/notifier_spec.rb
+++ b/spec/notifier_spec.rb
@@ -516,13 +516,13 @@ RSpec.describe Airbrake::Notifier do
     end
 
     it "ignores descendant classes" do
-      class AirbrakeTestSubError < AirbrakeTestError; end
+      descendant = Class.new(AirbrakeTestError)
 
       @airbrake.add_filter do |notice|
-        notice.ignore! if notice.exception.kind_of?(AirbrakeTestError)
+        notice.ignore! if notice.stash[:exception].is_a?(AirbrakeTestError)
       end
 
-      @airbrake.notify_sync(AirbrakeTestSubError.new('Not caring!'))
+      @airbrake.notify_sync(descendant.new('Not caring!'))
       expect(a_request(:post, endpoint)).not_to have_been_made
 
       @airbrake.notify_sync(RuntimeError.new('Catch me if you can!'))

--- a/spec/notifier_spec.rb
+++ b/spec/notifier_spec.rb
@@ -519,7 +519,7 @@ RSpec.describe Airbrake::Notifier do
       class AirbrakeTestSubError < AirbrakeTestError; end
 
       @airbrake.add_filter do |notice|
-        notice.ignore! if notice.exception.kind_of? AirbrakeTestError
+        notice.ignore! if notice.exception.kind_of?(AirbrakeTestError)
       end
 
       @airbrake.notify_sync(AirbrakeTestSubError.new('Not caring!'))


### PR DESCRIPTION
README shows following example to ignore ``StandardError``

```rb
Airbrake.add_filter do |notice|
  if notice[:errors].any? { |error| error[:type] == 'StandardError' }
    notice.ignore!
  end
end
```

But we rarely raise ``StandardError`` itself.
Instead, we raise the descendants of ``StandardError``.

Current implementation converts the exception to a string value before filtering.
It looses class hierarchy.

This patch allows filter to use exception instance to do like this:

```rb
Airbrake.add_filter do |notice|
  notice.ignore! if notice.exception.kind_of? StandardError
end
```
