### PR TITLE
code_hunk: handle `nil` lines & refactor to please Rubocop

### DIFF
--- a/spec/notice_spec.rb
+++ b/spec/notice_spec.rb
@@ -207,7 +207,7 @@ RSpec.describe Airbrake::Notice do
 
     it "always contains environment/program_name" do
       expect(notice.to_json).
-        to match(%r|"environment":{"program_name":.+/exe/rspec.*|)
+        to match(%r|"environment":{"program_name":.+/rspec.*|)
     end
   end
 


### PR DESCRIPTION
`nil` lines can happen when a backtrace contains file `config.ru` from
Rack. That frame doesn't carry line information.

Additionally, Rubocop was unhappy about the complexity of
`Airbrake::CodeHunk#get`, so I refactored it to make it simpler.

Tests were also leaking state because FileCache is global and we didn't nullify
it after every example. This is fixed now.