### PR TITLE
notifier: decouple RouteNotifier

### DIFF
--- a/lib/airbrake-ruby.rb
+++ b/lib/airbrake-ruby.rb
@@ -86,7 +86,7 @@ module Airbrake
   #   @see Airbrake.$0
 
   # NilNotifier is a no-op notifier, which mimics +Airbrake::Notifier+ and
-  # serves only for the purpose of making the library API easier to use.
+  # serves only the purpose of making the library API easier to use.
   #
   # @since 2.1.0
   class NilNotifier
@@ -120,16 +120,28 @@ module Airbrake
     def merge_context(_context); end
 
     # @macro see_public_api_method
-    def notify_request(_request_info); end
-
-    # @macro see_public_api_method
     def notify_query(_query_info); end
+  end
+
+  # NilRouteNotifier is a no-op notifier, which mimics +Airbrake::RouteNotifier+
+  # and serves only the purpose of making the library API easier to use.
+  #
+  # @since 3.1.0
+  class NilRouteNotifier
+    # @see Airbrake.notify_request
+    def notify(_request_info); end
   end
 
   # A Hash that holds all notifiers. The keys of the Hash are notifier
   # names, the values are Airbrake::Notifier instances. If a notifier is not
   # assigned to the hash, then it returns a null object (NilNotifier).
   @notifiers = Hash.new(NilNotifier.new)
+
+  # A Hash that holds all route notifiers. The keys of the Hash are notifier
+  # names, the values are Airbrake::RouteNotifier instances. If a route notifier
+  # is not assigned to the hash, then it returns a null object
+  # (NilRouteNotifier).
+  @route_notifiers = Hash.new(NilRouteNotifier.new)
 
   class << self
     # Retrieves configured notifiers.
@@ -177,6 +189,7 @@ module Airbrake
               "the '#{notifier_name}' notifier was already configured"
       else
         @notifiers[notifier_name] = Notifier.new(config)
+        @route_notifiers[notifier_name] = RouteNotifier.new(config)
       end
     end
 
@@ -394,7 +407,7 @@ module Airbrake
     # @return [void]
     # @since v3.0.0
     def notify_request(request_info)
-      @notifiers[:default].notify_request(request_info)
+      @route_notifiers[:default].notify(request_info)
     end
 
     # Increments SQL statistics of a certain +query+ that was invoked on

--- a/lib/airbrake-ruby/notifier.rb
+++ b/lib/airbrake-ruby/notifier.rb
@@ -40,7 +40,6 @@ module Airbrake
       @filter_chain = FilterChain.new(@config, @context)
       @async_sender = AsyncSender.new(@config)
       @sync_sender = SyncSender.new(@config)
-      @route_sender = RouteNotifier.new(@config)
       @query_sender = QueryNotifier.new(@config)
     end
 
@@ -104,21 +103,6 @@ module Airbrake
     # @macro see_public_api_method
     def merge_context(context)
       @context.merge!(context)
-    end
-
-    # @macro see_public_api_method
-    def notify_request(request_info)
-      promise = Airbrake::Promise.new
-
-      if @config.ignored_environment?
-        return promise.reject("The '#{@config.environment}' environment is ignored")
-      end
-
-      unless @config.performance_stats
-        return promise.reject("The Performance Stats feature is disabled")
-      end
-
-      @route_sender.notify_request(request_info, promise)
     end
 
     # @macro see_public_api_method

--- a/spec/airbrake_spec.rb
+++ b/spec/airbrake_spec.rb
@@ -112,7 +112,11 @@ RSpec.describe Airbrake do
   end
 
   describe ".notify_request" do
-    it "forwards 'notify_request' to the notifier" do
+    let(:default_notifier) do
+      described_class.instance_variable_get(:@route_notifiers)[:default]
+    end
+
+    it "calls 'notify' on the route notifier" do
       params = {
         method: 'GET',
         route: '/foo',
@@ -120,7 +124,7 @@ RSpec.describe Airbrake do
         start_time: Time.new(2018, 1, 1, 0, 20, 0, 0),
         end_time: Time.new(2018, 1, 1, 0, 19, 0, 0)
       }
-      expect(default_notifier).to receive(:notify_request).with(params)
+      expect(default_notifier).to receive(:notify).with(params)
       described_class.notify_request(params)
     end
   end

--- a/spec/notifier_spec.rb
+++ b/spec/notifier_spec.rb
@@ -455,44 +455,6 @@ RSpec.describe Airbrake::Notifier do
     end
   end
 
-  describe "#notify_request" do
-    let(:params) do
-      {
-        method: 'GET',
-        route: '/foo',
-        status_code: 200,
-        start_time: Time.new(2018, 1, 1, 0, 20, 0, 0),
-        end_time: Time.new(2018, 1, 1, 0, 19, 0, 0)
-      }
-    end
-
-    it "forwards 'notify_request' to RouteNotifier" do
-      expect_any_instance_of(Airbrake::RouteNotifier)
-        .to receive(:notify_request).with(params, instance_of(Airbrake::Promise))
-      subject.notify_request(params)
-    end
-
-    context "when performance stats are disabled" do
-      it "doesn't send route stats" do
-        notifier = described_class.new(user_params.merge(performance_stats: false))
-        expect_any_instance_of(Airbrake::RouteNotifier)
-          .not_to receive(:notify_request)
-        notifier.notify_request(params)
-      end
-    end
-
-    context "when current environment is ignored" do
-      it "doesn't send route stats" do
-        notifier = described_class.new(
-          user_params.merge(environment: 'test', ignore_environments: %w[test])
-        )
-        expect_any_instance_of(Airbrake::RouteNotifier)
-          .not_to receive(:notify_request)
-        notifier.notify_request(params)
-      end
-    end
-  end
-
   describe "#notify_query" do
     let(:params) do
       {


### PR DESCRIPTION
RouteNotifier has nothing to do with Notifier. They don't share any code and
don't rely on each other's state. Therefore, we can easily move it to the layer
above.