### PR TITLE
Send errors to 'api.airbrake.io' instead of 'airbrake.io'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Airbrake Ruby Changelog
 
 * Stopped passing project id on `Airbrake.create_deploy` as a query param
   ([#339](https://github.com/airbrake/airbrake-ruby/pull/339))
+* Changed the endpoint that Airbrake Ruby sends errors to.
+
+  Before: `https://airbrake.io/api/v4/projects/PROJECT_ID/notices`
+
+  After: `https://api.airbrake.io/api/v4/projects/PROJECT_ID/notices`
+
+  The endpoint neither accepts anything new nor removes existing functionality.
+  ([#340](https://github.com/airbrake/airbrake-ruby/pull/340))
 
 ### [v2.11.0][v2.11.0] (June 27, 2018)
 

--- a/lib/airbrake-ruby/config.rb
+++ b/lib/airbrake-ruby/config.rb
@@ -98,7 +98,7 @@ module Airbrake
 
       self.project_id = user_config[:project_id]
       self.project_key = user_config[:project_key]
-      self.host = 'https://airbrake.io'
+      self.host = 'https://api.airbrake.io'
 
       self.ignore_environments = []
 

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Airbrake::Config do
       end
 
       it "sets the default host" do
-        expect(config.host).to eq('https://airbrake.io')
+        expect(config.host).to eq('https://api.airbrake.io')
       end
 
       it "sets the default endpoint" do

--- a/spec/notifier_spec.rb
+++ b/spec/notifier_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe Airbrake::Notifier do
   end
 
   describe "#notify" do
-    let(:endpoint) { 'https://airbrake.io/api/v3/projects/1/notices' }
+    let(:endpoint) { 'https://api.airbrake.io/api/v3/projects/1/notices' }
 
     subject { described_class.new(user_params) }
 
@@ -179,7 +179,7 @@ RSpec.describe Airbrake::Notifier do
   end
 
   describe "#notify_sync" do
-    let(:endpoint) { 'https://airbrake.io/api/v3/projects/1/notices' }
+    let(:endpoint) { 'https://api.airbrake.io/api/v3/projects/1/notices' }
 
     let(:user_params) do
       { project_id: 1, project_key: 'abc', logger: Logger.new('/dev/null') }
@@ -393,7 +393,7 @@ RSpec.describe Airbrake::Notifier do
 
   describe "#create_deploy" do
     it "returns a promise" do
-      stub_request(:post, 'https://airbrake.io/api/v4/projects/1/deploys')
+      stub_request(:post, 'https://api.airbrake.io/api/v4/projects/1/deploys')
         .to_return(status: 201, body: '')
       expect(subject.create_deploy({})).to be_an(Airbrake::Promise)
     end
@@ -403,7 +403,7 @@ RSpec.describe Airbrake::Notifier do
         expect_any_instance_of(Airbrake::SyncSender).to receive(:send).with(
           { environment: 'barenv' },
           instance_of(Airbrake::Promise),
-          URI('https://airbrake.io/api/v4/projects/1/deploys')
+          URI('https://api.airbrake.io/api/v4/projects/1/deploys')
         )
         described_class.new(
           user_params.merge(environment: 'fooenv')
@@ -416,7 +416,7 @@ RSpec.describe Airbrake::Notifier do
         expect_any_instance_of(Airbrake::SyncSender).to receive(:send).with(
           { environment: 'fooenv' },
           instance_of(Airbrake::Promise),
-          URI('https://airbrake.io/api/v4/projects/1/deploys')
+          URI('https://api.airbrake.io/api/v4/projects/1/deploys')
         )
         subject.create_deploy(environment: 'fooenv')
       end

--- a/spec/notifier_spec/options_spec.rb
+++ b/spec/notifier_spec/options_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Airbrake::Notifier do
   let(:localhost) { 'http://localhost:8080' }
 
   let(:endpoint) do
-    "https://airbrake.io/api/v3/projects/#{project_id}/notices"
+    "https://api.airbrake.io/api/v3/projects/#{project_id}/notices"
   end
 
   let(:airbrake_params) do

--- a/spec/sync_sender_spec.rb
+++ b/spec/sync_sender_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Airbrake::SyncSender do
 
     let(:sender) { described_class.new(config) }
     let(:notice) { Airbrake::Notice.new(config, AirbrakeTestError.new) }
-    let(:endpoint) { 'https://airbrake.io/api/v3/projects/1/notices' }
+    let(:endpoint) { 'https://api.airbrake.io/api/v3/projects/1/notices' }
 
     before { stub_request(:post, endpoint).to_return(body: '{}') }
 
@@ -90,7 +90,7 @@ RSpec.describe Airbrake::SyncSender do
     end
 
     context "when IP is rate limited" do
-      let(:endpoint) { %r{https://airbrake.io/api/v3/projects/1/notices} }
+      let(:endpoint) { %r{https://api.airbrake.io/api/v3/projects/1/notices} }
 
       before do
         stub_request(:post, endpoint).to_return(


### PR DESCRIPTION
It's a simple renaming. This API doesn't introduce anything new.