### PR TITLE
Also filter the hash in the array with KeysBlacklist

### DIFF
--- a/lib/airbrake-ruby/filters/keys_filter.rb
+++ b/lib/airbrake-ruby/filters/keys_filter.rb
@@ -78,6 +78,8 @@ module Airbrake
             hash[key] = FILTERED
           elsif hash[key].is_a?(Hash)
             filter_hash(hash[key])
+          elsif hash[key].is_a?(Array)
+            hash[key].each { |h| filter_hash(h) }
           end
         end
       end

--- a/spec/filters/keys_blacklist_spec.rb
+++ b/spec/filters/keys_blacklist_spec.rb
@@ -60,6 +60,17 @@ RSpec.describe Airbrake::Filters::KeysBlacklist do
     )
   end
 
+  context "when a pattern is a Array of Hash" do
+    include_examples(
+      'pattern matching',
+      ['bingo'],
+      [
+        { array: [bingo: 'bango'] },
+        { array: [bingo: '[Filtered]'] }
+      ]
+    )
+  end
+
   context "when a Proc pattern was provided" do
     context "along with normal keys" do
       include_examples(


### PR DESCRIPTION
Hi, 

The current specification does not apply a filter if array contains parameter of notification contents. This PR also filters even if the filter target parameter is in array.