### PR TITLE
filter_chain: fix bugged #inspect when a chain has no filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Airbrake Ruby Changelog
 
 ### master
 
+* Fixed `no implicit conversion of Array into String` raised by
+  `FilterChain#inspect` when no filters were added
+  ([#414](https://github.com/airbrake/airbrake-ruby/pull/414))
+
 ### [v3.2.2][v3.2.2] (Febuary 11, 2019)
 
 * Fixed ``undefined method `notify_request'`` when calling

--- a/lib/airbrake-ruby/filter_chain.rb
+++ b/lib/airbrake-ruby/filter_chain.rb
@@ -76,7 +76,7 @@ module Airbrake
 
     # @return [String] customized inspect to lessen the amount of clutter
     def inspect
-      @filters.map(&:class)
+      @filters.map(&:class).to_s
     end
 
     # @return [String] {#inspect} for PrettyPrint
@@ -84,7 +84,7 @@ module Airbrake
       q.text('[')
 
       # Make nesting of the first element consistent on JRuby and MRI.
-      q.nest(2) { q.breakable }
+      q.nest(2) { q.breakable } if @filters.any?
 
       q.nest(2) do
         q.seplist(@filters) { |f| q.pp(f.class) }

--- a/spec/filter_chain_spec.rb
+++ b/spec/filter_chain_spec.rb
@@ -80,4 +80,15 @@ RSpec.describe Airbrake::FilterChain do
       expect(notice[:params][:foo]).to eq([2])
     end
   end
+
+  describe "#inspect" do
+    it "returns a string representation of an empty FilterChain" do
+      expect(subject.inspect).to eq('[]')
+    end
+
+    it "returns a string representation of a non-empty FilterChain" do
+      subject.add_filter(proc {})
+      expect(subject.inspect).to eq('[Proc]')
+    end
+  end
 end


### PR DESCRIPTION
Invoking `#inspect` on JRuby produces:

```
TypeError: no implicit conversion of Array into String
```

https://circleci.com/gh/airbrake/airbrake/3429