### PR TITLE
Add the ability to delete a filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -583,6 +583,20 @@ Airbrake.add_filter do |notice|
 end
 ```
 
+#### Airbrake.delete_filter
+
+Deletes a filter added via [`add_filter`](#airbrakeadd_filter). Expects a class name of the filter.
+
+```ruby
+# Add a MyFilter filter (we pass an instance here).
+Airbrake.add_filter(MyFilter.new)
+
+# Delete the filter (we pass class name here).
+Airbrake.delete_filter(MyFilter)
+```
+
+Note: This method cannot delete filters assigned via the Proc form.
+
 ##### Optional filters
 
 The library adds a few filters by default. However, some of them are optional

--- a/lib/airbrake-ruby.rb
+++ b/lib/airbrake-ruby.rb
@@ -98,6 +98,9 @@ module Airbrake
     def add_filter(_filter = nil, &_block); end
 
     # @macro see_public_api_method
+    def delete_filter(_filter_class); end
+
+    # @macro see_public_api_method
     def build_notice(_exception, _params = {}); end
 
     # @macro see_public_api_method
@@ -115,7 +118,7 @@ module Airbrake
     def merge_context(_context); end
 
     # @macro see_public_api_method
-    def notify_request(request_info); end
+    def notify_request(_request_info); end
   end
 
   # A Hash that holds all notifiers. The keys of the Hash are notifier
@@ -247,9 +250,25 @@ module Airbrake
     # @yieldparam [Airbrake::Notice]
     # @yieldreturn [void]
     # @return [void]
-    # @note Once a filter was added, there's no way to delete it
     def add_filter(filter = nil, &block)
       @notifiers[:default].add_filter(filter, &block)
+    end
+
+    # Deletes a filter added via {Airbrake#add_filter}.
+    #
+    # @example
+    #   # Add a MyFilter filter (we pass an instance here).
+    #   Airbrake.add_filter(MyFilter.new)
+    #
+    #   # Delete the filter (we pass class name here).
+    #   Airbrake.delete_filter(MyFilter)
+    #
+    # @param [Class] filter_class The class of the filter you want to delete
+    # @return [void]
+    # @since v3.1.0
+    # @note This method cannot delete filters assigned via the Proc form.
+    def delete_filter(filter_class)
+      @notifiers[:default].delete_filter(filter_class)
     end
 
     # Builds an Airbrake notice. This is useful, if you want to add or modify a

--- a/lib/airbrake-ruby/filter_chain.rb
+++ b/lib/airbrake-ruby/filter_chain.rb
@@ -36,6 +36,16 @@ module Airbrake
       end.reverse!
     end
 
+    # Deletes a filter from the the filter chain.
+    #
+    # @param [Class] filter_class The class of the filter you want to delete
+    # @return [void]
+    # @since v3.1.0
+    def delete_filter(filter_class)
+      index = @filters.index { |f| f.class.name == filter_class.name }
+      @filters.delete_at(index) if index
+    end
+
     # Applies all the filters in the filter chain to the given notice. Does not
     # filter ignored notices.
     #

--- a/lib/airbrake-ruby/notifier.rb
+++ b/lib/airbrake-ruby/notifier.rb
@@ -5,6 +5,7 @@ module Airbrake
   # @see Airbrake::Config The list of options
   # @since v1.0.0
   # @api private
+  # rubocop:disable Metrics/ClassLength
   class Notifier
     # @return [String] the label to be prepended to the log output
     LOG_LABEL = '**Airbrake:'.freeze
@@ -55,6 +56,11 @@ module Airbrake
     # @macro see_public_api_method
     def add_filter(filter = nil, &block)
       @filter_chain.add_filter(block_given? ? block : filter)
+    end
+
+    # @macro see_public_api_method
+    def delete_filter(filter_class)
+      @filter_chain.delete_filter(filter_class)
     end
 
     # @macro see_public_api_method
@@ -188,4 +194,5 @@ module Airbrake
       clean_bt
     end
   end
+  # rubocop:enable Metrics/ClassLength
 end

--- a/spec/filter_chain_spec.rb
+++ b/spec/filter_chain_spec.rb
@@ -47,4 +47,43 @@ RSpec.describe Airbrake::FilterChain do
       subject.refine(notice)
     end
   end
+
+  describe "#delete_filter" do
+    let(:filter) do
+      Class.new do
+        class << self
+          def name
+            'FooFilter'
+          end
+        end
+
+        def initialize(foo)
+          @foo = foo
+        end
+
+        def call(notice)
+          notice[:params][:foo] << @foo
+        end
+      end
+    end
+
+    it "deletes a class filter" do
+      notice[:params][:foo] = []
+
+      f1 = filter.new(1)
+      subject.add_filter(f1)
+
+      foo_filter_mock = double
+      expect(foo_filter_mock).to(
+        receive(:name).at_least(:once).and_return('FooFilter')
+      )
+      subject.delete_filter(foo_filter_mock)
+
+      f2 = filter.new(2)
+      subject.add_filter(f2)
+
+      subject.refine(notice)
+      expect(notice[:params][:foo]).to eq([2])
+    end
+  end
 end


### PR DESCRIPTION
Sometimes users may not be happy with the default behaviour of our
filters (concrete scenario: https://github.com/airbrake/airbrake/issues/883). In
this case we want users to allow deleting a default filter they don't like.

Competes with https://github.com/airbrake/airbrake-ruby/pull/375.