### PR TITLE
Readme cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ Key features
 * Awesome performance (check out our benchmarks)<sup>[[link](#running-benchmarks)]</sup>
 * Asynchronous exception reporting<sup>[[link](#asynchronous-airbrake-options)]</sup>
 * Promise support<sup>[[link](#promise)]</sup>
-* Flexible logging support (configure your own logger)<sup>[[link](#logger)]</sup>
 * Flexible configuration options (configure as many Airbrake notifers in one
   application as you want)<sup>[[link](#configuration)]</sup>
 * Support for proxying<sup>[[link](#proxy)]</sup>

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ automatically_, integrations with Resque, Sidekiq, Delayed Job and many more.
 Key features
 ------------
 
-* Uses the new Airbrake JSON API (v3)<sup>[[link][notice-v3]]</sup>
 * Simple, consistent and easy-to-use library API<sup>[[link](#api)]</sup>
 * Awesome performance (check out our benchmarks)<sup>[[link](#running-benchmarks)]</sup>
 * Asynchronous exception reporting<sup>[[link](#asynchronous-airbrake-options)]</sup>
@@ -820,7 +819,6 @@ The project uses the MIT License. See LICENSE.md for details.
 [airbrake.io]: https://airbrake.io
 [airbrake-gem]: https://github.com/airbrake/airbrake
 [semver2]: http://semver.org/spec/v2.0.0.html
-[notice-v3]: https://airbrake.io/docs/#create-notice-v3
 [project-idkey]: https://s3.amazonaws.com/airbrake-github-assets/airbrake-ruby/project-id-key.png
 [issues]: https://github.com/airbrake/airbrake-ruby/issues
 [twitter]: https://twitter.com/airbrake


### PR DESCRIPTION
* README: delete the mention of the v3 API

This is old news now.

---

* README: don't mention "flexible loggers" as a key feature

This feature is mostly a necessity for developers and for troubleshooting rather
than something useful for an average Airbrake user.
