### PR TITLE
route_sender: fix possible race with increment_stats

### DIFF
--- a/lib/airbrake-ruby/route_sender.rb
+++ b/lib/airbrake-ruby/route_sender.rb
@@ -142,9 +142,9 @@ module Airbrake
           routes = @routes
           @routes = {}
           @thread = nil
-        end
 
-        send(routes, promise)
+          send(routes, promise)
+        end
       end
 
       # Setting a name is needed to test the timer.


### PR DESCRIPTION
Sometimes we have routes that report 0 count. In theory, this should never
happen because if there's a route record, then the count should be at least 1.

I suspect this happens due to a possible race between `send` and
`increment_stats`.

This gets executed: `@routes[route] ||= RouteStat.new`

Then the scheduler switches to `send` and sends the routes. This essentially
sends the route with zero data.

So far I have no better idea and this is kind of a guess rather than a solid
proof.