### PR TITLE
filters/keys_filter: allow filtering HTTP headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Airbrake Ruby Changelog
 
 ### master
 
+* Fixed bug when HTTP headers couldn't be filtered
+  ([#257](https://github.com/airbrake/airbrake-ruby/pull/257))
+
 ### [v2.4.0][v2.4.0] (September 20, 2017)
 
 * Started appending `$PROGRAM_NAME` to `environment`

--- a/spec/filters/keys_blacklist_spec.rb
+++ b/spec/filters/keys_blacklist_spec.rb
@@ -192,6 +192,36 @@ RSpec.describe Airbrake::Filters::KeysBlacklist do
         subject.call(notice)
         expect(notice[:context][:user]).to eq('[Filtered]')
       end
+
+      context "and when it is a hash" do
+        let(:patterns) { ['name'] }
+
+        it "filters out individual user fields" do
+          notice[:context][:user] = { id: 1337, name: 'Bingo Bango' }
+          subject.call(notice)
+          expect(notice[:context][:user][:name]).to eq('[Filtered]')
+        end
+      end
+    end
+
+    context "when the headers key is present" do
+      let(:patterns) { ['headers'] }
+
+      it "filters out the headers" do
+        notice[:context][:headers] = { 'HTTP_COOKIE' => 'banana' }
+        subject.call(notice)
+        expect(notice[:context][:headers]).to eq('[Filtered]')
+      end
+
+      context "and when it is a hash" do
+        let(:patterns) { ['HTTP_COOKIE'] }
+
+        it "filters out individual header fields" do
+          notice[:context][:headers] = { 'HTTP_COOKIE' => 'banana' }
+          subject.call(notice)
+          expect(notice[:context][:headers]['HTTP_COOKIE']).to eq('[Filtered]')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #256 (blacklist of HTTP_COOKIE does not work)

It wasn't possible to filter HTTP filters, but with this commit this is fixed.