### PR TITLE
Build this gem on JRuby properly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ Gemfile.lock
 .bundle
 doc
 .yardoc
+pkg

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,9 @@
 AllCops:
   DisplayCopNames: true
   DisplayStyleGuide: true
+  Exclude:
+    - 'pkg/**/*'
+    - 'vendor/**/*'
 
 Metrics/MethodLength:
   Max: 25

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,53 @@
 require 'rspec/core/rake_task'
-RSpec::Core::RakeTask.new(:spec)
+require 'rubygems/package_task'
 
+RSpec::Core::RakeTask.new(:spec)
 task default: :spec
+
+# rubocop:disable Security/Eval
+def modify_base_gemspec
+  eval(File.read('airbrake-ruby.gemspec')).tap { |s| yield s }
+end
+# rubocop:enable Security/Eval
+
+namespace :ruby do
+  spec = modify_base_gemspec do |s|
+    # We keep this dependency in Gemfile, so we can run CI builds. When we
+    # generate gems, duplicate dependencies are not allowed.
+    s.dependencies.delete_if { |d| d.name == 'rbtree3' }
+
+    s.platform = Gem::Platform::RUBY
+    s.add_dependency('rbtree3', '~> 0.5')
+  end
+
+  Gem::PackageTask.new(spec) do |pkg|
+    pkg.need_zip = false
+    pkg.need_tar = false
+  end
+end
+
+namespace :jruby do
+  spec = modify_base_gemspec do |s|
+    # We keep this dependency in Gemfile, so we can run CI builds. When we
+    # generate gems, duplicate dependencies are not allowed.
+    s.dependencies.delete_if { |d| d.name == 'rbtree-jruby' }
+
+    s.platform = 'java'
+    s.add_dependency('rbtree-jruby', '~> 0.2')
+  end
+
+  Gem::PackageTask.new(spec) do |pkg|
+    pkg.need_zip = false
+    pkg.need_tar = false
+  end
+end
+
+desc 'Build all platform gems at once'
+task gems: %w[ruby:gem jruby:gem]
+
+desc 'Build and push platform gems'
+task pushgems: :gems do
+  chdir("#{File.dirname(__FILE__)}/pkg") do
+    Dir['*.gem'].each { |gem| sh "gem push #{gem}" }
+  end
+end

--- a/airbrake-ruby.gemspec
+++ b/airbrake-ruby.gemspec
@@ -1,7 +1,5 @@
 require './lib/airbrake-ruby/version'
 
-java = RUBY_PLATFORM =~ /java/
-
 Gem::Specification.new do |s|
   s.name        = 'airbrake-ruby'
   s.version     = Airbrake::AIRBRAKE_RUBY_VERSION.dup
@@ -27,12 +25,11 @@ DESC
   s.test_files   = Dir.glob('spec/**/*')
 
   s.required_ruby_version = '>= 2.1'
-  s.platform = java ? 'java' : Gem::Platform::RUBY
 
-  if java
-    s.add_dependency 'rbtree-jruby', '~> 0.2.1'
+  if defined?(JRuby)
+    s.add_dependency 'rbtree-jruby', '~> 0.2'
   else
-    s.add_dependency 'rbtree3', '~> 0.5.0'
+    s.add_dependency 'rbtree3', '~> 0.5'
   end
 
   s.add_development_dependency 'rspec', '~> 3'


### PR DESCRIPTION
The current approach doesn't work with JRuby. The patch that aimed to fix the
issue didn't actually work (duh):
https://github.com/airbrake/airbrake-ruby/pull/408

The problem is that I run `gem build *.gemspec` using CRuby, so the JRuby check
inside the gemspec always has the same outcome. This change builds gems
properly, with `rake gems`.