### PR TITLE
 Gemfile: lock rubocop to v0.51.0 & fix offences

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -77,12 +77,5 @@ Layout/IndentHeredoc:
 Gemspec/OrderedDependencies:
   Enabled: false
 
-Gemspec/RequiredRubyVersion:
-  Enabled: false
-
-# Broken behaviour: https://github.com/bbatsov/rubocop/issues/5224
-Layout/EmptyLinesAroundArguments:
-  Enabled: false
-
 Style/FormatStringToken:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,5 @@ gemspec
 
 # Rubocop supports only >=2.1.0
 if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.1.0')
-  gem 'rubocop', '~> 0.51', require: false
+  gem 'rubocop', '= 0.51', require: false
 end

--- a/spec/airbrake_spec.rb
+++ b/spec/airbrake_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe Airbrake do
 
       expect(filters.size).to eq(3)
 
-      described_class.add_filter{}
+      described_class.add_filter {}
 
       expect(filters.size).to eq(4)
       expect(filters.last).to be_a(Proc)

--- a/spec/notice_spec.rb
+++ b/spec/notice_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe Airbrake::Notice do
       end
 
       describe "object replacement with its string version" do
-        let(:klass) { Class.new{} }
+        let(:klass) { Class.new {} }
         let(:ex) { AirbrakeTestError.new }
         let(:params) { { bingo: [Object.new, klass.new] } }
         let(:notice) { described_class.new(Airbrake::Config.new, ex, params) }

--- a/spec/promise_spec.rb
+++ b/spec/promise_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Airbrake::Promise do
 
     context "when it is not resolved" do
       it "returns self" do
-        expect(subject.then{}).to eq(subject)
+        expect(subject.then {}).to eq(subject)
       end
 
       it "doesn't call the resolve callbacks yet" do
@@ -19,7 +19,7 @@ RSpec.describe Airbrake::Promise do
     context "when it is resolved" do
       shared_examples "then specs" do
         it "returns self" do
-          expect(subject.then{}).to eq(subject)
+          expect(subject.then {}).to eq(subject)
         end
 
         it "yields the resolved value" do
@@ -74,7 +74,7 @@ RSpec.describe Airbrake::Promise do
 
     context "when it is not rejected" do
       it "returns self" do
-        expect(subject.then{}).to eq(subject)
+        expect(subject.then {}).to eq(subject)
       end
 
       it "doesn't call the reject callbacks yet" do
@@ -86,7 +86,7 @@ RSpec.describe Airbrake::Promise do
     context "when it is rejected" do
       shared_examples "rescue specs" do
         it "returns self" do
-          expect(subject.rescue{}).to eq(subject)
+          expect(subject.rescue {}).to eq(subject)
         end
 
         it "yields the rejected value" do


### PR DESCRIPTION
Every time Circle runs a build, it pulls the newest Rubocop. This causes
troubles for contributors and personally me. Instead of working on new features
or fixes we have to work on fixing Rubocop offences prior to merging actual
useful PRs. This happens because we used to specify an open-ended version
pattern for Rubocop in our Gemfile which was deliberate. Now it's obvious that
this approach isn't good.

With this change I lock Rubocop to a specific version, so it doesn't interrupt
anyone. I'll be updating Rubocop manually from time to time and fix offences in
a sweep.