### PR TITLE
git_repository_filter: don't read repo on git 2.6 and lower

### DIFF
--- a/lib/airbrake-ruby/filters/git_repository_filter.rb
+++ b/lib/airbrake-ruby/filters/git_repository_filter.rb
@@ -11,6 +11,7 @@ module Airbrake
       def initialize(root_directory)
         @git_path = File.join(root_directory, '.git')
         @repository = nil
+        @git_version = Gem::Version.new(`git --version`.split.last)
         @weight = 116
       end
 
@@ -25,7 +26,14 @@ module Airbrake
 
         return unless File.exist?(@git_path)
 
-        @repository = `cd #{@git_path} && git remote get-url origin`.chomp
+        @repository =
+          if @git_version >= Gem::Version.new('2.7.0')
+            `cd #{@git_path} && git remote get-url origin`.chomp
+          else
+            "`git remote get-url` is unsupported in git #{@git_version}. " \
+            'Consider an upgrade to 2.7+'
+          end
+
         return unless @repository
         notice[:context][:repository] = @repository
       end


### PR DESCRIPTION
Git v2.7 introduced support for `git remote get-url`. Here we are adding a
special case for old git installations (unfortunately, there have been a few bug
reports, so people do run a 5-year old git).