### PR TITLE
notice: inline #[]= validation methods

### DIFF
--- a/lib/airbrake-ruby/notice.rb
+++ b/lib/airbrake-ruby/notice.rb
@@ -141,8 +141,15 @@ module Airbrake
     # @raise [Airbrake::Error] if the root value is not a Hash
     def []=(key, value)
       raise_if_ignored
-      raise_if_unrecognized_key(key)
-      raise_if_non_hash_value(value)
+
+      unless WRITABLE_KEYS.include?(key)
+        raise Airbrake::Error,
+              ":#{key} is not recognized among #{WRITABLE_KEYS}"
+      end
+
+      unless value.respond_to?(:to_hash)
+        raise Airbrake::Error, "Got #{value.class} value, wanted a Hash"
+      end
 
       @payload[key] = value.to_hash
     end
@@ -168,17 +175,6 @@ module Airbrake
     def raise_if_ignored
       return unless ignored?
       raise Airbrake::Error, 'cannot access ignored notice'
-    end
-
-    def raise_if_unrecognized_key(key)
-      return if WRITABLE_KEYS.include?(key)
-      raise Airbrake::Error,
-            ":#{key} is not recognized among #{WRITABLE_KEYS}"
-    end
-
-    def raise_if_non_hash_value(value)
-      return if value.respond_to?(:to_hash)
-      raise Airbrake::Error, "Got #{value.class} value, wanted a Hash"
     end
 
     def truncate


### PR DESCRIPTION
We don't reuse them, so there's no need for them to be separate
methods. Besides, this will decrease class length, so we don't introduce
any Rubocop offences
(https://github.com/airbrake/airbrake-ruby/pull/241)