### PR TITLE
notifier: decouple QueryNotifier

### DIFF
--- a/lib/airbrake-ruby.rb
+++ b/lib/airbrake-ruby.rb
@@ -118,12 +118,9 @@ module Airbrake
 
     # @macro see_public_api_method
     def merge_context(_context); end
-
-    # @macro see_public_api_method
-    def notify_query(_query_info); end
   end
 
-  # NilRouteNotifier is a no-op notifier, which mimics +Airbrake::RouteNotifier+
+  # NilRouteNotifier is a no-op notifier, which mimics {Airbrake::RouteNotifier}
   # and serves only the purpose of making the library API easier to use.
   #
   # @since 3.1.0
@@ -132,16 +129,31 @@ module Airbrake
     def notify(_request_info); end
   end
 
+  # NilQueryNotifier is a no-op notifier, which mimics {Airbrake::QueryNotifier}
+  # and serves only the purpose of making the library API easier to use.
+  #
+  # @since 3.1.0
+  class NilQueryNotifier
+    # @see Airbrake.notify_query
+    def notify(_query_info); end
+  end
+
   # A Hash that holds all notifiers. The keys of the Hash are notifier
   # names, the values are Airbrake::Notifier instances. If a notifier is not
   # assigned to the hash, then it returns a null object (NilNotifier).
   @notifiers = Hash.new(NilNotifier.new)
 
   # A Hash that holds all route notifiers. The keys of the Hash are notifier
-  # names, the values are Airbrake::RouteNotifier instances. If a route notifier
-  # is not assigned to the hash, then it returns a null object
+  # names, the values are {Airbrake::QueryNotifier} instances. If a route
+  # notifier is not assigned to the hash, then it returns a null object
   # (NilRouteNotifier).
   @route_notifiers = Hash.new(NilRouteNotifier.new)
+
+  # A Hash that holds all query notifiers. The keys of the Hash are notifier
+  # names, the values are {Airbrake::QueryNotifier} instances. If a route
+  # notifier is not assigned to the hash, then it returns a null object
+  # (NilQueryNotifier).
+  @query_notifiers = Hash.new(NilQueryNotifier.new)
 
   class << self
     # Retrieves configured notifiers.
@@ -190,6 +202,7 @@ module Airbrake
       else
         @notifiers[notifier_name] = Notifier.new(config)
         @route_notifiers[notifier_name] = RouteNotifier.new(config)
+        @query_notifiers[notifier_name] = QueryNotifier.new(config)
       end
     end
 
@@ -437,7 +450,7 @@ module Airbrake
     # @return [void]
     # @since v3.1.0
     def notify_query(query_info)
-      @notifiers[:default].notify_query(query_info)
+      @query_notifiers[:default].notify(query_info)
     end
   end
 end

--- a/lib/airbrake-ruby/notifier.rb
+++ b/lib/airbrake-ruby/notifier.rb
@@ -5,7 +5,6 @@ module Airbrake
   # @see Airbrake::Config The list of options
   # @since v1.0.0
   # @api private
-  # rubocop:disable Metrics/ClassLength
   class Notifier
     # @return [String] the label to be prepended to the log output
     LOG_LABEL = '**Airbrake:'.freeze
@@ -40,7 +39,6 @@ module Airbrake
       @filter_chain = FilterChain.new(@config, @context)
       @async_sender = AsyncSender.new(@config)
       @sync_sender = SyncSender.new(@config)
-      @query_sender = QueryNotifier.new(@config)
     end
 
     # @macro see_public_api_method
@@ -103,21 +101,6 @@ module Airbrake
     # @macro see_public_api_method
     def merge_context(context)
       @context.merge!(context)
-    end
-
-    # @macro see_public_api_method
-    def notify_query(query_info)
-      promise = Airbrake::Promise.new
-
-      if @config.ignored_environment?
-        return promise.reject("The '#{@config.environment}' environment is ignored")
-      end
-
-      unless @config.performance_stats
-        return promise.reject("The Performance Stats feature is disabled")
-      end
-
-      @query_sender.notify_query(query_info, promise)
     end
 
     # @return [String] customized inspect to lessen the amount of clutter
@@ -194,5 +177,4 @@ module Airbrake
       clean_bt
     end
   end
-  # rubocop:enable Metrics/ClassLength
 end

--- a/lib/airbrake-ruby/route_notifier.rb
+++ b/lib/airbrake-ruby/route_notifier.rb
@@ -37,7 +37,7 @@ module Airbrake
       end
     end
 
-    # @param [Airbrake::Config] config
+    # @param [Airbrake::Config, Hash] user_config
     def initialize(user_config)
       @config = (user_config.is_a?(Config) ? user_config : Config.new(user_config))
 

--- a/spec/airbrake_spec.rb
+++ b/spec/airbrake_spec.rb
@@ -130,7 +130,11 @@ RSpec.describe Airbrake do
   end
 
   describe ".notify_query" do
-    it "forwards 'notify_query' to the notifier" do
+    let(:default_notifier) do
+      described_class.instance_variable_get(:@query_notifiers)[:default]
+    end
+
+    it "calls 'notify' on the query notifier" do
       params = {
         method: 'GET',
         route: '/foo',
@@ -138,7 +142,7 @@ RSpec.describe Airbrake do
         start_time: Time.new(2018, 1, 1, 0, 20, 0, 0),
         end_time: Time.new(2018, 1, 1, 0, 19, 0, 0)
       }
-      expect(default_notifier).to receive(:notify_query).with(params)
+      expect(default_notifier).to receive(:notify).with(params)
       described_class.notify_query(params)
     end
   end

--- a/spec/notifier_spec.rb
+++ b/spec/notifier_spec.rb
@@ -455,44 +455,6 @@ RSpec.describe Airbrake::Notifier do
     end
   end
 
-  describe "#notify_query" do
-    let(:params) do
-      {
-        method: 'GET',
-        route: '/foo',
-        query: 'SELECT * FROM foos',
-        start_time: Time.new(2018, 1, 1, 0, 20, 0, 0),
-        end_time: Time.new(2018, 1, 1, 0, 19, 0, 0)
-      }
-    end
-
-    it "forwards 'notify_query' to QueryNotifier" do
-      expect_any_instance_of(Airbrake::QueryNotifier)
-        .to receive(:notify_query).with(params, instance_of(Airbrake::Promise))
-      subject.notify_query(params)
-    end
-
-    context "when performance stats are disabled" do
-      it "doesn't send query stats" do
-        notifier = described_class.new(user_params.merge(performance_stats: false))
-        expect_any_instance_of(Airbrake::QueryNotifier)
-          .not_to receive(:notify_query)
-        notifier.notify_query(params)
-      end
-    end
-
-    context "when current environment is ignored" do
-      it "doesn't send query stats" do
-        notifier = described_class.new(
-          user_params.merge(environment: 'test', ignore_environments: %w[test])
-        )
-        expect_any_instance_of(Airbrake::QueryNotifier)
-          .not_to receive(:notify_query)
-        notifier.notify_query(params)
-      end
-    end
-  end
-
   describe "#inspect" do
     it "displays object information" do
       expect(subject.inspect).to match(/

--- a/spec/query_notifier_spec.rb
+++ b/spec/query_notifier_spec.rb
@@ -7,19 +7,27 @@ RSpec.describe Airbrake::QueryNotifier do
     Airbrake::Config.new(
       project_id: 1,
       project_key: 'banana',
+      performance_stats: true,
       performance_stats_flush_period: 0
     )
   end
 
   subject { described_class.new(config) }
 
-  describe "#notify_query" do
+  describe "#initialize" do
+    it "raises error if config is invalid" do
+      expect { described_class.new(Airbrake::Config.new(project_id: 1)) }.
+        to raise_error(Airbrake::Error)
+    end
+  end
+
+  describe "#notify" do
     before do
       stub_request(:put, endpoint).to_return(status: 200, body: '')
     end
 
     it "rounds time to the floor minute" do
-      subject.notify_query(
+      subject.notify(
         query: 'SELECT * FROM foos',
         start_time: Time.new(2018, 1, 1, 0, 0, 20, 0)
       )
@@ -29,13 +37,13 @@ RSpec.describe Airbrake::QueryNotifier do
     end
 
     it "increments routes with the same key" do
-      subject.notify_query(
+      subject.notify(
         method: 'GET',
         route: '/foo',
         query: 'SELECT * FROM foos',
         start_time: Time.new(2018, 1, 1, 0, 0, 20, 0)
       )
-      subject.notify_query(
+      subject.notify(
         method: 'GET',
         route: '/foo',
         query: 'SELECT * FROM foos',
@@ -47,14 +55,14 @@ RSpec.describe Airbrake::QueryNotifier do
     end
 
     it "groups queries by time" do
-      subject.notify_query(
+      subject.notify(
         method: 'GET',
         route: '/foo',
         query: 'SELECT * FROM foos',
         start_time: Time.new(2018, 1, 1, 0, 0, 49, 0),
         end_time: Time.new(2018, 1, 1, 0, 0, 50, 0)
       )
-      subject.notify_query(
+      subject.notify(
         method: 'GET',
         route: '/foo',
         query: 'SELECT * FROM foos',
@@ -77,14 +85,14 @@ RSpec.describe Airbrake::QueryNotifier do
     end
 
     it "groups queries by route key" do
-      subject.notify_query(
+      subject.notify(
         method: 'GET',
         route: '/foo',
         query: 'SELECT * FROM foos',
         start_time: Time.new(2018, 1, 1, 0, 49, 0, 0),
         end_time: Time.new(2018, 1, 1, 0, 50, 0, 0)
       )
-      subject.notify_query(
+      subject.notify(
         method: 'POST',
         route: '/foo',
         query: 'SELECT * FROM foos',
@@ -107,7 +115,7 @@ RSpec.describe Airbrake::QueryNotifier do
     end
 
     it "returns a promise" do
-      promise = subject.notify_query(
+      promise = subject.notify(
         method: 'GET',
         route: '/foo',
         query: 'SELECT * FROM foos',
@@ -115,6 +123,33 @@ RSpec.describe Airbrake::QueryNotifier do
       )
       expect(promise).to be_an(Airbrake::Promise)
       expect(promise.value).to eq('' => nil)
+    end
+
+    it "doesn't send query stats when performance stats are disabled" do
+      notifier = described_class.new(
+        project_id: 1, project_key: '2', performance_stats: false
+      )
+      promise = notifier.notify(
+        method: 'GET', route: '/foo', status_code: 200, start_time: Time.new,
+        query: 'SELECT * FROM foos'
+      )
+      expect(a_request(:put, endpoint)).not_to have_been_made
+      expect(promise.value).to eq(
+        'error' => "The Performance Stats feature is disabled"
+      )
+    end
+
+    it "doesn't send query stats when current environment is ignored" do
+      notifier = described_class.new(
+        project_id: 1, project_key: '2', performance_stats: true,
+        environment: 'test', ignore_environments: %w[test]
+      )
+      promise = notifier.notify(
+        method: 'GET', route: '/foo', status_code: 200, start_time: Time.new,
+        query: 'SELECT * FROM foos'
+      )
+      expect(a_request(:put, endpoint)).not_to have_been_made
+      expect(promise.value).to eq('error' => "The 'test' environment is ignored")
     end
   end
 end


### PR DESCRIPTION
QueryNotifier has nothing to do with Notifier. They don't share any code and
don't rely on each other's state. Therefore, we can easily move it to the layer
above.

Similar to https://github.com/airbrake/airbrake-ruby/pull/383.