### PR TITLE
Drop support for Ruby 2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,14 +29,6 @@ jobs:
       - run:
           name: Run RuboCop linting
           command: bundle exec rubocop --parallel
-  "ruby-2.0":
-    docker:
-      - image: kyrylo/ruby-2.0.0p648
-    working_directory: /home/circleci/airbrake-ruby
-    steps:
-      - <<: *repo_restore_cache
-      - <<: *bundle_install
-      - <<: *unit
   "ruby-2.1":
     docker:
       - image: circleci/ruby:2.1
@@ -91,9 +83,6 @@ workflows:
   build:
     jobs:
       - lint
-      - "ruby-2.0":
-          requires:
-            - lint
       - "ruby-2.1":
           requires:
             - lint

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,4 @@
 source 'https://rubygems.org'
 gemspec
 
-# Rubocop supports only >=2.1.0
-if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.1.0')
-  gem 'rubocop', '= 0.55', require: false
-end
+gem 'rubocop', '= 0.55', require: false

--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ Introduction
 _Airbrake Ruby_ is a plain Ruby notifier for [Airbrake][airbrake.io], the
 leading exception reporting service. Airbrake Ruby provides minimalist API that
 enables the ability to send _any_ Ruby exception to the Airbrake dashboard. The
-library is extremely lightweight, contains _no_ dependencies and perfectly suits
-plain Ruby applications. For apps that are built with _Rails_, _Sinatra_ or any
-other Rack-compliant web framework we offer the [`airbrake`][airbrake-gem] gem.
-It has additional features such as _reporting of any unhandled exceptions
-automatically_, integrations with Resque, Sidekiq, Delayed Job and many more.
+library is extremely lightweight and it perfectly suits plain Ruby applications.
+For apps that are built with _Rails_, _Sinatra_ or any other Rack-compliant web
+framework we offer the [`airbrake`][airbrake-gem] gem.  It has additional
+features such as _reporting of any unhandled exceptions automatically_,
+integrations with Resque, Sidekiq, Delayed Job and many more.
 
 Key features
 ------------

--- a/airbrake-ruby.gemspec
+++ b/airbrake-ruby.gemspec
@@ -9,12 +9,11 @@ Gem::Specification.new do |s|
 Airbrake Ruby is a plain Ruby notifier for Airbrake (https://airbrake.io), the
 leading exception reporting service. Airbrake Ruby provides minimalist API that
 enables the ability to send any Ruby exception to the Airbrake dashboard. The
-library is extremely lightweight, contains no dependencies and perfectly suits
-plain Ruby applications. For apps that are built with Rails, Sinatra or any
-other Rack-compliant web framework we offer the airbrake gem
-(https://github.com/airbrake/airbrake). It has additional features such as
-reporting of any unhandled exceptions automatically, integrations with Resque,
-Sidekiq, Delayed Job and many more.
+library is extremely lightweight and it perfectly suits plain Ruby applications.
+For apps that are built with Rails, Sinatra or any other Rack-compliant web
+framework we offer the airbrake gem (https://github.com/airbrake/airbrake). It
+has additional features such as reporting of any unhandled exceptions
+automatically, integrations with Resque, Sidekiq, Delayed Job and many more.
 DESC
   s.author      = 'Airbrake Technologies, Inc.'
   s.email       = 'support@airbrake.io'

--- a/airbrake-ruby.gemspec
+++ b/airbrake-ruby.gemspec
@@ -25,7 +25,7 @@ DESC
   s.files        = ['lib/airbrake-ruby.rb', *Dir.glob('lib/**/*')]
   s.test_files   = Dir.glob('spec/**/*')
 
-  s.required_ruby_version = '>= 2.0'
+  s.required_ruby_version = '>= 2.1'
 
   s.add_dependency 'tdigest', '= 0.1.1'
 

--- a/lib/airbrake-ruby.rb
+++ b/lib/airbrake-ruby.rb
@@ -76,10 +76,6 @@ module Airbrake
   # @return [String] the label to be prepended to the log output
   LOG_LABEL = '**Airbrake:'.freeze
 
-  # @return [Boolean] true if current Ruby is Ruby 2.0.*. The result is used
-  #   for special cases where we need to work around older implementations
-  RUBY_20 = RUBY_VERSION.start_with?('2.0')
-
   # @return [Boolean] true if current Ruby is JRuby. The result is used for
   #  special cases where we need to work around older implementations
   JRUBY = (RUBY_ENGINE == 'jruby')

--- a/spec/backtrace_spec.rb
+++ b/spec/backtrace_spec.rb
@@ -248,6 +248,8 @@ RSpec.describe Airbrake::Backtrace do
          "/opt/rubies/ruby-2.3.1/lib/ruby/2.3.0/benchmark.rb:308:in `realtime'"]
       end
 
+      let(:ex) { ExecJS::RuntimeError.new.tap { |e| e.set_backtrace(bt) } }
+
       let(:parsed_backtrace) do
         [{ file: '(execjs)', line: 6692, function: 'compile' },
          { file: '<anonymous>', line: 1, function: 'eval' },
@@ -261,31 +263,9 @@ RSpec.describe Airbrake::Backtrace do
            function: 'realtime' }]
       end
 
-      context "when not on Ruby 2.0" do
-        let(:ex) { ExecJS::RuntimeError.new.tap { |e| e.set_backtrace(bt) } }
-
-        it "returns a properly formatted array of hashes" do
-          stub_const('ExecJS::RuntimeError', AirbrakeTestError)
-          stub_const('Airbrake::RUBY_20', false)
-
-          expect(described_class.parse(config, ex)).to eq(parsed_backtrace)
-        end
-      end
-
-      context "when on Ruby 2.0" do
-        context "and when exception's class isn't ExecJS" do
-          let(:ex) do
-            ActionView::Template::Error.new.tap { |e| e.set_backtrace(bt) }
-          end
-
-          it "returns a properly formatted array of hashes" do
-            stub_const('ActionView::Template::Error', AirbrakeTestError)
-            stub_const('ExecJS::RuntimeError', NameError)
-            stub_const('Airbrake::RUBY_20', true)
-
-            expect(described_class.parse(config, ex)).to eq(parsed_backtrace)
-          end
-        end
+      it "returns a properly formatted array of hashes" do
+        stub_const('ExecJS::RuntimeError', AirbrakeTestError)
+        expect(described_class.parse(config, ex)).to eq(parsed_backtrace)
       end
     end
 


### PR DESCRIPTION
Our newest dependency, `tdigest`, depends on `rbtree`. RBTree fails to compile
on 2.0.0p648: https://circleci.com/gh/airbrake/airbrake-ruby/2164

```
checking for rb_exec_recursive() in ruby.h... *** extconf.rb failed ***
  ...
/usr/local/lib/ruby/2.0.0/mkmf.rb:434:in `try_do': The compiler failed to
generate an executable file. (RuntimeError)
You have to install development tools first.
```

There are some patches on the internet that fix RBTree mentioned in:
https://github.com/seki/Drip/issues/4

There's also RBTree 2, which may fix the problem:
https://github.com/kitak/rbtree2

That said, we don't control what `tdigest` depends on, so we don't have any
means to experiment.

Now, I'm usually reluctant to dropping Rubies without real need. In theory if we
controlled `tdigest`, we could still continue supporting Ruby 2.0. It's possible
to fork it and hack on it. However, I don't think it's the right approach since
Ruby 2.0 is almost dead. It is simply not worth bothering with this because 99%
of users already migrated to newer Rubies.