### PR TITLE
gemspec: lock public_suffix to v2

### DIFF
--- a/airbrake-ruby.gemspec
+++ b/airbrake-ruby.gemspec
@@ -33,4 +33,8 @@ DESC
   s.add_development_dependency 'webmock', '~> 2.3'
   s.add_development_dependency 'benchmark-ips', '~> 2'
   s.add_development_dependency 'rubocop', '~> 0.47'
+
+  # Fixes build failure with public_suffix v3
+  # https://circleci.com/gh/airbrake/airbrake-ruby/889
+  s.add_development_dependency 'public_suffix', '~> 2.0', '< 3.0'
 end


### PR DESCRIPTION
This fixes the following failure:
https://circleci.com/gh/airbrake/airbrake-ruby/889