### PR TITLE
README: don't mention 'route_stats_flush_period'

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,20 +425,6 @@ Airbrake.configure do |c|
 end
 ```
 
-#### route_stats_flush_period
-
-By default, it's set to `15`. When `Airbrake.notify_request` is invoked, then
-Airbrake Ruby waits 15 seconds trying to collect route stats. After this delay
-it sends all route stats in a batch using only one web request. Setting this
-value allows speeding up or slowing down this process. Zero value means no
-delay.
-
-```ruby
-Airbrake.configure do |c|
-  c.route_stats_flush_period = 0
-end
-```
-
 ### Asynchronous Airbrake options
 
 The options listed below apply to [`Airbrake.notify`](#airbrakenotify), they do


### PR DESCRIPTION
This option is really only for testing and users shouldn't be configuring it. In
order to not confuse anyone, it's better to remove it from the README.