### PR TITLE
Rename the 'route_stats' option to 'performance_stats'

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Key features
 * Ability to add context to reported exceptions<sup>[[link](#airbrakemerge_context)]</sup>
 * Dependency tracking<sup>[[link](#airbrakefiltersdependencyfilter)]</sup>
 * Automatic and manual deploy tracking <sup>[[link](#airbrakecreate_deploy)]</sup>
-* Performance monitoring for web applications (route statistics) <sup>[[link](#route_stats)]</sup>
+* Performance monitoring for web applications (route statistics, SQL queries) <sup>[[link](#performance_stats)]</sup>
 * Last but not least, we follow semantic versioning 2.0.0<sup>[[link][semver2]]</sup>
 
 Installation
@@ -291,7 +291,7 @@ Setting this option allows Airbrake to filter exceptions occurring in unwanted
 environments such as `:test`. By default, it is equal to an empty Array, which
 means Airbrake Ruby sends exceptions occurring in all environments.
 
-This will also disable route stat collection for matched environments.
+This will also disable performance stat collection for matched environments.
 
 ```ruby
 Airbrake.configure do |c|
@@ -414,17 +414,20 @@ Airbrake.configure do |c|
 end
 ```
 
-#### route_stats
+#### performance_stats
 
-Configures route performance statistics collection (route name, response time,
-status code, etc). This statistics is displayed on the Performance tab of your
-project. By default, it's disabled.
+Configures performance statistics collection (routes, SQL queries) This
+statistics is displayed on the Performance tab of your project. By default, it's
+disabled.
 
-The statistics is sent via [`Airbrake.notify_request`](#airbrakenotify_request).
+The statistics is sent via:
+
+* [`Airbrake.notify_request`](#airbrakenotify_request)
+* [`Airbrake.notify_query`](#airbrakenotify_query)
 
 ```ruby
 Airbrake.configure do |c|
-  c.route_stats = true
+  c.performance_stats = true
 end
 ```
 
@@ -774,11 +777,11 @@ Airbrake.notify_request(
 )
 ```
 
-When [`config.route_stats = false`](#route_stats), it always returns a rejected
-promise.
+When [`config.performance_stats = false`](#performance_stats), it always returns
+a rejected promise.
 
-When [`config.route_stats = true`](#route_stats), then it aggregates statistics
-and sends as a batch every 15 seconds.
+When [`config.performance_stats = true`](#performance_stats), then it aggregates
+statistics and sends as a batch every 15 seconds.
 
 #### Airbrake.notify_query
 
@@ -795,11 +798,11 @@ Airbrake.notify_query(
 )
 ```
 
-When [`config.route_stats = false`](#route_stats), it always returns a rejected
-promise.
+When [`config.performance_stats = false`](#performance_stats), it always returns
+a rejected promise.
 
-When [`config.route_stats = true`](#route_stats), then it aggregates statistics
-and sends as a batch every 15 seconds.
+When [`config.performance_stats = true`](#performance_stats), then it aggregates
+statistics and sends as a batch every 15 seconds.
 
 ### Notice
 

--- a/lib/airbrake-ruby/config.rb
+++ b/lib/airbrake-ruby/config.rb
@@ -83,17 +83,17 @@ module Airbrake
     # @since v2.5.0
     attr_accessor :code_hunks
 
-    # @return [Boolean] true if the library should send route stats information
-    #   to Airbrake, false otherwise
+    # @return [Boolean] true if the library should send performance stats
+    #   information to Airbrake (routes, SQL queries), false otherwise
     # @api public
-    # @since v3.0.0
-    attr_accessor :route_stats
+    # @since v3.1.0
+    attr_accessor :performance_stats
 
     # @return [Integer] how many seconds to wait before sending collected route
     #   stats
     # @api public
-    # @since v3.0.0
-    attr_accessor :route_stats_flush_period
+    # @since v3.1.0
+    attr_accessor :performance_stats_flush_period
 
     # @param [Hash{Symbol=>Object}] user_config the hash to be used to build the
     #   config
@@ -126,8 +126,8 @@ module Airbrake
       )
 
       self.versions = {}
-      self.route_stats = false
-      self.route_stats_flush_period = 15
+      self.performance_stats = false
+      self.performance_stats_flush_period = 15
 
       merge(user_config)
     end
@@ -193,6 +193,38 @@ module Airbrake
           env == pattern.to_s
         end
       end
+    end
+
+    def route_stats
+      logger.warn(
+        "#{LOG_LABEL} the 'route_stats' option is deprecated. " \
+        "Use 'performance_stats' instead"
+      )
+      @performance_stats
+    end
+
+    def route_stats=(value)
+      logger.warn(
+        "#{LOG_LABEL} the 'route_stats' option is deprecated. " \
+        "Use 'performance_stats_flush_period' instead"
+      )
+      @performance_stats = value
+    end
+
+    def route_stats_flush_period
+      logger.warn(
+        "#{LOG_LABEL} the 'route_stats_flush_period' option is deprecated. " \
+        "Use 'performance_stats_flush_period' instead"
+      )
+      @performance_stats_flush_period
+    end
+
+    def route_stats_flush_period=(value)
+      logger.warn(
+        "#{LOG_LABEL} the 'route_stats_flush_period' option is deprecated. " \
+        "Use 'performance_stats' instead"
+      )
+      @performance_stats_flush_period = value
     end
 
     private

--- a/lib/airbrake-ruby/notifier.rb
+++ b/lib/airbrake-ruby/notifier.rb
@@ -114,8 +114,8 @@ module Airbrake
         return promise.reject("The '#{@config.environment}' environment is ignored")
       end
 
-      unless @config.route_stats
-        return promise.reject("The Route Stats feature is disabled")
+      unless @config.performance_stats
+        return promise.reject("The Performance Stats feature is disabled")
       end
 
       @route_sender.notify_request(request_info, promise)
@@ -129,8 +129,8 @@ module Airbrake
         return promise.reject("The '#{@config.environment}' environment is ignored")
       end
 
-      unless @config.route_stats
-        return promise.reject("The Route Stats feature is disabled")
+      unless @config.performance_stats
+        return promise.reject("The Performance Stats feature is disabled")
       end
 
       @query_sender.notify_query(query_info, promise)

--- a/lib/airbrake-ruby/query_sender.rb
+++ b/lib/airbrake-ruby/query_sender.rb
@@ -36,7 +36,7 @@ module Airbrake
 
     def initialize(config)
       @config = config
-      @flush_period = config.route_stats_flush_period
+      @flush_period = config.performance_stats_flush_period
       @sender = SyncSender.new(config, :put)
       @queries = {}
       @thread = nil

--- a/lib/airbrake-ruby/route_sender.rb
+++ b/lib/airbrake-ruby/route_sender.rb
@@ -39,7 +39,7 @@ module Airbrake
     # @param [Airbrake::Config] config
     def initialize(config)
       @config = config
-      @flush_period = config.route_stats_flush_period
+      @flush_period = config.performance_stats_flush_period
       @sender = SyncSender.new(config, :put)
       @routes = {}
       @thread = nil

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -79,12 +79,26 @@ RSpec.describe Airbrake::Config do
         expect(config.whitelist_keys).to be_empty
       end
 
-      it "enables route stats by default" do
+      it "disables route stats by default (deprecated)" do
+        out = StringIO.new
+        config.logger = Logger.new(out)
         expect(config.route_stats).to be_falsey
+        expect(out.string).to match(/'route_stats'.+is deprecated/)
       end
 
-      it "sets the default route_stats_flush_period" do
+      it "disables performance stats by default" do
+        expect(config.performance_stats).to be_falsey
+      end
+
+      it "sets the default route_stats_flush_period (deprecated)" do
+        out = StringIO.new
+        config.logger = Logger.new(out)
         expect(config.route_stats_flush_period).to eq(15)
+        expect(out.string).to match(/'route_stats_flush_period'.+is deprecated/)
+      end
+
+      it "sets the default performance_stats_flush_period" do
+        expect(config.performance_stats_flush_period).to eq(15)
       end
     end
   end

--- a/spec/notifier_spec.rb
+++ b/spec/notifier_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Airbrake::Notifier do
       project_id: 1,
       project_key: 'abc',
       logger: Logger.new('/dev/null'),
-      route_stats: true
+      performance_stats: true
     }
   end
 
@@ -472,9 +472,9 @@ RSpec.describe Airbrake::Notifier do
       subject.notify_request(params)
     end
 
-    context "when route stats are disabled" do
+    context "when performance stats are disabled" do
       it "doesn't send route stats" do
-        notifier = described_class.new(user_params.merge(route_stats: false))
+        notifier = described_class.new(user_params.merge(performance_stats: false))
         expect_any_instance_of(Airbrake::RouteSender)
           .not_to receive(:notify_request)
         notifier.notify_request(params)
@@ -510,9 +510,9 @@ RSpec.describe Airbrake::Notifier do
       subject.notify_query(params)
     end
 
-    context "when route stats are disabled" do
+    context "when performance stats are disabled" do
       it "doesn't send query stats" do
-        notifier = described_class.new(user_params.merge(route_stats: false))
+        notifier = described_class.new(user_params.merge(performance_stats: false))
         expect_any_instance_of(Airbrake::QuerySender)
           .not_to receive(:notify_query)
         notifier.notify_query(params)

--- a/spec/query_sender_spec.rb
+++ b/spec/query_sender_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Airbrake::QuerySender do
     Airbrake::Config.new(
       project_id: 1,
       project_key: 'banana',
-      route_stats_flush_period: 0
+      performance_stats_flush_period: 0
     )
   end
 

--- a/spec/route_sender_spec.rb
+++ b/spec/route_sender_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Airbrake::RouteSender do
     Airbrake::Config.new(
       project_id: 1,
       project_key: 'banana',
-      route_stats_flush_period: 0
+      performance_stats_flush_period: 0
     )
   end
 
@@ -17,9 +17,6 @@ RSpec.describe Airbrake::RouteSender do
     before do
       stub_request(:put, endpoint).to_return(status: 200, body: '')
     end
-
-    # Let the request finish.
-    after { sleep 0.2 }
 
     it "rounds time to the floor minute" do
       subject.notify_request(


### PR DESCRIPTION
`route_stats` was good for routes but since we also collect SQL queries, we need
to adapt. `performance_stats` will configure both of these features. The name
corresponds to the name of the feature in our dashboard.