### PR TITLE
backtrace: don't collect code hunks for files in vendor/bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ Airbrake Ruby Changelog
 
 ### master
 
+* Blacklisted the `vendor/bundle` path for code hunks. This fixes unwanted code
+  hunk reporting for gems inside `root_directory`, which causes every notice to
+  go over the notice limit.
+  ([#302](https://github.com/airbrake/airbrake-ruby/pull/302))
+
 ### [v2.8.0][v2.8.0] (January 16, 2018)
 
 * Added support for Regexps for the `ignore_environments` option

--- a/lib/airbrake-ruby/backtrace.rb
+++ b/lib/airbrake-ruby/backtrace.rb
@@ -197,7 +197,7 @@ module Airbrake
           next(frame) if !config.code_hunks || frame[:file].nil?
 
           if !root_directory.empty?
-            populate_code(config, frame) if frame[:file].start_with?(root_directory)
+            populate_code(config, frame) if frame_in_root?(frame, root_directory)
           elsif i < CODE_FRAME_LIMIT
             populate_code(config, frame)
           end
@@ -209,6 +209,10 @@ module Airbrake
       def populate_code(config, frame)
         code = Airbrake::CodeHunk.new(config).get(frame[:file], frame[:line])
         frame[:code] = code if code
+      end
+
+      def frame_in_root?(frame, root_directory)
+        frame[:file].start_with?(root_directory) && frame[:file] !~ %r{vendor/bundle}
       end
     end
   end

--- a/spec/backtrace_spec.rb
+++ b/spec/backtrace_spec.rb
@@ -320,6 +320,11 @@ RSpec.describe Airbrake::Backtrace do
               file: fixture_path('notroot.txt'),
               line: 3,
               function: 'pineapple'
+            },
+            {
+              file: project_root_path('vendor/bundle/ignored_file.rb'),
+              line: 2,
+              function: 'ignore_me'
             }
           ]
         end
@@ -328,7 +333,8 @@ RSpec.describe Airbrake::Backtrace do
           ex = RuntimeError.new
           backtrace = [
             project_root_path('code.rb') + ":94:in `to_json'",
-            fixture_path('notroot.txt' + ":3:in `pineapple'")
+            fixture_path('notroot.txt' + ":3:in `pineapple'"),
+            project_root_path('vendor/bundle/ignored_file.rb') + ":2:in `ignore_me'"
           ]
           ex.set_backtrace(backtrace)
           expect(described_class.parse(config, ex)).to eq(parsed_backtrace)

--- a/spec/fixtures/project_root/vendor/bundle/ignored_file.rb
+++ b/spec/fixtures/project_root/vendor/bundle/ignored_file.rb
@@ -1,0 +1,5 @@
+module IgnoredFile
+  def ignore_me
+    puts 'Anybody here?'
+  end
+end


### PR DESCRIPTION
`vendor/bundle` needs to be blacklisted because if it's inside `root_directory`,
then code hunks are collected for every single frame (including gems).

The `vendor/bundle` path is not random. This is what Bundler docs say:

> Install your dependencies, even gems that are already installed to your system
> gems, to a location other than your system's gem repository. In this case,
> install them to vendor/bundle.

As result, some Heroku users may see code hunks for every single frame, which
often causes unwanted truncation of the notice.