### PR TITLE
query,request: add support for environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -827,6 +827,7 @@ displayed on the Performance tab of your project.
 
 ```ruby
 Airbrake.notify_query(
+  environment: 'production', # optional
   method: 'GET',
   route: '/things/1',
   query: 'SELECT * FROM foos',

--- a/lib/airbrake-ruby.rb
+++ b/lib/airbrake-ruby.rb
@@ -496,6 +496,7 @@ module Airbrake
     #   )
     #
     # @param [Hash{Symbol=>Object}] query_info
+    # @option request_info [String] :environment (optional)
     # @option request_info [String] :method The HTTP method that triggered this
     #   SQL query (optional)
     # @option request_info [String] :route The route that triggered this SQL

--- a/lib/airbrake-ruby/query.rb
+++ b/lib/airbrake-ruby/query.rb
@@ -6,12 +6,14 @@ module Airbrake
   # @since v3.2.0
   # rubocop:disable Metrics/ParameterLists, Metrics/BlockLength
   Query = Struct.new(
-    :method, :route, :query, :func, :file, :line, :start_time, :end_time
+    :environment, :method, :route, :query, :func, :file, :line, :start_time,
+    :end_time
   ) do
     include HashKeyable
     include Ignorable
 
     def initialize(
+      environment: nil,
       method:,
       route:,
       query:,
@@ -21,7 +23,10 @@ module Airbrake
       start_time:,
       end_time: Time.now
     )
-      super(method, route, query, func, file, line, start_time, end_time)
+      super(
+        environment, method, route, query, func, file, line, start_time,
+        end_time
+      )
     end
 
     def name
@@ -30,6 +35,7 @@ module Airbrake
 
     def to_h
       {
+        'environment' => environment,
         'method' => method,
         'route' => route,
         'query' => query,
@@ -37,7 +43,7 @@ module Airbrake
         'function' => func,
         'file' => file,
         'line' => line
-      }
+      }.delete_if { |_key, val| val.nil? }
     end
     # rubocop:enable Metrics/ParameterLists, Metrics/BlockLength
   end

--- a/lib/airbrake-ruby/request.rb
+++ b/lib/airbrake-ruby/request.rb
@@ -4,13 +4,22 @@ module Airbrake
   # @see Airbrake.notify_request
   # @api public
   # @since v3.2.0
-  Request = Struct.new(:method, :route, :status_code, :start_time, :end_time) do
+  # rubocop:disable Metrics/ParameterLists
+  Request = Struct.new(
+    :environment, :method, :route, :status_code, :start_time, :end_time
+  ) do
     include HashKeyable
     include Ignorable
 
-    def initialize(method:, route:, status_code:, start_time:, end_time: Time.now)
-      @ignored = false
-      super(method, route, status_code, start_time, end_time)
+    def initialize(
+      environment: nil,
+      method:,
+      route:,
+      status_code:,
+      start_time:,
+      end_time: Time.now
+    )
+      super(environment, method, route, status_code, start_time, end_time)
     end
 
     def name
@@ -19,11 +28,13 @@ module Airbrake
 
     def to_h
       {
+        'environment' => environment,
         'method' => method,
         'route' => route,
         'statusCode' => status_code,
         'time' => TimeTruncate.utc_truncate_minutes(start_time)
-      }
+      }.delete_if { |_key, val| val.nil? }
     end
   end
+  # rubocop:enable Metrics/ParameterLists
 end

--- a/spec/performance_notifier_spec.rb
+++ b/spec/performance_notifier_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Airbrake::PerformanceNotifier do
     it "sends full query" do
       subject.notify(
         Airbrake::Query.new(
+          environment: 'development',
           method: 'POST',
           route: '/foo',
           query: 'SELECT * FROM things',
@@ -36,6 +37,7 @@ RSpec.describe Airbrake::PerformanceNotifier do
       expect(
         a_request(:put, queries).with(body: %r|
           \A{"queries":\[{
+            "environment":"development",
             "method":"POST",
             "route":"/foo",
             "query":"SELECT\s\*\sFROM\sthings",
@@ -43,6 +45,34 @@ RSpec.describe Airbrake::PerformanceNotifier do
             "function":"foo",
             "file":"foo.rb",
             "line":123,
+            "count":1,
+            "sum":60000.0,
+            "sumsq":3600000000.0,
+            "tdigest":"AAAAAkA0AAAAAAAAAAAAAUdqYAAB"
+          }\]}\z|x)
+      ).to have_been_made
+    end
+
+    it "sends full request" do
+      subject.notify(
+        Airbrake::Request.new(
+          environment: 'development',
+          method: 'POST',
+          route: '/foo',
+          status_code: 200,
+          start_time: Time.new(2018, 1, 1, 0, 49, 0, 0),
+          end_time: Time.new(2018, 1, 1, 0, 50, 0, 0)
+        )
+      )
+
+      expect(
+        a_request(:put, routes).with(body: %r|
+          \A{"routes":\[{
+            "environment":"development",
+            "method":"POST",
+            "route":"/foo",
+            "statusCode":200,
+            "time":"2018-01-01T00:49:00\+00:00",
             "count":1,
             "sum":60000.0,
             "sumsq":3600000000.0,


### PR DESCRIPTION
`Airbrake.notify_{request,query}` can now send environment information.

Additionally, when `Query` or `Request` are serialised to Hash, we don't include
`nil` values, so we rely on the backend default values.