### PR TITLE
rspec: use 'doc' formatter

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --warnings
+--format=doc


### PR DESCRIPTION
From time to time the build segfaults on Ruby 2.3. It's hard to tell which
example is to blame, so to debug the problem I'm temporarily changing the
formatter to a more verbose one.

Example build: https://circleci.com/gh/airbrake/airbrake-ruby/1399