### PR TITLE
notifier: don't pass project id on `create_deploy` as a query param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Airbrake Ruby Changelog
 
 ### master
 
+* Stopped passing project id on `Airbrake.create_deploy` as a query param
+  ([#339](https://github.com/airbrake/airbrake-ruby/pull/339))
+
 ### [v2.11.0][v2.11.0] (June 27, 2018)
 
 * Added `GitRevisionFilter`

--- a/lib/airbrake-ruby/notifier.rb
+++ b/lib/airbrake-ruby/notifier.rb
@@ -76,9 +76,12 @@ module Airbrake
     # @macro see_public_api_method
     def create_deploy(deploy_params)
       deploy_params[:environment] ||= @config.environment
-      path = "api/v4/projects/#{@config.project_id}/deploys?key=#{@config.project_key}"
       promise = Airbrake::Promise.new
-      @sync_sender.send(deploy_params, promise, URI.join(@config.host, path))
+      @sync_sender.send(
+        deploy_params,
+        promise,
+        URI.join(@config.host, "api/v4/projects/#{@config.project_id}/deploys")
+      )
       promise
     end
 

--- a/spec/notifier_spec.rb
+++ b/spec/notifier_spec.rb
@@ -393,7 +393,7 @@ RSpec.describe Airbrake::Notifier do
 
   describe "#create_deploy" do
     it "returns a promise" do
-      stub_request(:post, "https://airbrake.io/api/v4/projects/1/deploys?key=abc")
+      stub_request(:post, 'https://airbrake.io/api/v4/projects/1/deploys')
         .to_return(status: 201, body: '')
       expect(subject.create_deploy({})).to be_an(Airbrake::Promise)
     end
@@ -403,7 +403,7 @@ RSpec.describe Airbrake::Notifier do
         expect_any_instance_of(Airbrake::SyncSender).to receive(:send).with(
           { environment: 'barenv' },
           instance_of(Airbrake::Promise),
-          URI('https://airbrake.io/api/v4/projects/1/deploys?key=abc')
+          URI('https://airbrake.io/api/v4/projects/1/deploys')
         )
         described_class.new(
           user_params.merge(environment: 'fooenv')
@@ -416,7 +416,7 @@ RSpec.describe Airbrake::Notifier do
         expect_any_instance_of(Airbrake::SyncSender).to receive(:send).with(
           { environment: 'fooenv' },
           instance_of(Airbrake::Promise),
-          URI('https://airbrake.io/api/v4/projects/1/deploys?key=abc')
+          URI('https://airbrake.io/api/v4/projects/1/deploys')
         )
         subject.create_deploy(environment: 'fooenv')
       end


### PR DESCRIPTION
`SyncSender` already handles that.