### PR TITLE
route_sender: replace min/max with TDigests

### DIFF
--- a/airbrake-ruby.gemspec
+++ b/airbrake-ruby.gemspec
@@ -27,6 +27,8 @@ DESC
 
   s.required_ruby_version = '>= 2.0'
 
+  s.add_dependency 'tdigest', '= 0.1.1'
+
   s.add_development_dependency 'rspec', '~> 3'
   s.add_development_dependency 'rake', '~> 10'
   s.add_development_dependency 'pry', '~> 0'

--- a/lib/airbrake-ruby/response.rb
+++ b/lib/airbrake-ruby/response.rb
@@ -23,7 +23,7 @@ module Airbrake
 
       begin
         case code
-        when 200
+        when 200, 204
           logger.debug("#{LOG_LABEL} #{name} (#{code}): #{body}")
           { response.msg => response.body }
         when 201

--- a/spec/response_spec.rb
+++ b/spec/response_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Airbrake::Response do
     let(:out) { StringIO.new }
     let(:logger) { Logger.new(out) }
 
-    [200, 201].each do |code|
+    [200, 201, 204].each do |code|
       context "when response code is #{code}" do
         it "logs response body" do
           described_class.parse(OpenStruct.new(code: code, body: '{}'), logger)

--- a/spec/route_sender_spec.rb
+++ b/spec/route_sender_spec.rb
@@ -48,10 +48,10 @@ RSpec.describe Airbrake::RouteSender do
             {"routes":\[
               {"method":"GET","route":"/foo","statusCode":200,
                "time":"2018-01-01T00:00:00\+00:00","count":1,"sum":24.0,
-               "sumsq":576.0,"min":24.0,"max":24.0},
+               "sumsq":576.0,"tDigest":"AAAAAkBZAAAAAAAAAAAAAUHAAAAB"},
               {"method":"GET","route":"/foo","statusCode":200,
                "time":"2018-01-01T00:01:00\+00:00","count":1,"sum":10.0,
-               "sumsq":100.0,"min":10.0,"max":10.0}\]}
+               "sumsq":100.0,"tDigest":"AAAAAkBZAAAAAAAAAAAAAUEgAAAB"}\]}
           \z|x
         )
       ).to have_been_made
@@ -67,10 +67,10 @@ RSpec.describe Airbrake::RouteSender do
             {"routes":\[
               {"method":"GET","route":"/foo","statusCode":200,
                "time":"2018-01-01T00:00:00\+00:00","count":1,"sum":24.0,
-               "sumsq":576.0,"min":24.0,"max":24.0},
+               "sumsq":576.0,"tDigest":"AAAAAkBZAAAAAAAAAAAAAUHAAAAB"},
               {"method":"POST","route":"/foo","statusCode":200,
                "time":"2018-01-01T00:00:00\+00:00","count":1,"sum":10.0,
-               "sumsq":100.0,"min":10.0,"max":10.0}\]}
+               "sumsq":100.0,"tDigest":"AAAAAkBZAAAAAAAAAAAAAUEgAAAB"}\]}
           \z|x
         )
       ).to have_been_made


### PR DESCRIPTION
https://github.com/tdunning/t-digest

> A new data structure for accurate on-line accumulation of rank-based
> statistics such as quantiles and trimmed means. The t-digest algorithm is also
> very parallel friendly making it useful in map-reduce and parallel streaming
> applications.

This introduces a few new dependencies:

```
tdigest (https://github.com/castle/tdigest)
|__rbtree (https://rubygems.org/gems/rbtree)
```

I am locking the `tdigest` dependency because it doesn't seem to follow
semver. It also is not in active development, so a sudden minor bump may break
Airbrake Ruby for a lot of customers. This is especially true since we
monkey-patch the class to pack tdigests how we need.