### PR TITLE
airbrake-ruby/config: support Regexps for 'ignore_environments'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Airbrake Ruby Changelog
 
 ### master
 
+* Added support for Regexps for the `ignore_environments` option
+  ([#299](https://github.com/airbrake/airbrake-ruby/pull/299))
+
 ### [v2.7.1][v2.7.1] (January 8, 2018)
 
 * Fixed disabling of code hunks. It was impossible to disable them

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ means Airbrake Ruby sends exceptions occurring in all environments.
 
 ```ruby
 Airbrake.configure do |c|
-  c.ignore_environments = [:test]
+  c.ignore_environments = [:production, /test.+/]
 end
 ```
 

--- a/lib/airbrake-ruby/config.rb
+++ b/lib/airbrake-ruby/config.rb
@@ -50,9 +50,9 @@ module Airbrake
     attr_accessor :environment
 
     ##
-    # @return [Array<String, Symbol>] the array of environments that forbids
-    #   sending exceptions when the application is running in them. Other
-    #   possible environments not listed in the array will allow sending
+    # @return [Array<String,Symbol,Regexp>] the array of environments that
+    #   forbids sending exceptions when the application is running in them.
+    #   Other possible environments not listed in the array will allow sending
     #   occurring exceptions.
     attr_accessor :ignore_environments
 
@@ -168,7 +168,14 @@ module Airbrake
                     "'ignore_environments' has no effect")
       end
 
-      ignore_environments.map(&:to_s).include?(environment.to_s)
+      env = environment.to_s
+      ignore_environments.any? do |pattern|
+        if pattern.is_a?(Regexp)
+          env.match(pattern)
+        else
+          env == pattern.to_s
+        end
+      end
     end
 
     private

--- a/spec/notifier_spec/options_spec.rb
+++ b/spec/notifier_spec/options_spec.rb
@@ -225,6 +225,15 @@ RSpec.describe Airbrake::Notifier do
       context "when the current env is set and notify envs aren't" do
         include_examples 'sent notice', environment: :development
       end
+
+      context "when ignore_environments specifies a Regexp pattern" do
+        params = {
+          environment: :testing,
+          ignore_environments: ['staging', /test.+/]
+        }
+
+        include_examples 'ignored notice', params
+      end
     end
 
     describe ":blacklist_keys" do


### PR DESCRIPTION
Fixes https://github.com/airbrake/airbrake-ruby/issues/298
(Support for regex in 'ignore_environments')