### PR TITLE
route_sender: send `status_code` as `statusCode`

### DIFF
--- a/lib/airbrake-ruby/route_sender.rb
+++ b/lib/airbrake-ruby/route_sender.rb
@@ -49,7 +49,7 @@ module Airbrake
     using TDigestBigEndianness
 
     # The key that represents a route.
-    RouteKey = Struct.new(:method, :route, :status_code, :time)
+    RouteKey = Struct.new(:method, :route, :statusCode, :time)
 
     # RouteStat holds data that describes a route's performance.
     RouteStat = Struct.new(:count, :sum, :sumsq, :tdigest) do

--- a/spec/route_sender_spec.rb
+++ b/spec/route_sender_spec.rb
@@ -73,10 +73,10 @@ RSpec.describe Airbrake::RouteSender do
         a_request(:put, endpoint).with(
           body: %r|\A
             {"routes":\[
-              {"method":"GET","route":"/foo","status_code":200,
+              {"method":"GET","route":"/foo","statusCode":200,
                "time":"2018-01-01T00:00:00\+00:00","count":1,"sum":1000.0,
                "sumsq":1000000.0,"tdigest":"AAAAAkA0AAAAAAAAAAAAAUR6AAAB"},
-              {"method":"GET","route":"/foo","status_code":200,
+              {"method":"GET","route":"/foo","statusCode":200,
                "time":"2018-01-01T00:01:00\+00:00","count":1,"sum":6000.0,
                "sumsq":36000000.0,"tdigest":"AAAAAkA0AAAAAAAAAAAAAUW7gAAB"}\]}
           \z|x
@@ -104,10 +104,10 @@ RSpec.describe Airbrake::RouteSender do
         a_request(:put, endpoint).with(
           body: %r|\A
             {"routes":\[
-              {"method":"GET","route":"/foo","status_code":200,
+              {"method":"GET","route":"/foo","statusCode":200,
                "time":"2018-01-01T00:49:00\+00:00","count":1,"sum":60000.0,
                "sumsq":3600000000.0,"tdigest":"AAAAAkA0AAAAAAAAAAAAAUdqYAAB"},
-              {"method":"POST","route":"/foo","status_code":200,
+              {"method":"POST","route":"/foo","statusCode":200,
                "time":"2018-01-01T00:49:00\+00:00","count":1,"sum":60000.0,
                "sumsq":3600000000.0,"tdigest":"AAAAAkA0AAAAAAAAAAAAAUdqYAAB"}\]}
           \z|x


### PR DESCRIPTION
We change it back to `statusCode` due to internal policies.