### PR TITLE
performance_notifier: add the ability to attach caller locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -830,8 +830,11 @@ Airbrake.notify_query(
   method: 'GET',
   route: '/things/1',
   query: 'SELECT * FROM foos',
+  func: 'foo', # optional
+  file: 'foo.rb', # optional
+  line: 123, # optional
   start_time: Time.new - 200,
-  end_time: Time.new
+  end_time: Time.new # optional
 )
 ```
 

--- a/lib/airbrake-ruby.rb
+++ b/lib/airbrake-ruby.rb
@@ -450,6 +450,9 @@ module Airbrake
     #     method: 'POST',
     #     route: '/thing/:id/create',
     #     status_code: 200,
+    #     func: 'do_stuff',
+    #     file: 'app/models/foo.rb',
+    #     line: 452,
     #     start_time: timestamp,
     #     end_time: Time.now
     #   )
@@ -457,7 +460,14 @@ module Airbrake
     # @param [Hash{Symbol=>Object}] request_info
     # @option request_info [String] :method The HTTP method that was invoked
     # @option request_info [String] :route The route that was invoked
-    # @option request_info [Integer] :status_code The respose code that the route returned
+    # @option request_info [Integer] :status_code The respose code that the
+    #   route returned
+    # @option request_info [String] :func The function that called the query
+    #   (optional)
+    # @option request_info [String] :file The file that has the function that
+    #   called the query (optional)
+    # @option request_info [Integer] :line The line that executes the query
+    #   (optional)
     # @option request_info [Date] :start_time When the request started
     # @option request_info [Time] :end_time When the request ended (optional)
     # @return [void]

--- a/lib/airbrake-ruby/performance_notifier.rb
+++ b/lib/airbrake-ruby/performance_notifier.rb
@@ -137,12 +137,24 @@ module Airbrake
   # @see Airbrake.notify_query
   # @api public
   # @since v3.2.0
-  Query = Struct.new(:method, :route, :query, :start_time, :end_time) do
+  # rubocop:disable Metrics/ParameterLists, Metrics/BlockLength
+  Query = Struct.new(
+    :method, :route, :query, :func, :file, :line, :start_time, :end_time
+  ) do
     include HashKeyable
     include Ignorable
 
-    def initialize(method:, route:, query:, start_time:, end_time: Time.now)
-      super(method, route, query, start_time, end_time)
+    def initialize(
+      method:,
+      route:,
+      query:,
+      func: nil,
+      file: nil,
+      line: nil,
+      start_time:,
+      end_time: Time.now
+    )
+      super(method, route, query, func, file, line, start_time, end_time)
     end
 
     def name
@@ -154,8 +166,12 @@ module Airbrake
         'method' => method,
         'route' => route,
         'query' => query,
-        'time' => TimeTruncate.utc_truncate_minutes(start_time)
+        'time' => TimeTruncate.utc_truncate_minutes(start_time),
+        'function' => func,
+        'file' => file,
+        'line' => line
       }
     end
+    # rubocop:enable Metrics/ParameterLists, Metrics/BlockLength
   end
 end


### PR DESCRIPTION
Adds support for `func`, `file` & `line` for `Airbrake.notify_query`.

```rb
Airbrake.notify_query(
  method: 'POST',
  route: '/foo',
  query: 'SELECT * FROM things',
  func: 'foo',
  file: 'foo.rb',
  line: 123,
  start_time: Time.new(2018, 1, 1, 0, 49, 0, 0),
  end_time: Time.new(2018, 1, 1, 0, 50, 0, 0)
)
```