### PR TITLE
Improve jruby detection

### DIFF
--- a/airbrake-ruby.gemspec
+++ b/airbrake-ruby.gemspec
@@ -1,6 +1,6 @@
 require './lib/airbrake-ruby/version'
 
-jruby = RbConfig::CONFIG['ruby_install_name'] == 'jruby'
+java = RUBY_PLATFORM =~ /java/
 
 Gem::Specification.new do |s|
   s.name        = 'airbrake-ruby'
@@ -27,9 +27,9 @@ DESC
   s.test_files   = Dir.glob('spec/**/*')
 
   s.required_ruby_version = '>= 2.1'
-  s.platform = jruby ? 'java' : Gem::Platform::RUBY
+  s.platform = java ? 'java' : Gem::Platform::RUBY
 
-  if jruby
+  if java
     s.add_dependency 'rbtree-jruby', '~> 0.2.1'
   else
     s.add_dependency 'rbtree3', '~> 0.5.0'


### PR DESCRIPTION
I'm seeing an issue with 3.2.0 on jruby, my builds are failing because bundler is attempting to install the ruby version of rbtree3, not the jruby version.

I think the current method of detecting jruby doesn't work in all cases, for example when using rvm on travis.

```
/home/travis/.rvm/gems/jruby-9.1.9.0/extensions/universal-java-1.8/2.3.0/rbtree3-0.5.0/mkmf.log
extconf failed, exit code 1
Gem files will remain installed in
/home/travis/.rvm/gems/jruby-9.1.9.0/gems/rbtree3-0.5.0 for inspection.
Results logged to
/home/travis/.rvm/gems/jruby-9.1.9.0/extensions/universal-java-1.8/2.3.0/rbtree3-0.5.0/gem_make.out
An error occurred while installing rbtree3 (0.5.0), and Bundler cannot
continue.
Make sure that `gem install rbtree3 -v '0.5.0' --source 'https://rubygems.org/'`
succeeds before bundling.
In rails_5_0.gemfile:
  mygem was resolved to 0.0.2, which depends on
    delayed-plugins-airbrake was resolved to 1.1.0, which depends on
      airbrake was resolved to 8.0.1, which depends on
        airbrake-ruby was resolved to 3.2.0, which depends on
          rbtree3
```

You can see that its trying to use `rbtree3`, not `rbtree-jruby`, despite being on jruby.