### PR TITLE
gemspec: lock rubocop to v0.49

### DIFF
--- a/airbrake-ruby.gemspec
+++ b/airbrake-ruby.gemspec
@@ -32,7 +32,7 @@ DESC
   s.add_development_dependency 'pry', '~> 0'
   s.add_development_dependency 'webmock', '~> 2.3'
   s.add_development_dependency 'benchmark-ips', '~> 2'
-  s.add_development_dependency 'rubocop', '~> 0.47'
+  s.add_development_dependency 'rubocop', '= 0.49'
 
   # Fixes build failure with public_suffix v3
   # https://circleci.com/gh/airbrake/airbrake-ruby/889


### PR DESCRIPTION
v0.50 has a few bugs that prevent me from upgrading:

* https://github.com/bbatsov/rubocop/issues/4768
* https://github.com/bbatsov/rubocop/issues/4767