### PR TITLE
Implement Airbrake.notifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,7 +464,7 @@ API
 
 #### Airbrake.[]
 
-Retrieves a configured notifier.
+Retrieves a configured *notice* notifier.
 
 ```ruby
 Airbrake[:my_notifier] #=> Airbrake::NoticeNotifier
@@ -472,6 +472,25 @@ Airbrake[:my_notifier] #=> Airbrake::NoticeNotifier
 
 If the notifier is not configured, returns an instance of
 `Airbrake::NilNotifier` (a no-op version of `Airbrake::NoticeNotifier`).
+
+#### Airbrake.notifiers
+
+Returns a Hash with all notifiers (notice, performance, deploy).
+
+```ruby
+Airbrake.notifiers
+# {
+#   :notice => {
+#     :default => ...
+#   },
+#   :performance => {
+#     :default => ...
+#   },
+#   :deploy => {
+#     :default => ...
+#   }
+# }
+```
 
 #### Airbrake.notify
 

--- a/lib/airbrake-ruby.rb
+++ b/lib/airbrake-ruby.rb
@@ -191,6 +191,17 @@ module Airbrake
       @notice_notifiers[notifier_name]
     end
 
+    # @return [Hash{Symbol=>Array<Object>}] a Hash with all configured notifiers
+    #   (notice, performance, deploy)
+    # @since v3.2.0
+    def notifiers
+      {
+        notice: @notice_notifiers,
+        performance: @performance_notifiers,
+        deploy: @deploy_notifiers
+      }
+    end
+
     # Configures a new +notifier+ with the given name. If the name is not given,
     # configures the default notifier.
     #

--- a/lib/airbrake-ruby/config.rb
+++ b/lib/airbrake-ruby/config.rb
@@ -2,7 +2,7 @@ module Airbrake
   # Represents the Airbrake config. A config contains all the options that you
   # can use to configure an Airbrake instance.
   #
-  # @api private
+  # @api public
   # @since v1.0.0
   class Config
     # @return [Integer] the project identificator. This value *must* be set.

--- a/lib/airbrake-ruby/deploy_notifier.rb
+++ b/lib/airbrake-ruby/deploy_notifier.rb
@@ -6,6 +6,8 @@ module Airbrake
   # - repository
   # - revision
   # - version
+  #
+  # @api public
   # @since v3.2.0
   class DeployNotifier
     # @param [Airbrake::Config] config

--- a/lib/airbrake-ruby/notice_notifier.rb
+++ b/lib/airbrake-ruby/notice_notifier.rb
@@ -4,7 +4,7 @@ module Airbrake
   #
   # @see Airbrake::Config The list of options
   # @since v1.0.0
-  # @api private
+  # @api public
   # rubocop:disable Metrics/ClassLength
   class NoticeNotifier
     # @return [String] the label to be prepended to the log output

--- a/lib/airbrake-ruby/performance_notifier.rb
+++ b/lib/airbrake-ruby/performance_notifier.rb
@@ -1,6 +1,8 @@
 module Airbrake
   # QueryNotifier aggregates information about SQL queries and periodically sends
   # collected data to Airbrake.
+  #
+  # @api public
   # @since v3.2.0
   class PerformanceNotifier
     # @param [Airbrake::Config] config

--- a/spec/airbrake_spec.rb
+++ b/spec/airbrake_spec.rb
@@ -5,6 +5,14 @@ RSpec.describe Airbrake do
     end
   end
 
+  describe ".notifiers" do
+    it "returns a Hash of notifiers" do
+      expect(described_class.notifiers).to eq(
+        notice: {}, performance: {}, deploy: {}
+      )
+    end
+  end
+
   let(:default_notifier) do
     described_class[:default]
   end
@@ -12,7 +20,11 @@ RSpec.describe Airbrake do
   describe ".configure" do
     let(:config_params) { { project_id: 1, project_key: 'abc' } }
 
-    after { described_class.instance_variable_get(:@notice_notifiers).clear }
+    after do
+      described_class.instance_variable_get(:@notice_notifiers).clear
+      described_class.instance_variable_get(:@performance_notifiers).clear
+      described_class.instance_variable_get(:@deploy_notifiers).clear
+    end
 
     it "yields the config" do
       expect do |b|
@@ -110,9 +122,7 @@ RSpec.describe Airbrake do
   end
 
   describe ".create_deploy" do
-    let(:default_notifier) do
-      described_class.instance_variable_get(:@deploy_notifiers)[:default]
-    end
+    let(:default_notifier) { described_class.notifiers[:deploy][:default] }
 
     it "calls 'notify' on the deploy notifier" do
       expect(default_notifier).to receive(:notify).with(foo: 'bar')
@@ -128,9 +138,7 @@ RSpec.describe Airbrake do
   end
 
   describe ".notify_request" do
-    let(:default_notifier) do
-      described_class.instance_variable_get(:@performance_notifiers)[:default]
-    end
+    let(:default_notifier) { described_class.notifiers[:performance][:default] }
 
     it "calls 'notify' on the route notifier" do
       params = {
@@ -146,9 +154,7 @@ RSpec.describe Airbrake do
   end
 
   describe ".notify_query" do
-    let(:default_notifier) do
-      described_class.instance_variable_get(:@performance_notifiers)[:default]
-    end
+    let(:default_notifier) { described_class.notifiers[:performance][:default] }
 
     it "calls 'notify' on the query notifier" do
       params = {


### PR DESCRIPTION
This new method returns all configured notifiers. This way it's possible to
access performance and deploy notifiers, which is going to be used in the
airbrake gem.

The old `Airbrake#[]` method is a weird citizen now. It can retreive only notice
notifiers. I am not deprecating it yet but in the future it might be removed or
merged with `Airbarke.notifiers`.