### PR TITLE
Add hound.yml

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,2 @@
+ruby:
+  config_file: .rubocop.yml


### PR DESCRIPTION
We use custom Rubocop rules and Hound can't see them. Inside the config we tell
Hound to respect our rules: https://houndci.com/configuration#ruby