### PR TITLE
Rubocop v0.50 fixes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,7 +26,7 @@ Style/StringLiterals:
 Style/HashSyntax:
   EnforcedStyle: ruby19
 
-Style/FileName:
+Naming/FileName:
   Exclude:
     - 'lib/airbrake-ruby.rb'
 
@@ -36,7 +36,7 @@ Style/NumericLiterals:
 Style/SignalException:
   EnforcedStyle: only_raise
 
-Style/PredicateName:
+Naming/PredicateName:
   Exclude:
     - 'lib/airbrake-ruby/async_sender.rb'
 
@@ -53,7 +53,7 @@ Layout/IndentArray:
 Style/NumericPredicate:
   Enabled: false
 
-Style/VariableNumber:
+Naming/VariableNumber:
   Enabled: false
 
 Style/SafeNavigation:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,9 +4,6 @@ AllCops:
   DisplayCopNames: true
   DisplayStyleGuide: true
 
-Lint/HandleExceptions:
-  Enabled: true
-
 Metrics/MethodLength:
   Max: 25
 

--- a/airbrake-ruby.gemspec
+++ b/airbrake-ruby.gemspec
@@ -32,7 +32,7 @@ DESC
   s.add_development_dependency 'pry', '~> 0'
   s.add_development_dependency 'webmock', '~> 2.3'
   s.add_development_dependency 'benchmark-ips', '~> 2'
-  s.add_development_dependency 'rubocop', '= 0.49'
+  s.add_development_dependency 'rubocop', '~> 0.50'
 
   # Fixes build failure with public_suffix v3
   # https://circleci.com/gh/airbrake/airbrake-ruby/889

--- a/benchmarks/truncator_string_encoding.rb
+++ b/benchmarks/truncator_string_encoding.rb
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 require_relative 'benchmark_helpers'
 
 require 'securerandom'

--- a/lib/airbrake-ruby/notice.rb
+++ b/lib/airbrake-ruby/notice.rb
@@ -200,7 +200,7 @@ module Airbrake
 
       begin
         attributes = exception.to_airbrake
-      rescue => ex
+      rescue StandardError => ex
         @config.logger.error(
           "#{LOG_LABEL} #{exception.class}#to_airbrake failed: #{ex.class}: #{ex}"
         )

--- a/lib/airbrake-ruby/response.rb
+++ b/lib/airbrake-ruby/response.rb
@@ -35,7 +35,7 @@ module Airbrake
           logger.error("#{LOG_LABEL} unexpected code (#{code}). Body: #{body_msg}")
           { 'error' => body_msg }
         end
-      rescue => ex
+      rescue StandardError => ex
         body_msg = truncated_body(body)
         logger.error("#{LOG_LABEL} error while parsing body (#{ex}). Body: #{body_msg}")
         { 'error' => ex.inspect }

--- a/lib/airbrake-ruby/sync_sender.rb
+++ b/lib/airbrake-ruby/sync_sender.rb
@@ -36,7 +36,7 @@ module Airbrake
 
       begin
         response = https.request(req)
-      rescue => ex
+      rescue StandardError => ex
         reason = "#{LOG_LABEL} HTTP error: #{ex}"
         @config.logger.error(reason)
         return promise.reject(reason)

--- a/spec/notifier_spec.rb
+++ b/spec/notifier_spec.rb
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 require 'spec_helper'
 
 RSpec.describe Airbrake::Notifier do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -43,11 +43,11 @@ class AirbrakeTestError < RuntimeError
     # rubocop:enable Metrics/LineLength
   end
 
-  # rubocop:disable Style/AccessorMethodName
+  # rubocop:disable Naming/AccessorMethodName
   def set_backtrace(backtrace)
     @backtrace = backtrace
   end
-  # rubocop:enable Style/AccessorMethodName
+  # rubocop:enable Naming/AccessorMethodName
 
   def message
     'App crashed!'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -90,9 +90,9 @@ class Ruby21Error < RuntimeError
   end
 end
 
-puts <<EOS
+puts <<BANNER
 #{'#' * 80}
 # RUBY_VERSION: #{RUBY_VERSION}
 # RUBY_ENGINE: #{RUBY_ENGINE}
 #{'#' * 80}
-EOS
+BANNER

--- a/spec/truncator_spec.rb
+++ b/spec/truncator_spec.rb
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 require 'spec_helper'
 
 RSpec.describe Airbrake::Truncator do


### PR DESCRIPTION
* rubocop: don't enable already enabled [by default] cops
* rubocop: fix "wrong namespace" warnings
* rubocop: fix offences of the Naming/HeredocDelimiterNaming cop



