### PR TITLE
filters/git_repository: don't filter when Git is not installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Airbrake Ruby Changelog
 
 ### master
 
+* Fixed ``undefined method `split' for nil:NilClass`` in `GitRepositoryFilter`
+  when `git` is not installed
+  ([#417](https://github.com/airbrake/airbrake-ruby/pull/417))
+
 ### [v3.2.3][v3.2.3] (Feburary 12, 2019)
 
 * Fixed `no implicit conversion of Array into String` raised by

--- a/lib/airbrake-ruby/filters/git_repository_filter.rb
+++ b/lib/airbrake-ruby/filters/git_repository_filter.rb
@@ -11,20 +11,24 @@ module Airbrake
       def initialize(root_directory)
         @git_path = File.join(root_directory, '.git')
         @repository = nil
-        @git_version = Gem::Version.new(`git --version`.split[2])
+        @git_version = detect_git_version
         @weight = 116
       end
 
       # @macro call_filter
       def call(notice)
         return if notice[:context].key?(:repository)
+        attach_repository(notice)
+      end
 
+      def attach_repository(notice)
         if @repository
           notice[:context][:repository] = @repository
           return
         end
 
         return unless File.exist?(@git_path)
+        return unless @git_version
 
         @repository =
           if @git_version >= Gem::Version.new('2.7.0')
@@ -36,6 +40,24 @@ module Airbrake
 
         return unless @repository
         notice[:context][:repository] = @repository
+      end
+
+      private
+
+      def detect_git_version
+        return unless which('git')
+        Gem::Version.new(`git --version`.split[2])
+      end
+
+      # Cross-platform way to tell if an executable is accessible.
+      def which(cmd)
+        exts = ENV['PATHEXT'] ? ENV['PATHEXT'].split(';') : ['']
+        ENV['PATH'].split(File::PATH_SEPARATOR).find do |path|
+          exts.find do |ext|
+            exe = File.join(path, "#{cmd}#{ext}")
+            File.executable?(exe) && !File.directory?(exe)
+          end
+        end
       end
     end
   end

--- a/spec/filters/git_repository_filter.rb
+++ b/spec/filters/git_repository_filter.rb
@@ -50,4 +50,12 @@ RSpec.describe Airbrake::Filters::GitRepositoryFilter do
       )
     end
   end
+
+  context "when git is not in PATH" do
+    it "does not attach context/repository" do
+      ENV['PATH'] = ''
+      subject.call(notice)
+      expect(notice[:context][:repository]).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
Fixes ``undefined method `split' for nil:NilClass`` when Git is not
installed (could easily happen inside a Docker container).