### PR TITLE
filters/keys: don't try to filter already filtered value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Airbrake Ruby Changelog
 
 ### master
 
+* Fixed the bug when both `whitelist_keys` and `blacklist_keys` are specified
+  ([#277](https://github.com/airbrake/airbrake-ruby/pull/277))
+
 ### [v2.5.0][v2.5.0] (October 20, 2017)
 
 * Added code hunks support (surrounding lines around every stack frame)

--- a/lib/airbrake-ruby/filters/keys_filter.rb
+++ b/lib/airbrake-ruby/filters/keys_filter.rb
@@ -131,6 +131,7 @@ module Airbrake
 
       def filter_context_key(notice, key)
         return unless notice[:context][key]
+        return if notice[:context][key] == FILTERED
         return filter_hash(notice[:context][key]) unless should_filter?(key)
 
         notice[:context][key] = FILTERED

--- a/spec/notifier_spec/options_spec.rb
+++ b/spec/notifier_spec/options_spec.rb
@@ -226,5 +226,25 @@ RSpec.describe Airbrake::Notifier do
         include_examples 'sent notice', environment: :development
       end
     end
+
+    describe ":blacklist_keys" do
+      # Fixes https://github.com/airbrake/airbrake-ruby/issues/276
+      context "when specified along with :whitelist_keys" do
+        context "and when context payload is present" do
+          it "sends a notice" do
+            params = {
+              blacklist_keys: %i[password password_confirmation],
+              whitelist_keys: [:email, /user/i, 'account_id']
+            }
+            airbrake = described_class.new(airbrake_params.merge(params))
+            notice = airbrake.build_notice(ex)
+            notice[:context][:headers] = 'banana'
+            airbrake.notify_sync(notice)
+
+            expect(a_request(:post, endpoint)).to have_been_made
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #276 (Specifying `blacklist_keys` with `whitelist_keys` can result in
error)