### PR TITLE
Revert "route_sender: fix possible race with increment_stats"

### DIFF
--- a/lib/airbrake-ruby/route_sender.rb
+++ b/lib/airbrake-ruby/route_sender.rb
@@ -142,9 +142,9 @@ module Airbrake
           routes = @routes
           @routes = {}
           @thread = nil
-
-          send(routes, promise)
         end
+
+        send(routes, promise)
       end
 
       # Setting a name is needed to test the timer.


### PR DESCRIPTION
This reverts commit 71b25575018c4c31e7763eb49326f21f964d28a8.

The fix did not fix anything and it's better to `send` outside mutex so the
thread is not blocked during network operations.