### PR TITLE
Maintain UTC offset when truncating

### DIFF
--- a/lib/airbrake-ruby/time_truncate.rb
+++ b/lib/airbrake-ruby/time_truncate.rb
@@ -9,13 +9,9 @@ module Airbrake
     # @param [Time] time
     # @return [String]
     def self.utc_truncate_minutes(time)
-      time_array = time.to_a
-      time_array[0] = 0
-      tm = Time.utc(*time_array)
+      tm = time.getutc
 
-      Time.new(
-        tm.year, tm.month, tm.day, tm.hour, tm.min, 0, tm.utc_offset || 0
-      ).to_datetime.rfc3339
+      Time.utc(tm.year, tm.month, tm.day, tm.hour, tm.min).to_datetime.rfc3339
     end
   end
 end

--- a/spec/time_truncate_spec.rb
+++ b/spec/time_truncate_spec.rb
@@ -6,5 +6,10 @@ RSpec.describe Airbrake::TimeTruncate do
       time = Time.new(2018, 1, 1, 0, 0, 20, 0)
       expect(subject.utc_truncate_minutes(time)).to eq('2018-01-01T00:00:00+00:00')
     end
+
+    it "converts time with zone to UTC" do
+      time = Time.new(2018, 1, 1, 0, 0, 20, '-05:00')
+      expect(subject.utc_truncate_minutes(time)).to eq('2018-01-01T05:00:00+00:00')
+    end
   end
 end


### PR DESCRIPTION
Previously, the time would be converted to UTC without properly adjusting for the given time's time zone.