### PR TITLE
git_repository_filter: handle non-standard git versions

### DIFF
--- a/lib/airbrake-ruby/filters/git_repository_filter.rb
+++ b/lib/airbrake-ruby/filters/git_repository_filter.rb
@@ -11,7 +11,7 @@ module Airbrake
       def initialize(root_directory)
         @git_path = File.join(root_directory, '.git')
         @repository = nil
-        @git_version = Gem::Version.new(`git --version`.split.last)
+        @git_version = Gem::Version.new(`git --version`.split[2])
         @weight = 116
       end
 

--- a/spec/filters/git_repository_filter.rb
+++ b/spec/filters/git_repository_filter.rb
@@ -5,6 +5,26 @@ RSpec.describe Airbrake::Filters::GitRepositoryFilter do
     Airbrake::Notice.new(Airbrake::Config.new, AirbrakeTestError.new)
   end
 
+  describe "#initialize" do
+    it "parses standard git version" do
+      allow_any_instance_of(Kernel).
+        to receive(:`).and_return('git version 2.18.0')
+      expect { subject }.not_to raise_error
+    end
+
+    it "parses release candidate git version" do
+      allow_any_instance_of(Kernel).
+        to receive(:`).and_return('git version 2.21.0-rc0')
+      expect { subject }.not_to raise_error
+    end
+
+    it "parses git version with brackets" do
+      allow_any_instance_of(Kernel).
+        to receive(:`).and_return('git version 2.17.2 (Apple Git-113)')
+      expect { subject }.not_to raise_error
+    end
+  end
+
   context "when context/repository is defined" do
     it "doesn't attach anything to context/repository" do
       notice[:context][:repository] = 'git@github.com:kyrylo/test.git'


### PR DESCRIPTION
Fixes #407 ("Malformed version number string" error with version 3.2.0)

Apparently, if you compile Git from source, it appends some sort of meta
information.