### PR TITLE
notifier: implement #inspect and #pretty_print

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Airbrake Ruby Changelog
 
 ### master
 
+* Made `Airbrake::Notifier#inspect` less verbose
+  ([#350](https://github.com/airbrake/airbrake-ruby/pull/350))
+
 ### [v2.13.0.rc.1][v2.13.0.rc.1] (October 26, 2018)
 
 * Added support for route stats

--- a/spec/filter_chain_spec.rb
+++ b/spec/filter_chain_spec.rb
@@ -1,8 +1,12 @@
 require 'spec_helper'
 
 RSpec.describe Airbrake::FilterChain do
+  subject { described_class.new(config, {}) }
+
+  let(:config) { Airbrake::Config.new }
+
   let(:notice) do
-    Airbrake::Notice.new(Airbrake::Config.new, AirbrakeTestError.new)
+    Airbrake::Notice.new(config, AirbrakeTestError.new)
   end
 
   describe "#refine" do

--- a/spec/notifier_spec.rb
+++ b/spec/notifier_spec.rb
@@ -459,5 +459,35 @@ RSpec.describe Airbrake::Notifier do
       subject.inc_request('GET', '/foo', 200, 1000, t)
     end
   end
+
+  describe "#inspect" do
+    it "displays object information" do
+      expect(subject.inspect).to match(/
+        #<Airbrake::Notifier:0x\w+\s
+          project_id="\d+"\s
+          project_key=".+"\s
+          host="http.+"\s
+          filter_chain=\[.+\]>
+      /x)
+    end
+  end
+
+  describe "#pretty_print" do
+    it "displays object information in a beautiful way" do
+      q = PP.new
+
+      # Guarding is needed to fix JRuby failure:
+      # NoMethodError: undefined method `[]' for nil:NilClass
+      q.guard_inspect_key { subject.pretty_print(q) }
+
+      expect(q.output).to match(/
+        #<Airbrake::Notifier:0x\w+\s
+          project_id="\d+"\s
+          project_key=".+"\s
+          host="http.+"\s
+          filter_chain=\[\n\s\s
+      /x)
+    end
+  end
 end
 # rubocop:enable Layout/DotPosition

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@ require 'pathname'
 require 'webrick'
 require 'English'
 require 'base64'
+require 'pp'
 
 require 'helpers'
 


### PR DESCRIPTION
It has always bothered me that when you configure a notifier in Pry, it would
print a huge object state, which is barely readable. Quite often I would need to
exit pager with (q) to be able to type again.

With help of this change we get a meaningful inspect output, so only relevant
information is shown.

The default filter stuff was also moved from Notifier to FilterChain because
Rubocop was complaining that the Notifier class is too big.