### PR TITLE
filters/gem_root: do not mutate file to avoid side effects

### DIFF
--- a/lib/airbrake-ruby/filters/gem_root_filter.rb
+++ b/lib/airbrake-ruby/filters/gem_root_filter.rb
@@ -24,7 +24,7 @@ module Airbrake
               # If the frame is unparseable, then 'file' is nil, thus nothing to
               # filter (all frame's data is in 'function' instead).
               next unless (file = frame[:file])
-              file.sub!(/\A#{gem_path}/, GEM_ROOT_LABEL)
+              frame[:file] = file.sub(/\A#{gem_path}/, GEM_ROOT_LABEL)
             end
           end
         end


### PR DESCRIPTION
Mutating `file` with `GEM_ROOT` causes problems with code hunks. They rely on
the pristine value.