### PR TITLE
Enable truncation of frozen hashes

### DIFF
--- a/lib/airbrake-ruby/truncator.rb
+++ b/lib/airbrake-ruby/truncator.rb
@@ -101,6 +101,7 @@ module Airbrake
     end
 
     def truncate_hash(hash, seen)
+      hash = hash.dup if hash.frozen?
       hash.each_with_index do |(key, val), idx|
         if idx < @max_size
           hash[key] = truncate(val, seen)

--- a/spec/truncator_spec.rb
+++ b/spec/truncator_spec.rb
@@ -373,6 +373,31 @@ RSpec.describe Airbrake::Truncator do
           expect(params).to eq(bish: [['bongo'], ['bongo']])
         end
       end
+
+      context "which have been frozen" do
+        let(:params) do
+          {
+            bingo: 'bango' * 2000,
+            bongo: 'bish',
+            bash: 'bosh' * 1000,
+            bish: {
+              bingo: 'bango' * 10_000
+            }.freeze
+          }.freeze
+        end
+
+        it "allows truncation" do
+          expect(params[:bingo].length).to eq(10_000)
+          expect(params[:bongo].length).to eq(4)
+          expect(params[:bash].length).to eq(4000)
+
+          truncated_params = @truncator.truncate_object(params)
+
+          expect(truncated_params[:bingo].length).to eq(max_len)
+          expect(truncated_params[:bongo].length).to eq(4)
+          expect(truncated_params[:bash].length).to eq(max_len)
+        end
+      end
     end
 
     describe "unicode payload" do


### PR DESCRIPTION
# Issue discovered in Truncator.rb
## Summary

Frozen hashes are unable to be truncated correctly by 
https://github.com/airbrake/airbrake-ruby/blob/master/lib/airbrake-ruby/truncator.rb#L103.

![truncation error](https://user-images.githubusercontent.com/1417959/32422965-740d9c32-c308-11e7-919f-4400a330b180.png)

## Description

Currently when truncating hashes for logging purposes, the original hash values get modified.

While immutability would be preferred, reusing the hash is likely here for keeping memory usage down. This is however creating an error when a frozen hash is passed in.

## Solution 👍 

This change resolves this by checking for a frozen hash, and duplicates it allowing for modification when required.