### PR TITLE
spec/filters/git_last_checkout: fix flakey test

### DIFF
--- a/spec/filters/git_last_checkout_filter_spec.rb
+++ b/spec/filters/git_last_checkout_filter_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Airbrake::Filters::GitLastCheckoutFilter do
     end
 
     it "attaches last checkouted email" do
-      expect(notice[:context][:lastCheckout][:email]).to match(/\A\w+@\w+\z/)
+      expect(notice[:context][:lastCheckout][:email]).to match(/\A\w+@\w+\.?\w+?\z/)
     end
 
     it "attaches last checkouted revision" do


### PR DESCRIPTION
Circle uses the following email format: `circleci@123` (no dot), real emails use
`circleci@example.com`. Therefore, the test needs to know about this. Let's just
blame it on Circle.