### PR TITLE
truncator: update comments for #truncate_object

### DIFF
--- a/lib/airbrake-ruby/truncator.rb
+++ b/lib/airbrake-ruby/truncator.rb
@@ -25,11 +25,9 @@ module Airbrake
     # Performs deep truncation of arrays, hashes and sets. Uses a
     # placeholder for recursive objects (`[Circular]`).
     #
-    # @param [Hash,Array] object The object to truncate
+    # @param [Hash,Array,Set] object The object to truncate
     # @param [Hash] seen The hash that helps to detect recursion
     # @return [void]
-    # @note This method is public to simplify testing. You probably want to use
-    #   {truncate_notice} instead
     def truncate_object(object, seen = {})
       return seen[object] if seen[object]
 


### PR DESCRIPTION
As pointed out by
https://github.com/airbrake/airbrake-ruby/issues/281#issuecomment-342663451
the comment was misleading.