### PR TITLE
filters/git_repository: read remote through config

### DIFF
--- a/lib/airbrake-ruby/filters/git_repository_filter.rb
+++ b/lib/airbrake-ruby/filters/git_repository_filter.rb
@@ -28,7 +28,7 @@ module Airbrake
 
         @repository =
           if @git_version >= Gem::Version.new('2.7.0')
-            `cd #{@git_path} && git remote get-url origin`.chomp
+            `cd #{@git_path} && git config --get remote.origin.url`.chomp
           else
             "`git remote get-url` is unsupported in git #{@git_version}. " \
             'Consider an upgrade to 2.7+'


### PR DESCRIPTION
This way is less noisy. If Airbrake run against a repo that doesn't have a
remote, the following warning is emitted:

    % bundle exec rake airbrake:test
    fatal: No such remote 'origin'
    ...

If we read through config, nothing is printed.