### PR TITLE
Implement the ability to filter requests and queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -804,6 +804,22 @@ a rejected promise.
 When [`config.performance_stats = true`](#performance_stats), then it aggregates
 statistics and sends as a batch every 15 seconds.
 
+#### Airbrake.add_performance_filter
+
+Adds a performance filter that filters performance data. Works exactly like
+[`Airbrake.add_filter`](#airbrakeadd_filter). The only difference is that
+instead of `Airbrake::Notice` it yields performance data (such as
+`Airbrake::Query` or `Airbrake::Request`). It's invoked after
+[`notify_request`](#airbrakenotify_request) or
+[`notify_query`](#airbrakenotify_query) (but [`notify`](#airbrakenotify) calls
+don't trigger it!).
+
+#### Airbrake.delete_performance_filter
+
+Deletes a performance filter added via
+[`Airbrake.add_performance_filter`](#airbrakeadd_performance_filter). Works
+exactly like [`Airbrake.delete_filter`](#airbrakedelete_filter).
+
 ### Notice
 
 #### Notice#ignore!

--- a/lib/airbrake-ruby/ignorable.rb
+++ b/lib/airbrake-ruby/ignorable.rb
@@ -1,0 +1,44 @@
+module Airbrake
+  # Ignorable contains methods that allow the includee to be ignored.
+  #
+  # @example
+  #   class A
+  #     include Airbrake::Ignorable
+  #   end
+  #
+  #   a = A.new
+  #   a.ignore!
+  #   a.ignored? #=> true
+  #
+  # @since v3.2.0
+  # @api private
+  module Ignorable
+    attr_accessor :ignored
+
+    # Checks whether the instance was ignored.
+    # @return [Boolean]
+    # @see #ignore!
+    # rubocop:disable Style/DoubleNegation
+    def ignored?
+      !!ignored
+    end
+    # rubocop:enable Style/DoubleNegation
+
+    # Ignores an instance. Ignored instances must never reach the Airbrake
+    # dashboard.
+    # @return [void]
+    # @see #ignored?
+    def ignore!
+      self.ignored = true
+    end
+
+    private
+
+    # A method that is meant to be used as a guard.
+    # @raise [Airbrake::Error] when instance is ignored
+    def raise_if_ignored
+      return unless ignored?
+      raise Airbrake::Error, "cannot access ignored #{self.class}"
+    end
+  end
+end

--- a/lib/airbrake-ruby/notice.rb
+++ b/lib/airbrake-ruby/notice.rb
@@ -49,6 +49,8 @@ module Airbrake
     # @return [String]
     DEFAULT_SEVERITY = 'error'.freeze
 
+    include Ignorable
+
     # @since v1.7.0
     # @return [Hash{Symbol=>Object}] the hash with arbitrary objects to be used
     #   in filters
@@ -89,23 +91,6 @@ module Airbrake
 
         break if truncate == 0
       end
-    end
-
-    # Ignores a notice. Ignored notices never reach the Airbrake dashboard.
-    #
-    # @return [void]
-    # @see #ignored?
-    # @note Ignored noticed can't be unignored
-    def ignore!
-      @payload = nil
-    end
-
-    # Checks whether the notice was ignored.
-    #
-    # @return [Boolean]
-    # @see #ignore!
-    def ignored?
-      @payload.nil?
     end
 
     # Reads a value from notice's payload.
@@ -158,11 +143,6 @@ module Airbrake
 
         severity: DEFAULT_SEVERITY
       }.merge(CONTEXT).delete_if { |_key, val| val.nil? || val.empty? }
-    end
-
-    def raise_if_ignored
-      return unless ignored?
-      raise Airbrake::Error, 'cannot access ignored notice'
     end
 
     def truncate

--- a/spec/ignorable_spec.rb
+++ b/spec/ignorable_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+RSpec.describe Airbrake::Ignorable do
+  let(:klass) do
+    mod = subject
+    Class.new { include(mod) }
+  end
+
+  it "ignores includee" do
+    instance = klass.new
+    expect(instance).not_to be_ignored
+
+    instance.ignore!
+    expect(instance).to be_ignored
+  end
+end

--- a/spec/notice_spec.rb
+++ b/spec/notice_spec.rb
@@ -261,7 +261,7 @@ RSpec.describe Airbrake::Notice do
     it "raises error if notice is ignored" do
       notice.ignore!
       expect { notice[:params] }.
-        to raise_error(Airbrake::Error, 'cannot access ignored notice')
+        to raise_error(Airbrake::Error, 'cannot access ignored Airbrake::Notice')
     end
   end
 
@@ -275,7 +275,7 @@ RSpec.describe Airbrake::Notice do
     it "raises error if notice is ignored" do
       notice.ignore!
       expect { notice[:params] = {} }.
-        to raise_error(Airbrake::Error, 'cannot access ignored notice')
+        to raise_error(Airbrake::Error, 'cannot access ignored Airbrake::Notice')
     end
 
     it "raises error when trying to assign unrecognized key" do


### PR DESCRIPTION
The API:

```ruby
Airbrake.add_performance_filter(&:ignore!)
Airbrake.delete_performance_filter(MyFilter)
```

It behaves *exactly* like `Airbrake.add_filter` and
`Airbrake.delete_filter`. The only difference is that instead of notices
`Airbrake::Request` & `Airbrake::Query` are being yielded.

These objects are called "resources". They don't quack like notices, though,
although they do have `#ignored?` and `#ignore!` methods, which makes them obey
certain rules developed during the `add_filter` rule.