### PR TITLE
notice_notifier: add 'notify_request' kludge for compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Airbrake Ruby Changelog
 
 ### master
 
+* Fixed ``undefined method `notify_request'`` when calling
+  `Airbrake.notify_request` (added backwards compatibility)
+  ([#411](https://github.com/airbrake/airbrake-ruby/pull/411))
+
 ### [v3.2.1][v3.2.1] (Febuary 11, 2019)
 
 * Fixed `Malformed version number string` in `GitRepositoryFilter` when

--- a/lib/airbrake-ruby.rb
+++ b/lib/airbrake-ruby.rb
@@ -239,8 +239,13 @@ module Airbrake
 
       raise Airbrake::Error, config.validation_error_message unless config.valid?
 
-      @notice_notifiers[notifier_name] = NoticeNotifier.new(config)
-      @performance_notifiers[notifier_name] = PerformanceNotifier.new(config)
+      # TODO: Kludge to avoid
+      # https://github.com/airbrake/airbrake-ruby/issues/406
+      # Stop passing perf_notifier to NoticeNotifier as soon as possible.
+      perf_notifier = PerformanceNotifier.new(config)
+      @performance_notifiers[notifier_name] = perf_notifier
+      @notice_notifiers[notifier_name] = NoticeNotifier.new(config, perf_notifier)
+
       @deploy_notifiers[notifier_name] = DeployNotifier.new(config)
     end
 

--- a/lib/airbrake-ruby/notice_notifier.rb
+++ b/lib/airbrake-ruby/notice_notifier.rb
@@ -34,7 +34,7 @@ module Airbrake
     #   notice_notifier = Airbrake::NoticeNotifier.new(config)
     #
     # @param [Airbrake::Config] config
-    def initialize(config)
+    def initialize(config, perf_notifier = nil)
       @config =
         if config.is_a?(Config)
           config
@@ -52,6 +52,7 @@ module Airbrake
       @filter_chain = FilterChain.new
       @async_sender = AsyncSender.new(@config)
       @sync_sender = SyncSender.new(@config)
+      @perf_notifier = perf_notifier
 
       add_default_filters
     end
@@ -64,6 +65,15 @@ module Airbrake
     # @macro see_public_api_method
     def notify_sync(exception, params = {}, &block)
       send_notice(exception, params, @sync_sender, &block).value
+    end
+
+    # @deprecated Update the airbrake gem to v8.1.0 or higher
+    def notify_request(request_info, promise = Promise.new)
+      @config.logger.info(
+        "#{LOG_LABEL} #{self.class}##{__method__} is deprecated. Update " \
+        'the airbrake gem to v8.1.0 or higher'
+      )
+      @perf_notifier.notify(Request.new(request_info), promise)
     end
 
     # @macro see_public_api_method


### PR DESCRIPTION
Fixes #406 (Airbrake failing with undefined method `notify_request’ as of 3.2)

This looks ugly but preserves backwards compatibility with current airbrake
gem (v8.0.1).