### PR TITLE
Implement basic API for merging context

### DIFF
--- a/lib/airbrake-ruby.rb
+++ b/lib/airbrake-ruby.rb
@@ -23,6 +23,7 @@ require 'airbrake-ruby/filters/gem_root_filter'
 require 'airbrake-ruby/filters/system_exit_filter'
 require 'airbrake-ruby/filters/root_directory_filter'
 require 'airbrake-ruby/filters/thread_filter'
+require 'airbrake-ruby/filters/context_filter'
 require 'airbrake-ruby/filter_chain'
 require 'airbrake-ruby/notifier'
 require 'airbrake-ruby/code_hunk'
@@ -267,6 +268,55 @@ module Airbrake
     # @return [void]
     def create_deploy(deploy_params)
       @notifiers[:default].create_deploy(deploy_params)
+    end
+
+    ##
+    # Merges +context+ with the current context.
+    #
+    # The context will be attached to the notice object upon a notify call and
+    # cleared after it's attached. The context data is attached to the
+    # `params/airbrake_context` key.
+    #
+    # @example
+    #   class MerryGrocer
+    #     def load_fruits(fruits)
+    #       Airbrake.merge_context(fruits: fruits)
+    #     end
+    #
+    #     def deliver_fruits
+    #       Airbrake.notify('fruitception')
+    #     end
+    #
+    #     def load_veggies
+    #       Airbrake.merge_context(veggies: veggies)
+    #     end
+    #
+    #     def deliver_veggies
+    #       Airbrake.notify('veggieboom!')
+    #     end
+    #   end
+    #
+    #   grocer = MerryGrocer.new
+    #
+    #   # Load some fruits to the context.
+    #   grocer.load_fruits(%w(mango banana apple))
+    #
+    #   # Deliver the fruits. Note that we are not passing anything,
+    #   # `deliver_fruits` knows that we loaded something.
+    #   grocer.deliver_fruits
+    #
+    #   # Load some vegetables and deliver them to Airbrake. Note that the
+    #   # fruits have been delivered and therefore the grocer doesn't have them
+    #   # anymore. We merge veggies with the new context.
+    #   grocer.load_veggies(%w(cabbage carrot onion))
+    #   grocer.deliver_veggies
+    #
+    #   # The context is empty again, feel free to load more.
+    #
+    # @param [Hash{Symbol=>Object}] context
+    # @return [void]
+    def merge_context(context)
+      @notifiers[:default].merge_context(context)
     end
   end
 end

--- a/lib/airbrake-ruby/filters/context_filter.rb
+++ b/lib/airbrake-ruby/filters/context_filter.rb
@@ -1,0 +1,28 @@
+module Airbrake
+  module Filters
+    # Adds user context to the notice object. Clears the context after it's
+    # attached.
+    #
+    # @api private
+    # @since v2.9.0
+    class ContextFilter
+      # @return [Integer]
+      attr_reader :weight
+
+      def initialize(context)
+        @context = context
+        @weight = 119
+        @mutex = Mutex.new
+      end
+
+      def call(notice)
+        @mutex.synchronize do
+          return if @context.empty?
+
+          notice[:params][:airbrake_context] = @context.dup
+          @context.clear
+        end
+      end
+    end
+  end
+end

--- a/lib/airbrake-ruby/notifier.rb
+++ b/lib/airbrake-ruby/notifier.rb
@@ -31,6 +31,8 @@ module Airbrake
 
       raise Airbrake::Error, @config.validation_error_message unless @config.valid?
 
+      @context = {}
+
       @filter_chain = FilterChain.new
       add_default_filters
 
@@ -98,6 +100,12 @@ module Airbrake
       @config.valid?
     end
 
+    ##
+    # @macro see_public_api_method
+    def merge_context(context)
+      @context.merge!(context)
+    end
+
     private
 
     def convert_to_exception(ex)
@@ -162,6 +170,8 @@ module Airbrake
         )
       end
 
+      @filter_chain.add_filter(Airbrake::Filters::ContextFilter.new(@context))
+
       return unless (root_directory = @config.root_directory)
       @filter_chain.add_filter(
         Airbrake::Filters::RootDirectoryFilter.new(root_directory)
@@ -190,5 +200,7 @@ module Airbrake
     def configured?
       false
     end
+
+    def merge_context(_context); end
   end
 end

--- a/spec/airbrake_spec.rb
+++ b/spec/airbrake_spec.rb
@@ -163,16 +163,20 @@ RSpec.describe Airbrake do
       filter_chain = notifier.instance_variable_get(:@filter_chain)
       filters = filter_chain.instance_variable_get(:@filters)
 
-      expect(filters.size).to eq(3)
+      expect(filters.size).to eq(4)
 
       described_class.add_filter {}
 
-      expect(filters.size).to eq(4)
+      expect(filters.size).to eq(5)
       expect(filters.last).to be_a(Proc)
     end
   end
 
   describe ".build_notice" do
     include_examples 'non-configured notifier handling', :build_notice
+  end
+
+  describe ".merge_context" do
+    include_examples 'non-configured notifier handling', :merge_context
   end
 end

--- a/spec/filters/context_filter_spec.rb
+++ b/spec/filters/context_filter_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+RSpec.describe Airbrake::Filters::ContextFilter do
+  let(:notice) do
+    Airbrake::Notice.new(Airbrake::Config.new, AirbrakeTestError.new)
+  end
+
+  context "when the current context is empty" do
+    it "doesn't merge anything with params" do
+      described_class.new({}).call(notice)
+      expect(notice[:params]).to be_empty
+    end
+  end
+
+  context "when the current context has some data" do
+    it "merges the data with params" do
+      described_class.new(apples: 'oranges').call(notice)
+      expect(notice[:params]).to eq(airbrake_context: { apples: 'oranges' })
+    end
+
+    it "clears the data from the provided context" do
+      context = { apples: 'oranges' }
+      described_class.new(context).call(notice)
+      expect(context).to be_empty
+    end
+  end
+end

--- a/spec/notifier_spec.rb
+++ b/spec/notifier_spec.rb
@@ -614,4 +614,15 @@ RSpec.describe Airbrake::Notifier do
     subject { described_class.new(airbrake_params) }
     it { is_expected.to be_configured }
   end
+
+  describe "#merge_context" do
+    it "merges the provided context with the notice object" do
+      @airbrake.merge_context(apples: 'oranges')
+      @airbrake.notify_sync('oops')
+      expect(
+        a_request(:post, endpoint).
+        with(body: /"params":{"airbrake_context":{"apples":"oranges"}/)
+      ).to have_been_made.once
+    end
+  end
 end


### PR DESCRIPTION
Fixes #314 (Possible to set context for possible error?)

This feature has been request many times already. While Airbrake
supports it, it's not obvious for users how to make it work. It's also
hard to advertise it since there's no simple method to call to explain
the API. Previously, I used to link people to
https://github.com/airbrake/airbrake/issues/696#issuecomment-366857391

I guess it is not very convenient to use that API. Therefore, the feature
doesn't use Threads and is much simpler to use. Users no longer need to mess
with threads and cleaning up context information is on us.