### PR TITLE
filters/git_revision: cache revision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ Airbrake Ruby Changelog
   Note: this feature is enabled only for certain accounts. Further details as to
   how to use it will be published in the README once it's released to everybody.
 
+* Cached revision of `GitRevisionFilter`, so we don't repeatedly
+  read the file ([#342](https://github.com/airbrake/airbrake-ruby/pull/342))
+
 ### [v2.11.0][v2.11.0] (June 27, 2018)
 
 * Added `GitRevisionFilter`

--- a/lib/airbrake-ruby/filters/git_revision_filter.rb
+++ b/lib/airbrake-ruby/filters/git_revision_filter.rb
@@ -13,16 +13,24 @@ module Airbrake
       # @param [String] root_directory
       def initialize(root_directory)
         @git_path = File.join(root_directory, '.git')
+        @revision = nil
         @weight = 116
       end
 
       # @macro call_filter
       def call(notice)
         return if notice[:context].key?(:revision)
+
+        if @revision
+          notice[:context][:revision] = @revision
+          return
+        end
+
         return unless File.exist?(@git_path)
 
-        revision = find_revision
-        notice[:context][:revision] = revision if revision
+        @revision = find_revision
+        return unless @revision
+        notice[:context][:revision] = @revision
       end
 
       private


### PR DESCRIPTION
We shouldn't be reading files on every error. It's enough to read it once and
cache the result.