### PR TITLE
Fixes missing require for DateTime

### DIFF
--- a/lib/airbrake-ruby/filters/git_last_checkout_filter.rb
+++ b/lib/airbrake-ruby/filters/git_last_checkout_filter.rb
@@ -1,3 +1,5 @@
+require 'date'
+
 module Airbrake
   module Filters
     # Attaches git checkout info to `context`. The info includes:

--- a/spec/filters/git_last_checkout_filter_spec.rb
+++ b/spec/filters/git_last_checkout_filter_spec.rb
@@ -32,7 +32,9 @@ RSpec.describe Airbrake::Filters::GitLastCheckoutFilter do
     end
 
     it "attaches last checkouted email" do
-      expect(notice[:context][:lastCheckout][:email]).to match(/\A\w+@\w+\.?\w+?\z/)
+      expect(notice[:context][:lastCheckout][:email]).to(
+        match(/\A\w+[\w.-]*@\w+\.?\w+?\z/)
+      )
     end
 
     it "attaches last checkouted revision" do


### PR DESCRIPTION
Stops hitting this error on bare ruby usage:
```
NoMethodError: undefined method `to_datetime' for 2018-11-29 16:24:52 -0600:Time
from airbrake-ruby-2.12.0/lib/airbrake-ruby/filters/git_last_checkout_filter.rb:84'
```

The #to_datetime and #rfc3339 methods are both defined in the Date stdlib but are not included by default.

Also the test email regex didn't allow for dashes nor dots which are both relatively common.