### PR TITLE
Rename Notifier to NoticeNotifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,11 +467,11 @@ API
 Retrieves a configured notifier.
 
 ```ruby
-Airbrake[:my_notifier] #=> Airbrake::Notifier
+Airbrake[:my_notifier] #=> Airbrake::NoticeNotifier
 ```
 
 If the notifier is not configured, returns an instance of
-`Airbrake::NilNotifier` (a no-op version of `Airbrake::Notifier`).
+`Airbrake::NilNotifier` (a no-op version of `Airbrake::NoticeNotifier`).
 
 #### Airbrake.notify
 

--- a/lib/airbrake-ruby/notice_notifier.rb
+++ b/lib/airbrake-ruby/notice_notifier.rb
@@ -1,11 +1,11 @@
 module Airbrake
-  # This class is reponsible for sending notices to Airbrake. It supports
+  # NoticeNotifier is reponsible for sending notices to Airbrake. It supports
   # synchronous and asynchronous delivery.
   #
   # @see Airbrake::Config The list of options
   # @since v1.0.0
   # @api private
-  class Notifier
+  class NoticeNotifier
     # @return [String] the label to be prepended to the log output
     LOG_LABEL = '**Airbrake:'.freeze
 

--- a/spec/airbrake_spec.rb
+++ b/spec/airbrake_spec.rb
@@ -3,18 +3,18 @@ require 'spec_helper'
 RSpec.describe Airbrake do
   describe ".[]" do
     it "returns a NilNotifier" do
-      expect(described_class[:test]).to be_an(Airbrake::NilNotifier)
+      expect(described_class[:test]).to be_an(Airbrake::NilNoticeNotifier)
     end
   end
 
   let(:default_notifier) do
-    described_class.instance_variable_get(:@notifiers)[:default]
+    described_class[:default]
   end
 
   describe ".configure" do
     let(:config_params) { { project_id: 1, project_key: 'abc' } }
 
-    after { described_class.instance_variable_get(:@notifiers).clear }
+    after { described_class.instance_variable_get(:@notice_notifiers).clear }
 
     it "yields the config" do
       expect do |b|
@@ -26,17 +26,17 @@ RSpec.describe Airbrake do
       end.to yield_with_args(Airbrake::Config)
     end
 
-    context "when invoked with a notifier name" do
-      it "sets notifier name to the provided name" do
+    context "when invoked with a notice notifier name" do
+      it "sets notice notifier name to the provided name" do
         described_class.configure(:test) { |c| c.merge(config_params) }
-        expect(described_class[:test]).to be_an(Airbrake::Notifier)
+        expect(described_class[:test]).to be_an(Airbrake::NoticeNotifier)
       end
     end
 
     context "when invoked without a notifier name" do
       it "defaults to the :default notifier name" do
         described_class.configure { |c| c.merge(config_params) }
-        expect(described_class[:default]).to be_an(Airbrake::Notifier)
+        expect(described_class[:default]).to be_an(Airbrake::NoticeNotifier)
       end
     end
 

--- a/spec/notice_notifier_spec.rb
+++ b/spec/notice_notifier_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 # rubocop:disable Layout/DotPosition
-RSpec.describe Airbrake::Notifier do
+RSpec.describe Airbrake::NoticeNotifier do
   let(:user_params) do
     {
       project_id: 1,
@@ -426,7 +426,7 @@ RSpec.describe Airbrake::Notifier do
   describe "#inspect" do
     it "displays object information" do
       expect(subject.inspect).to match(/
-        #<Airbrake::Notifier:0x\w+\s
+        #<Airbrake::NoticeNotifier:0x\w+\s
           project_id="\d+"\s
           project_key=".+"\s
           host="http.+"\s
@@ -444,7 +444,7 @@ RSpec.describe Airbrake::Notifier do
       q.guard_inspect_key { subject.pretty_print(q) }
 
       expect(q.output).to match(/
-        #<Airbrake::Notifier:0x\w+\s
+        #<Airbrake::NoticeNotifier:0x\w+\s
           project_id="\d+"\s
           project_key=".+"\s
           host="http.+"\s

--- a/spec/notice_notifier_spec/options_spec.rb
+++ b/spec/notice_notifier_spec/options_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe Airbrake::Notifier do
+RSpec.describe Airbrake::NoticeNotifier do
   def expect_a_request_with_body(body)
     expect(a_request(:post, endpoint).with(body: body)).to have_been_made.once
   end


### PR DESCRIPTION
Now that we have all sorts of notifiers in this library, the name `Notifier`
doesn't look too descriptive. It's too generic. It was tempting to rename it to
`ErrorNotifier` but this would likely be confusing. Although we send errors to
Airbrake, the object that we work with is called `Notice`. Had we used `Error`,
`ErrorNotifier` would make more sense, but alas.

Accessing `Airbrake::Notifier` is still possible but each time doing so emits a
warning. Although `Airbrake::Notifier` was marked as private API since its
creation, it's too tempting to use this class in your codebase and I suspect
some people might do that, so I am just being cautions here.