### PR TITLE
airbrake-ruby: validate config in Airbrake#configure

### DIFF
--- a/lib/airbrake-ruby.rb
+++ b/lib/airbrake-ruby.rb
@@ -215,6 +215,8 @@ module Airbrake
     # @return [void]
     # @raise [Airbrake::Error] when trying to reconfigure already
     #   existing notifier
+    # @raise [Airbrake::Error] when either +project_id+ or +project_key+
+    #   is missing (or both)
     # @note There's no way to reconfigure a notifier
     # @note There's no way to read config values outside of this library
     def configure(notifier_name = :default)
@@ -223,12 +225,14 @@ module Airbrake
       if @notice_notifiers.key?(notifier_name)
         raise Airbrake::Error,
               "the '#{notifier_name}' notifier was already configured"
-      else
-        @notice_notifiers[notifier_name] = NoticeNotifier.new(config)
-        @route_notifiers[notifier_name] = RouteNotifier.new(config)
-        @query_notifiers[notifier_name] = QueryNotifier.new(config)
-        @deploy_notifiers[notifier_name] = DeployNotifier.new(config)
       end
+
+      raise Airbrake::Error, config.validation_error_message unless config.valid?
+
+      @notice_notifiers[notifier_name] = NoticeNotifier.new(config)
+      @route_notifiers[notifier_name] = RouteNotifier.new(config)
+      @query_notifiers[notifier_name] = QueryNotifier.new(config)
+      @deploy_notifiers[notifier_name] = DeployNotifier.new(config)
     end
 
     # @return [Boolean] true if the notifier was configured, false otherwise

--- a/lib/airbrake-ruby/deploy_notifier.rb
+++ b/lib/airbrake-ruby/deploy_notifier.rb
@@ -8,10 +8,20 @@ module Airbrake
   # - version
   # @since v3.2.0
   class DeployNotifier
-    def initialize(user_config)
-      @config = (user_config.is_a?(Config) ? user_config : Config.new(user_config))
-
-      raise Airbrake::Error, @config.validation_error_message unless @config.valid?
+    # @param [Airbrake::Config] config
+    def initialize(config)
+      @config =
+        if config.is_a?(Config)
+          config
+        else
+          loc = caller_locations(1..1).first
+          signature = "#{self.class.name}##{__method__}"
+          warn(
+            "#{loc.path}:#{loc.lineno}: warning: passing a Hash to #{signature} " \
+            'is deprecated. Pass `Airbrake::Config` instead'
+          )
+          Config.new(config)
+        end
 
       @sender = SyncSender.new(@config)
     end

--- a/lib/airbrake-ruby/notice_notifier.rb
+++ b/lib/airbrake-ruby/notice_notifier.rb
@@ -15,25 +15,28 @@ module Airbrake
       "project_key=\"%<project_key>s\" " \
       "host=\"%<host>s\" filter_chain=%<filter_chain>s>".freeze
 
-    # Creates a new Airbrake notifier with the given config options.
+    # Creates a new notice notifier with the given config options.
     #
-    # @example Configuring with a Hash
-    #   airbrake = Airbrake.new(project_id: 123, project_key: '321')
-    #
-    # @example Configuring with an Airbrake::Config
+    # @example
     #   config = Airbrake::Config.new
     #   config.project_id = 123
     #   config.project_key = '321'
-    #   airbake = Airbrake.new(config)
+    #   notice_notifier = Airbrake::NoticeNotifier.new(config)
     #
-    # @param [Hash, Airbrake::Config] user_config The config that contains
-    #   information about how the notifier should operate
-    # @raise [Airbrake::Error] when either +project_id+ or +project_key+
-    #   is missing (or both)
-    def initialize(user_config)
-      @config = (user_config.is_a?(Config) ? user_config : Config.new(user_config))
-
-      raise Airbrake::Error, @config.validation_error_message unless @config.valid?
+    # @param [Airbrake::Config] config
+    def initialize(config)
+      @config =
+        if config.is_a?(Config)
+          config
+        else
+          loc = caller_locations(1..1).first
+          signature = "#{self.class.name}##{__method__}"
+          warn(
+            "#{loc.path}:#{loc.lineno}: warning: passing a Hash to #{signature} " \
+            'is deprecated. Pass `Airbrake::Config` instead'
+          )
+          Config.new(config)
+        end
 
       @context = {}
       @filter_chain = FilterChain.new(@config, @context)

--- a/lib/airbrake-ruby/query_notifier.rb
+++ b/lib/airbrake-ruby/query_notifier.rb
@@ -34,11 +34,20 @@ module Airbrake
       end
     end
 
-    # @param [Airbrake::Config, Hash] user_config
-    def initialize(user_config)
-      @config = (user_config.is_a?(Config) ? user_config : Config.new(user_config))
-
-      raise Airbrake::Error, @config.validation_error_message unless @config.valid?
+    # @param [Airbrake::Config] config
+    def initialize(config)
+      @config =
+        if config.is_a?(Config)
+          config
+        else
+          loc = caller_locations(1..1).first
+          signature = "#{self.class.name}##{__method__}"
+          warn(
+            "#{loc.path}:#{loc.lineno}: warning: passing a Hash to #{signature} " \
+            'is deprecated. Pass `Airbrake::Config` instead'
+          )
+          Config.new(config)
+        end
 
       @flush_period = @config.performance_stats_flush_period
       @sender = SyncSender.new(@config, :put)

--- a/lib/airbrake-ruby/route_notifier.rb
+++ b/lib/airbrake-ruby/route_notifier.rb
@@ -37,11 +37,20 @@ module Airbrake
       end
     end
 
-    # @param [Airbrake::Config, Hash] user_config
-    def initialize(user_config)
-      @config = (user_config.is_a?(Config) ? user_config : Config.new(user_config))
-
-      raise Airbrake::Error, @config.validation_error_message unless @config.valid?
+    # @param [Airbrake::Config] config
+    def initialize(config)
+      @config =
+        if config.is_a?(Config)
+          config
+        else
+          loc = caller_locations(1..1).first
+          signature = "#{self.class.name}##{__method__}"
+          warn(
+            "#{loc.path}:#{loc.lineno}: warning: passing a Hash to #{signature} " \
+            'is deprecated. Pass `Airbrake::Config` instead'
+          )
+          Config.new(config)
+        end
 
       @flush_period = @config.performance_stats_flush_period
       @sender = SyncSender.new(@config, :put)

--- a/spec/airbrake_spec.rb
+++ b/spec/airbrake_spec.rb
@@ -50,6 +50,20 @@ RSpec.describe Airbrake do
         )
       end
     end
+
+    context "when user config doesn't contain a project id" do
+      it "raises error" do
+        expect { described_class.configure { |c| c.project_key = '1' } }.
+          to raise_error(Airbrake::Error, ':project_id is required')
+      end
+    end
+
+    context "when user config doesn't contain a project key" do
+      it "raises error" do
+        expect { described_class.configure { |c| c.project_id = 1 } }.
+          to raise_error(Airbrake::Error, ':project_key is required')
+      end
+    end
   end
 
   describe ".configured?" do

--- a/spec/query_notifier_spec.rb
+++ b/spec/query_notifier_spec.rb
@@ -14,13 +14,6 @@ RSpec.describe Airbrake::QueryNotifier do
 
   subject { described_class.new(config) }
 
-  describe "#initialize" do
-    it "raises error if config is invalid" do
-      expect { described_class.new(Airbrake::Config.new(project_id: 1)) }.
-        to raise_error(Airbrake::Error)
-    end
-  end
-
   describe "#notify" do
     before do
       stub_request(:put, endpoint).to_return(status: 200, body: '')
@@ -127,7 +120,9 @@ RSpec.describe Airbrake::QueryNotifier do
 
     it "doesn't send query stats when performance stats are disabled" do
       notifier = described_class.new(
-        project_id: 1, project_key: '2', performance_stats: false
+        Airbrake::Config.new(
+          project_id: 1, project_key: '2', performance_stats: false
+        )
       )
       promise = notifier.notify(
         method: 'GET', route: '/foo', status_code: 200, start_time: Time.new,
@@ -141,8 +136,10 @@ RSpec.describe Airbrake::QueryNotifier do
 
     it "doesn't send query stats when current environment is ignored" do
       notifier = described_class.new(
-        project_id: 1, project_key: '2', performance_stats: true,
-        environment: 'test', ignore_environments: %w[test]
+        Airbrake::Config.new(
+          project_id: 1, project_key: '2', performance_stats: true,
+          environment: 'test', ignore_environments: %w[test]
+        )
       )
       promise = notifier.notify(
         method: 'GET', route: '/foo', status_code: 200, start_time: Time.new,

--- a/spec/route_notifier_spec.rb
+++ b/spec/route_notifier_spec.rb
@@ -14,13 +14,6 @@ RSpec.describe Airbrake::RouteNotifier do
 
   subject { described_class.new(config) }
 
-  describe "#initialize" do
-    it "raises error if config is invalid" do
-      expect { described_class.new(Airbrake::Config.new(project_id: 1)) }.
-        to raise_error(Airbrake::Error)
-    end
-  end
-
   describe "#notify" do
     before do
       stub_request(:put, endpoint).to_return(status: 200, body: '')
@@ -129,7 +122,9 @@ RSpec.describe Airbrake::RouteNotifier do
 
     it "doesn't send route stats when performance stats are disabled" do
       notifier = described_class.new(
-        project_id: 1, project_key: '2', performance_stats: false
+        Airbrake::Config.new(
+          project_id: 1, project_key: '2', performance_stats: false
+        )
       )
       promise = notifier.notify(
         method: 'GET', route: '/foo', status_code: 200, start_time: Time.new
@@ -142,8 +137,10 @@ RSpec.describe Airbrake::RouteNotifier do
 
     it "doesn't send route stats when current environment is ignored" do
       notifier = described_class.new(
-        project_id: 1, project_key: '2', performance_stats: true,
-        environment: 'test', ignore_environments: %w[test]
+        Airbrake::Config.new(
+          project_id: 1, project_key: '2', performance_stats: true,
+          environment: 'test', ignore_environments: %w[test]
+        )
       )
       promise = notifier.notify(
         method: 'GET', route: '/foo', status_code: 200, start_time: Time.new


### PR DESCRIPTION
This change aims to remove duplicative code from notifiers. Every notifier used
to check if the config is valid and raise an error. It makes sense to avoid this
duplication by moving config validation on the layer above, closer to the public
API.

As result, notifiers stopped accepting hashes and expect an instance of Config.
In case people initialize notifiers directly (shouldn't be the case, but who
knows), we show a deprecation warning, that passing a hash is not supported
anymore.