### PR TITLE
notifier: yield notice before filter_chain is invoked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ Airbrake Ruby Changelog
 
 * Cached revision of `GitRevisionFilter`, so we don't repeatedly
   read the file ([#342](https://github.com/airbrake/airbrake-ruby/pull/342))
+* Changed the order of execution of inline filters (added via `Airbrake.notify
+  do ... end`) and the `Airbrake.add_filter` filters. Now the former is being
+  executed first (used to be executed last)
+  ([#345](https://github.com/airbrake/airbrake-ruby/pull/345))
 
 ### [v2.11.0][v2.11.0] (June 27, 2018)
 

--- a/lib/airbrake-ruby/notifier.rb
+++ b/lib/airbrake-ruby/notifier.rb
@@ -118,8 +118,8 @@ module Airbrake
       end
 
       notice = build_notice(exception, params)
+      yield notice if block_given?
       @filter_chain.refine(notice)
-      yield notice if block_given? && !notice.ignored?
 
       return promise.reject("#{notice} was marked as ignored") if notice.ignored?
 

--- a/spec/notifier_spec.rb
+++ b/spec/notifier_spec.rb
@@ -129,17 +129,25 @@ RSpec.describe Airbrake::Notifier do
       end
     end
 
-    context "when a notice is ignored" do
+    context "when a notice is ignored via a filter" do
       before { subject.add_filter(&:ignore!) }
 
-      it "doesn't yield the notice" do
+      it "yields the notice" do
         expect { |b| subject.notify('ex', &b) }
-          .not_to yield_with_args(Airbrake::Notice)
+          .to yield_with_args(Airbrake::Notice)
       end
 
       it "returns a rejected promise" do
         value = subject.notify('ex').value
         expect(value['error']).to match(/was marked as ignored/)
+      end
+    end
+
+    context "when a notice is ignored via an inline filter" do
+      before { subject.add_filter { raise AirbrakeTestError } }
+
+      it "doesn't invoke regular filters" do
+        expect { subject.notify('ex', &:ignore!) }.not_to raise_error
       end
     end
 
@@ -221,17 +229,25 @@ RSpec.describe Airbrake::Notifier do
       end
     end
 
-    context "when a notice is ignored" do
+    context "when a notice is ignored via a filter" do
       before { subject.add_filter(&:ignore!) }
 
-      it "doesn't yield the notice" do
+      it "yields the notice" do
         expect { |b| subject.notify_sync('ex', &b) }
-          .not_to yield_with_args(Airbrake::Notice)
+          .to yield_with_args(Airbrake::Notice)
       end
 
       it "returns an error hash" do
         response = subject.notify_sync('ex')
         expect(response['error']).to match(/was marked as ignored/)
+      end
+    end
+
+    context "when a notice is ignored via an inline filter" do
+      before { subject.add_filter { raise AirbrakeTestError } }
+
+      it "doesn't invoke regular filters" do
+        expect { subject.notify('ex', &:ignore!) }.not_to raise_error
       end
     end
 


### PR DESCRIPTION
The order switch is needed to make inline filters usable in the ignore scenario.

Let's say we set notice's component in the inline filter. Then we define a
filter to ignore it via `Airbrake.add_filter`.

Before: `Airbrake.add_filter` filters are invoked. The inline filter is invoked
next. Nothing is ignored.

After: The inline filter is invoked. `Airbrake.add_filter` filters are reading
that and ignoring the notice.

This is exactly the problem with our Logger integration (it appears to be
impossible to ignore logger messages).