### PR TITLE
Add $PROGRAM_NAME to the Notice context

### DIFF
--- a/lib/airbrake-ruby/notice.rb
+++ b/lib/airbrake-ruby/notice.rb
@@ -67,6 +67,9 @@ module Airbrake
     def initialize(config, exception, params = {})
       @config = config
 
+      # The command used to execute the program.
+      params[:programName] = $PROGRAM_NAME
+
       @payload = {
         errors: NestedException.new(exception, @config.logger).as_json,
         context: context,


### PR DESCRIPTION
We're running a lot of Ruby executables, but they all use the same stack (with different config). This makes it impossible to tell which executable experienced an error by looking at Airbrake.

By adding `$PROGRAM_NAME` to the context, I hope to solve that.