### PR TITLE
backtrace: fix disabling of code hunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Airbrake Ruby Changelog
 
 ### master
 
+* Fixed disabling of code hunks. It was impossible to disable them
+  ([#295](https://github.com/airbrake/airbrake-ruby/pull/295))
+
 ### [v2.7.0][v2.7.0] (December 13, 2017)
 
 * Stopped gathering thread information by default

--- a/lib/airbrake-ruby/backtrace.rb
+++ b/lib/airbrake-ruby/backtrace.rb
@@ -194,7 +194,7 @@ module Airbrake
 
         exception.backtrace.map.with_index do |stackframe, i|
           frame = stack_frame(config, regexp, stackframe)
-          next(frame) if config.code_hunks.nil? || frame[:file].nil?
+          next(frame) if !config.code_hunks || frame[:file].nil?
 
           if !root_directory.empty?
             populate_code(config, frame) if frame[:file].start_with?(root_directory)

--- a/spec/backtrace_spec.rb
+++ b/spec/backtrace_spec.rb
@@ -420,5 +420,35 @@ RSpec.describe Airbrake::Backtrace do
         end
       end
     end
+
+    context "when code hunks are disabled" do
+      let(:config) do
+        config = Airbrake::Config.new
+        config.logger = Logger.new('/dev/null')
+        config.code_hunks = false
+        config
+      end
+
+      context "and when root_directory is configured" do
+        before { config.root_directory = project_root_path('') }
+
+        let(:parsed_backtrace) do
+          [
+            {
+              file: project_root_path('code.rb'),
+              line: 94,
+              function: 'to_json'
+            }
+          ]
+        end
+
+        it "doesn't attach code to frames" do
+          ex = RuntimeError.new
+          backtrace = [project_root_path('code.rb') + ":94:in `to_json'"]
+          ex.set_backtrace(backtrace)
+          expect(described_class.parse(config, ex)).to eq(parsed_backtrace)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
`config.code_hunks = false` had no effect. With this fix it's now possible to
disable code hunks.