### PR TITLE
filter_chain: move default filter instantiation to notice_notifier

### DIFF
--- a/spec/filter_chain_spec.rb
+++ b/spec/filter_chain_spec.rb
@@ -1,12 +1,8 @@
 require 'spec_helper'
 
 RSpec.describe Airbrake::FilterChain do
-  subject { described_class.new(config, {}) }
-
-  let(:config) { Airbrake::Config.new }
-
   let(:notice) do
-    Airbrake::Notice.new(config, AirbrakeTestError.new)
+    Airbrake::Notice.new(Airbrake::Config.new, AirbrakeTestError.new)
   end
 
   describe "#refine" do


### PR DESCRIPTION
FilterChain is going to be used in other notifiers, such as
RouteNotifier. Currently, it's tightly coupled with NoticeNotifier because of
default filters.