### PR TITLE
filters/keys_filter: handle non-hash values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Airbrake Ruby Changelog
 
 ### master
 
+* Fixed bug introduced in v2.8.2 in blacklist/whitelist filtering. All
+  v2.8.2 users must upgrade to the recent version
+  ([#309](https://github.com/airbrake/airbrake-ruby/pull/309))
+
 ### [v2.8.2][v2.8.2] (March 5, 2018)
 
 * Fixed bug where params inside arrays couldn't be

--- a/lib/airbrake-ruby/filters/keys_filter.rb
+++ b/lib/airbrake-ruby/filters/keys_filter.rb
@@ -73,6 +73,8 @@ module Airbrake
       private
 
       def filter_hash(hash)
+        return hash unless hash.is_a?(Hash)
+
         hash.each_key do |key|
           if should_filter?(key.to_s)
             hash[key] = FILTERED

--- a/spec/filters/keys_blacklist_spec.rb
+++ b/spec/filters/keys_blacklist_spec.rb
@@ -65,8 +65,8 @@ RSpec.describe Airbrake::Filters::KeysBlacklist do
       'pattern matching',
       ['bingo'],
       [
-        { array: [bingo: 'bango'] },
-        { array: [bingo: '[Filtered]'] }
+        { array: [{ bingo: 'bango' }, []] },
+        { array: [{ bingo: '[Filtered]' }, []] }
       ]
     )
   end


### PR DESCRIPTION
Fixes #308
(Change in 2.8.2 makes airbrake crash on error when filtering array
typed keys)

We should simply return non-hash values to make recursion stop failing.