### PR TITLE
Fix build failure

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -73,3 +73,6 @@ Performance/RegexpMatch:
 
 Layout/IndentHeredoc:
   Enabled: false
+
+Gemspec/OrderedDependencies:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,7 @@
 source 'https://rubygems.org'
 gemspec
+
+# Rubocop supports only >=2.1.0
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.1.0')
+  gem 'rubocop', '~> 0.51', require: false
+end

--- a/airbrake-ruby.gemspec
+++ b/airbrake-ruby.gemspec
@@ -32,7 +32,6 @@ DESC
   s.add_development_dependency 'pry', '~> 0'
   s.add_development_dependency 'webmock', '~> 2.3'
   s.add_development_dependency 'benchmark-ips', '~> 2'
-  s.add_development_dependency 'rubocop', '~> 0.50'
 
   # Fixes build failure with public_suffix v3
   # https://circleci.com/gh/airbrake/airbrake-ruby/889


### PR DESCRIPTION
* Gemfile: move rubocop from gemspec to Gemfile (Latest Rubocop doesn't support Ruby 2.0.0 anymore)
* rubocop: disable stupid rule of Gemspec/OrderedDependencies