### PR TITLE
filter_chain: add the ability to replace a default filter

### DIFF
--- a/lib/airbrake-ruby/filter_chain.rb
+++ b/lib/airbrake-ruby/filter_chain.rb
@@ -26,11 +26,18 @@ module Airbrake
       add_default_filters
     end
 
-    # Adds a filter to the filter chain. Sorts filters by weight.
+    # Adds a filter to the filter chain. Sorts filters by weight. When passed
+    # `filter` is of a class that has already been registered in the filter
+    # chain, this new filter replaces the old one.
     #
     # @param [#call] filter The filter object (proc, class, module, etc)
     # @return [void]
     def add_filter(filter)
+      if !filter.is_a?(Proc) && (name = filter.class.name)
+        index = @filters.index { |f| f.class.name == name }
+        @filters.delete_at(index) if index
+      end
+
       @filters = (@filters << filter).sort_by do |f|
         f.respond_to?(:weight) ? f.weight : DEFAULT_WEIGHT
       end.reverse!

--- a/spec/filter_chain_spec.rb
+++ b/spec/filter_chain_spec.rb
@@ -47,4 +47,38 @@ RSpec.describe Airbrake::FilterChain do
       subject.refine(notice)
     end
   end
+
+  describe "#add_filter" do
+    let(:filter) do
+      Class.new do
+        class << self
+          def name
+            'FooFilter'
+          end
+        end
+
+        def initialize(foo)
+          @foo = foo
+        end
+
+        def call(notice)
+          notice[:params][:foo] << @foo
+        end
+      end
+    end
+
+    it "replaces old filter with a new one when the same class owns it" do
+      notice[:params][:foo] = []
+
+      f1 = filter.new(1)
+      subject.add_filter(f1)
+
+      f2 = filter.new(2)
+      subject.add_filter(f2)
+
+      subject.refine(notice)
+
+      expect(notice[:params][:foo]).to eq([2])
+    end
+  end
 end


### PR DESCRIPTION
Sometimes users may not be happy with the default behaviour of our
filters (concrete scenario: https://github.com/airbrake/airbrake/issues/883). In
this case we want users to allow replacing a default filter they don't like.