### PR TITLE
Introduce the 'versions' option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Airbrake Ruby Changelog
 
 ### master
 
+* Added the `versions` option
+  ([#327](https://github.com/airbrake/airbrake-ruby/pull/327))
+
 ### [v2.9.0][v2.9.0] (April 26, 2018)
 
 * Changed format for `[GEM_ROOT]` & `[PROJECT_ROOT]` placeholders to

--- a/README.md
+++ b/README.md
@@ -222,6 +222,21 @@ Airbrake.configure do |c|
 end
 ```
 
+#### versions
+
+A hash of arbitrary versions that your application uses that you want to
+track (Rails, Linux kernel, API version, etc.). By default, it's empty.
+
+```ruby
+Airbrake.configure do |c|
+  c.versions = {
+    'Rails' => '5.2.0',
+    'bundler' => '1.16.1',
+    'LinuxKernel' => '4.4.0-97-generic'
+  }
+end
+```
+
 #### host
 
 By default, it is set to `airbrake.io`. A `host` is a web address containing a

--- a/lib/airbrake-ruby/config.rb
+++ b/lib/airbrake-ruby/config.rb
@@ -28,6 +28,12 @@ module Airbrake
     attr_accessor :app_version
 
     ##
+    # @return [Hash{String=>String}] arbitrary versions that your app wants to
+    #   track
+    # @since v2.10.0
+    attr_accessor :versions
+
+    ##
     # @return [Integer] the max number of notices that can be queued up
     attr_accessor :queue_size
 
@@ -107,6 +113,8 @@ module Airbrake
         (defined?(Bundler) && Bundler.root) ||
         Dir.pwd
       )
+
+      self.versions = {}
 
       merge(user_config)
     end

--- a/lib/airbrake-ruby/notice.rb
+++ b/lib/airbrake-ruby/notice.rb
@@ -159,6 +159,7 @@ module Airbrake
     def context
       {
         version: @config.app_version,
+        versions: @config.versions,
         # We ensure that root_directory is always a String, so it can always be
         # converted to JSON in a predictable manner (when it's a Pathname and in
         # Rails environment, it converts to unexpected JSON).

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -25,6 +25,10 @@ RSpec.describe Airbrake::Config do
         expect(config.app_version).to be_nil
       end
 
+      it "sets the default versions" do
+        expect(config.versions).to be_empty
+      end
+
       it "sets the default host" do
         expect(config.host).to eq('https://airbrake.io')
       end

--- a/spec/notice_spec.rb
+++ b/spec/notice_spec.rb
@@ -30,6 +30,23 @@ RSpec.describe Airbrake::Notice do
       end
     end
 
+    context "when versions is empty" do
+      it "doesn't set the 'versions' payload" do
+        expect(notice.to_json).not_to match(
+          /"context":{"versions":{"dep":"1.2.3"}}/
+        )
+      end
+    end
+
+    context "when versions is not empty" do
+      it "sets the 'versions' payload" do
+        notice[:context][:versions] = { 'dep' => '1.2.3' }
+        expect(notice.to_json).to match(
+          /"context":{.*"versions":{"dep":"1.2.3"}.*}/
+        )
+      end
+    end
+
     context "truncation" do
       shared_examples 'payloads' do |size, msg|
         it msg do


### PR DESCRIPTION
We have been using `app_version` for tracking the user's app version. Since the
option expects a string there was no way to track any other
versions (dependencies is the most prominent example; version of Rails). We've
been using a hack where we prepend versions to the `app_version` value like this
'app/1.2.3 Rails/5.2.0`.

Those gloomy days are over with this new and shiny `versions` option. Now you
can attach any key and any value (please use names and versions respectively).
For example:

```ruby
config.versions = { 'bundler' => '1.2.3', 'Rails' => '5.2.0' }
```