### PR TITLE
Gemfile: update rubocop to v0.55.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -82,3 +82,6 @@ Style/FormatStringToken:
 
 Naming/UncommunicativeMethodParamName:
   Enabled: false
+
+Gemspec/RequiredRubyVersion:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -79,3 +79,6 @@ Gemspec/OrderedDependencies:
 
 Style/FormatStringToken:
   Enabled: false
+
+Naming/UncommunicativeMethodParamName:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,5 @@ gemspec
 
 # Rubocop supports only >=2.1.0
 if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.1.0')
-  gem 'rubocop', '= 0.51', require: false
+  gem 'rubocop', '= 0.55', require: false
 end


### PR DESCRIPTION
* rubocop: disable the Naming/UncommunicativeMethodParamName cop

    This rule is a little annoying to follow. Although I understand that it
prevents you from bad variable names, I am not ready to refuse from ingrained
names such as `th` or `ex` that we use in this codebase.

* rubocop: disable the Gemspec/RequiredRubyVersion cop

    Rubocop doesn't support Ruby 2.0 but we still do. We simply cannot have the best
of both worlds (latest rubocop versions and old versions support), so I have to
disable it.