### PR TITLE
Move NilNotifier to airbrake-ruby.rb

### DIFF
--- a/lib/airbrake-ruby.rb
+++ b/lib/airbrake-ruby.rb
@@ -83,6 +83,31 @@ module Airbrake
   JRUBY = (RUBY_ENGINE == 'jruby')
 
   ##
+  # NilNotifier is a no-op notifier, which mimics +Airbrake::Notifier+ and
+  # serves only for the purpose of making the library API easier to use.
+  #
+  # @since 2.1.0
+  class NilNotifier
+    def notify(_exception, _params = {}, &block); end
+
+    def notify_sync(_exception, _params = {}, &block); end
+
+    def add_filter(_filter = nil, &_block); end
+
+    def build_notice(_exception, _params = {}); end
+
+    def close; end
+
+    def create_deploy(_deploy_params); end
+
+    def configured?
+      false
+    end
+
+    def merge_context(_context); end
+  end
+
+  ##
   # A Hash that holds all notifiers. The keys of the Hash are notifier
   # names, the values are Airbrake::Notifier instances. If a notifier is not
   # assigned to the hash, then it returns a null object (NilNotifier).

--- a/lib/airbrake-ruby/notifier.rb
+++ b/lib/airbrake-ruby/notifier.rb
@@ -178,29 +178,4 @@ module Airbrake
       )
     end
   end
-
-  ##
-  # NilNotifier is a no-op notifier, which mimics +Airbrake::Notifier+ and
-  # serves only for the purpose of making the library API easier to use.
-  #
-  # @since 2.1.0
-  class NilNotifier
-    def notify(_exception, _params = {}, &block); end
-
-    def notify_sync(_exception, _params = {}, &block); end
-
-    def add_filter(_filter = nil, &_block); end
-
-    def build_notice(_exception, _params = {}); end
-
-    def close; end
-
-    def create_deploy(_deploy_params); end
-
-    def configured?
-      false
-    end
-
-    def merge_context(_context); end
-  end
 end


### PR DESCRIPTION
It makes more sense to keep it there because that file is the only place where
it is used.