### PR TITLE
async_sender: prevent race conditions in #has_workers?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Airbrake Ruby Changelog
   `/GEM_ROOT` & `/PROJECT_ROOT` respectively. This improves searching
   capabilities in the Airbrake
   dashboard. ([#311](https://github.com/airbrake/airbrake-ruby/pull/311))
+* Fixed `TypeError: can't move to the enclosed thread group` when
+  using `notify` at the same time from multiple threads
+  ([#316](https://github.com/airbrake/airbrake-ruby/pull/316))
 
 ### [v2.8.3][v2.8.3] (March 12, 2018)
 

--- a/lib/airbrake-ruby/async_sender.rb
+++ b/lib/airbrake-ruby/async_sender.rb
@@ -80,14 +80,16 @@ module Airbrake
     # @return [Boolean] true if an instance wasn't closed, but has no workers
     # @see https://goo.gl/oydz8h Example of at_exit that prevents exit
     def has_workers?
-      return false if @closed
+      @mutex.synchronize do
+        return false if @closed
 
-      if @pid != Process.pid && @workers.list.empty?
-        @pid = Process.pid
-        spawn_workers
+        if @pid != Process.pid && @workers.list.empty?
+          @pid = Process.pid
+          spawn_workers
+        end
+
+        !@closed && @workers.list.any?
       end
-
-      !@closed && @workers.list.any?
     end
 
     private


### PR DESCRIPTION
Fixes #312 (TypeError: can't move to the enclosed thread group)

`@workers.list.empty?` is racey, so if multiple threads are spawned at
the same time, one of them would spawn workers, the other one would
see that the list is empty, too and try to spawn the workers again.

I have to admit that storing the workers in a ThreadGroup instead of
an Array was a damn good choice. Luckily, it saved us from the worker
leak disaster.