### PR TITLE
Rename Route & Query senders to Route & Query notifiers

### DIFF
--- a/lib/airbrake-ruby.rb
+++ b/lib/airbrake-ruby.rb
@@ -35,7 +35,7 @@ require 'airbrake-ruby/notifier'
 require 'airbrake-ruby/code_hunk'
 require 'airbrake-ruby/file_cache'
 require 'airbrake-ruby/tdigest_big_endianness'
-require 'airbrake-ruby/route_sender'
+require 'airbrake-ruby/route_notifier'
 require 'airbrake-ruby/query_sender'
 
 # This module defines the Airbrake API. The user is meant to interact with

--- a/lib/airbrake-ruby.rb
+++ b/lib/airbrake-ruby.rb
@@ -36,7 +36,7 @@ require 'airbrake-ruby/code_hunk'
 require 'airbrake-ruby/file_cache'
 require 'airbrake-ruby/tdigest_big_endianness'
 require 'airbrake-ruby/route_notifier'
-require 'airbrake-ruby/query_sender'
+require 'airbrake-ruby/query_notifier'
 
 # This module defines the Airbrake API. The user is meant to interact with
 # Airbrake via its public class methods. Before using the library, you must to

--- a/lib/airbrake-ruby/notifier.rb
+++ b/lib/airbrake-ruby/notifier.rb
@@ -40,7 +40,7 @@ module Airbrake
       @filter_chain = FilterChain.new(@config, @context)
       @async_sender = AsyncSender.new(@config)
       @sync_sender = SyncSender.new(@config)
-      @route_sender = RouteSender.new(@config)
+      @route_sender = RouteNotifier.new(@config)
       @query_sender = QuerySender.new(@config)
     end
 

--- a/lib/airbrake-ruby/notifier.rb
+++ b/lib/airbrake-ruby/notifier.rb
@@ -41,7 +41,7 @@ module Airbrake
       @async_sender = AsyncSender.new(@config)
       @sync_sender = SyncSender.new(@config)
       @route_sender = RouteNotifier.new(@config)
-      @query_sender = QuerySender.new(@config)
+      @query_sender = QueryNotifier.new(@config)
     end
 
     # @macro see_public_api_method

--- a/lib/airbrake-ruby/query_notifier.rb
+++ b/lib/airbrake-ruby/query_notifier.rb
@@ -2,10 +2,10 @@ require 'tdigest'
 require 'base64'
 
 module Airbrake
-  # QuerySender aggregates information about SQL queries and periodically sends
+  # QueryNotifier aggregates information about SQL queries and periodically sends
   # collected data to Airbrake.
   # @since v3.2.0
-  class QuerySender
+  class QueryNotifier
     using TDigestBigEndianness
 
     # The key that represents a query event.

--- a/lib/airbrake-ruby/route_notifier.rb
+++ b/lib/airbrake-ruby/route_notifier.rb
@@ -2,10 +2,10 @@ require 'tdigest'
 require 'base64'
 
 module Airbrake
-  # RouteSender aggregates information about requests and periodically sends
+  # RouteNotifier aggregates information about requests and periodically sends
   # collected data to Airbrake.
   # @since v3.0.0
-  class RouteSender
+  class RouteNotifier
     using TDigestBigEndianness
 
     # The key that represents a route.

--- a/spec/notifier_spec.rb
+++ b/spec/notifier_spec.rb
@@ -504,8 +504,8 @@ RSpec.describe Airbrake::Notifier do
       }
     end
 
-    it "forwards 'notify_query' to QuerySender" do
-      expect_any_instance_of(Airbrake::QuerySender)
+    it "forwards 'notify_query' to QueryNotifier" do
+      expect_any_instance_of(Airbrake::QueryNotifier)
         .to receive(:notify_query).with(params, instance_of(Airbrake::Promise))
       subject.notify_query(params)
     end
@@ -513,7 +513,7 @@ RSpec.describe Airbrake::Notifier do
     context "when performance stats are disabled" do
       it "doesn't send query stats" do
         notifier = described_class.new(user_params.merge(performance_stats: false))
-        expect_any_instance_of(Airbrake::QuerySender)
+        expect_any_instance_of(Airbrake::QueryNotifier)
           .not_to receive(:notify_query)
         notifier.notify_query(params)
       end
@@ -524,7 +524,7 @@ RSpec.describe Airbrake::Notifier do
         notifier = described_class.new(
           user_params.merge(environment: 'test', ignore_environments: %w[test])
         )
-        expect_any_instance_of(Airbrake::QuerySender)
+        expect_any_instance_of(Airbrake::QueryNotifier)
           .not_to receive(:notify_query)
         notifier.notify_query(params)
       end

--- a/spec/notifier_spec.rb
+++ b/spec/notifier_spec.rb
@@ -466,8 +466,8 @@ RSpec.describe Airbrake::Notifier do
       }
     end
 
-    it "forwards 'notify_request' to RouteSender" do
-      expect_any_instance_of(Airbrake::RouteSender)
+    it "forwards 'notify_request' to RouteNotifier" do
+      expect_any_instance_of(Airbrake::RouteNotifier)
         .to receive(:notify_request).with(params, instance_of(Airbrake::Promise))
       subject.notify_request(params)
     end
@@ -475,7 +475,7 @@ RSpec.describe Airbrake::Notifier do
     context "when performance stats are disabled" do
       it "doesn't send route stats" do
         notifier = described_class.new(user_params.merge(performance_stats: false))
-        expect_any_instance_of(Airbrake::RouteSender)
+        expect_any_instance_of(Airbrake::RouteNotifier)
           .not_to receive(:notify_request)
         notifier.notify_request(params)
       end
@@ -486,7 +486,7 @@ RSpec.describe Airbrake::Notifier do
         notifier = described_class.new(
           user_params.merge(environment: 'test', ignore_environments: %w[test])
         )
-        expect_any_instance_of(Airbrake::RouteSender)
+        expect_any_instance_of(Airbrake::RouteNotifier)
           .not_to receive(:notify_request)
         notifier.notify_request(params)
       end
@@ -524,7 +524,7 @@ RSpec.describe Airbrake::Notifier do
         notifier = described_class.new(
           user_params.merge(environment: 'test', ignore_environments: %w[test])
         )
-        expect_any_instance_of(Airbrake::RouteSender)
+        expect_any_instance_of(Airbrake::QuerySender)
           .not_to receive(:notify_query)
         notifier.notify_query(params)
       end

--- a/spec/query_notifier_spec.rb
+++ b/spec/query_notifier_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe Airbrake::QuerySender do
+RSpec.describe Airbrake::QueryNotifier do
   let(:endpoint) { 'https://api.airbrake.io/api/v5/projects/1/queries-stats' }
 
   let(:config) do

--- a/spec/route_notifier_spec.rb
+++ b/spec/route_notifier_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe Airbrake::RouteSender do
+RSpec.describe Airbrake::RouteNotifier do
   let(:endpoint) { 'https://api.airbrake.io/api/v5/projects/1/routes-stats' }
 
   let(:config) do


### PR DESCRIPTION
In this library "Sender" powers "Notifier". The Notifier has Async and Sync
senders. "Route/QuerySender" resides on the same layer as "Notifier" (and uses
SyncSender internally), therefore it should be named appropriately.