### PR TITLE
Add the `route_stats` option and make RouteSender respect envs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ Airbrake Ruby Changelog
 
 ### master
 
+* Added the `route_stats` option, which enables/disables route stat
+  collection. Route stat collection also respects current environment now, which
+  means the notifier won't be collecting route information for ignored
+  environments ([#369](https://github.com/airbrake/airbrake-ruby/pull/369))
+
 ### [v3.0.0.rc.8][v3.0.0.rc.8] (November 21, 2018)
 
 * Reverted the fix applied in v3.0.0.rc.7 because it didn't do what it claimed

--- a/README.md
+++ b/README.md
@@ -290,6 +290,8 @@ Setting this option allows Airbrake to filter exceptions occurring in unwanted
 environments such as `:test`. By default, it is equal to an empty Array, which
 means Airbrake Ruby sends exceptions occurring in all environments.
 
+This will also disable route stat collection for matched environments.
+
 ```ruby
 Airbrake.configure do |c|
   c.ignore_environments = [:production, /test.+/]
@@ -408,6 +410,18 @@ hunks are collected. By default, it's set to `true`.
 ```ruby
 Airbrake.configure do |c|
   c.code_hunks = false
+end
+```
+
+#### route_stats
+
+Configures route stats collection. By default, it's set to `true`. When set to
+`false`, `Airbrake.notify_request` won't have an effect. The call would always
+return a rejected promise.
+
+```ruby
+Airbrake.configure do |c|
+  c.route_stats = false
 end
 ```
 

--- a/lib/airbrake-ruby/config.rb
+++ b/lib/airbrake-ruby/config.rb
@@ -83,6 +83,12 @@ module Airbrake
     # @since v2.5.0
     attr_accessor :code_hunks
 
+    # @return [Boolean] true if the library should send route stats information
+    #   to Airbrake, false otherwise
+    # @api public
+    # @since v3.0.0
+    attr_accessor :route_stats
+
     # @return [Integer] how many seconds to wait before sending collected route
     #   stats
     # @api public
@@ -91,6 +97,7 @@ module Airbrake
 
     # @param [Hash{Symbol=>Object}] user_config the hash to be used to build the
     #   config
+    # rubocop:disable Metrics/AbcSize
     def initialize(user_config = {})
       @validator = Config::Validator.new(self)
 
@@ -119,10 +126,12 @@ module Airbrake
       )
 
       self.versions = {}
+      self.route_stats = true
       self.route_stats_flush_period = 15
 
       merge(user_config)
     end
+    # rubocop:enable Metrics/AbcSize
 
     # The full URL to the Airbrake Notice API. Based on the +:host+ option.
     # @return [URI] the endpoint address

--- a/lib/airbrake-ruby/notifier.rb
+++ b/lib/airbrake-ruby/notifier.rb
@@ -101,7 +101,17 @@ module Airbrake
 
     # @macro see_public_api_method
     def notify_request(request_info)
-      @route_sender.notify_request(request_info)
+      promise = Airbrake::Promise.new
+
+      if @config.ignored_environment?
+        return promise.reject("The '#{@config.environment}' environment is ignored")
+      end
+
+      unless @config.route_stats
+        return promise.reject("The Route Stats feature is disabled")
+      end
+
+      @route_sender.notify_request(request_info, promise)
     end
 
     # @return [String] customized inspect to lessen the amount of clutter

--- a/lib/airbrake-ruby/route_sender.rb
+++ b/lib/airbrake-ruby/route_sender.rb
@@ -87,14 +87,14 @@ module Airbrake
     end
 
     # @macro see_public_api_method
-    def notify_request(request_info)
+    # @param [Airbrake::Promise] promise
+    def notify_request(request_info, promise = Airbrake::Promise.new)
       route = create_route_key(
         request_info[:method],
         request_info[:route],
         request_info[:status_code],
         utc_truncate_minutes(request_info[:start_time])
       )
-      promise = Airbrake::Promise.new
 
       @mutex.synchronize do
         @routes[route] ||= RouteStat.new

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -79,6 +79,10 @@ RSpec.describe Airbrake::Config do
         expect(config.whitelist_keys).to be_empty
       end
 
+      it "enables route stats by default" do
+        expect(config.route_stats).to be_truthy
+      end
+
       it "sets the default route_stats_flush_period" do
         expect(config.route_stats_flush_period).to eq(15)
       end


### PR DESCRIPTION
`RouteSender` must respect the `ignore_environments` option because the current
behaviour is inconsistent (e.g. we collect route stats but don't send notices).

The `route_stats` option allows disabling the feature altogether, no matter what
environment is used. When enabled (the default), it will work only in allowed
environments. This should be useful for apps that don't have any routes, which
protects against unwanted `Airbrake.notify_request` calls. Low tier accounts that
don't support the feature should also be configuring this.