### PR TITLE
truncator: store and compare object ids instead of object hashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Airbrake Ruby Changelog
 
 ### master
 
+* Additional fixes for circular references in the new truncator
+  ([#288](https://github.com/airbrake/airbrake-ruby/pull/288)). Again, if you're
+  on v2.6, please upgrade as soon as possible
+
 ### [v2.6.1][v2.6.1] (December 1, 2017)
 
 * Fixed circular references in the new truncator

--- a/lib/airbrake-ruby/truncator.rb
+++ b/lib/airbrake-ruby/truncator.rb
@@ -33,11 +33,11 @@ module Airbrake
     # @param [Set] seen The cache that helps to detect recursion
     # @return [Object] truncated object
     def truncate(object, seen = Set.new)
-      if seen.include?(object)
+      if seen.include?(object.object_id)
         return CIRCULAR if CIRCULAR_TYPES.any? { |t| object.is_a?(t) }
         return object
       end
-      truncate_object(object, seen << object)
+      truncate_object(object, seen << object.object_id)
     end
 
     # Reduces maximum allowed size of hashes, arrays, sets & strings by half.

--- a/spec/truncator_spec.rb
+++ b/spec/truncator_spec.rb
@@ -219,6 +219,7 @@ RSpec.describe Airbrake::Truncator do
         {
           errors: [
             { file: 'a' },
+            { file: 'a' },
             hashie.new.merge(file: 'bcde')
           ]
         }
@@ -227,6 +228,7 @@ RSpec.describe Airbrake::Truncator do
       it "truncates values" do
         expect(subject).to eq(
           errors: [
+            { file: 'a' },
             { file: 'a' },
             hashie.new.merge(file: 'bcd[Truncated]')
           ]


### PR DESCRIPTION
Additional fix for #285
("Cannot unmarshal string into Go struct field StackFrame.line" after truncating
big notices)

The problem is that `.include?` compares object hashes. For example, if we do

```
h1 = { a: 1 }
h2 = { a: 1 }

a = [h1, h2]
```

...then `h1 == h2`. Thus, if we truncate `a`, the truncator will incorrectly
mark them as circular. However, their object ids are different and they're not
really circular.