### PR TITLE
Remove deprecated functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Airbrake Ruby Changelog
 
 * Reduced clutter of `DeployNotifier` and `PerformanceNotifier` when
   `inspect`ing ([#423](https://github.com/airbrake/airbrake-ruby/pull/423))
+* Deleted deprecated `Airbrake::Notifier` & `Airbrake::NilNotifier` constants
+* Deleted deprecated `Config#route_stats`, `Config#route_stats_flush_period`
+* `PerformanceNotifier`, `NoticeNotifier` & `DeployNotifier` stopped accepting
+  deprecated Hash as a `config` object
 
 ### [v3.2.5][v3.2.5] (Feburary 20, 2019)
 

--- a/lib/airbrake-ruby.rb
+++ b/lib/airbrake-ruby.rb
@@ -126,14 +126,6 @@ module Airbrake
     def merge_context(_context); end
   end
 
-  # @deprecated Use {Airbrake::NoticeNotifier} instead
-  Notifier = NoticeNotifier
-  deprecate_constant(:Notifier) if respond_to?(:deprecate_constant)
-
-  # @deprecated Use {Airbrake::NilNoticeNotifier} instead
-  NilNotifier = NilNoticeNotifier
-  deprecate_constant(:NilNotifier) if respond_to?(:deprecate_constant)
-
   # NilPerformanceNotifier is a no-op notifier, which mimics
   # {Airbrake::PerformanceNotifier} and serves only the purpose of making the
   # library API easier to use.

--- a/lib/airbrake-ruby/config.rb
+++ b/lib/airbrake-ruby/config.rb
@@ -195,38 +195,6 @@ module Airbrake
       end
     end
 
-    def route_stats
-      logger.warn(
-        "#{LOG_LABEL} the 'route_stats' option is deprecated. " \
-        "Use 'performance_stats' instead"
-      )
-      @performance_stats
-    end
-
-    def route_stats=(value)
-      logger.warn(
-        "#{LOG_LABEL} the 'route_stats' option is deprecated. " \
-        "Use 'performance_stats' instead"
-      )
-      @performance_stats = value
-    end
-
-    def route_stats_flush_period
-      logger.warn(
-        "#{LOG_LABEL} the 'route_stats_flush_period' option is deprecated. " \
-        "Use 'performance_stats_flush_period' instead"
-      )
-      @performance_stats_flush_period
-    end
-
-    def route_stats_flush_period=(value)
-      logger.warn(
-        "#{LOG_LABEL} the 'route_stats_flush_period' option is deprecated. " \
-        "Use 'performance_stats' instead"
-      )
-      @performance_stats_flush_period = value
-    end
-
     private
 
     def set_option(option, value)

--- a/lib/airbrake-ruby/deploy_notifier.rb
+++ b/lib/airbrake-ruby/deploy_notifier.rb
@@ -14,20 +14,8 @@ module Airbrake
 
     # @param [Airbrake::Config] config
     def initialize(config)
-      @config =
-        if config.is_a?(Config)
-          config
-        else
-          loc = caller_locations(1..1).first
-          signature = "#{self.class.name}##{__method__}"
-          warn(
-            "#{loc.path}:#{loc.lineno}: warning: passing a Hash to #{signature} " \
-            'is deprecated. Pass `Airbrake::Config` instead'
-          )
-          Config.new(config)
-        end
-
-      @sender = SyncSender.new(@config)
+      @config = config
+      @sender = SyncSender.new(config)
     end
 
     # @see Airbrake.create_deploy

--- a/lib/airbrake-ruby/notice_notifier.rb
+++ b/lib/airbrake-ruby/notice_notifier.rb
@@ -5,7 +5,6 @@ module Airbrake
   # @see Airbrake::Config The list of options
   # @since v1.0.0
   # @api public
-  # rubocop:disable Metrics/ClassLength
   class NoticeNotifier
     # @return [Array<Class>] filters to be executed first
     DEFAULT_FILTERS = [
@@ -28,23 +27,11 @@ module Airbrake
     #
     # @param [Airbrake::Config] config
     def initialize(config, perf_notifier = nil)
-      @config =
-        if config.is_a?(Config)
-          config
-        else
-          loc = caller_locations(1..1).first
-          signature = "#{self.class.name}##{__method__}"
-          warn(
-            "#{loc.path}:#{loc.lineno}: warning: passing a Hash to #{signature} " \
-            'is deprecated. Pass `Airbrake::Config` instead'
-          )
-          Config.new(config)
-        end
-
+      @config = config
       @context = {}
       @filter_chain = FilterChain.new
-      @async_sender = AsyncSender.new(@config)
-      @sync_sender = SyncSender.new(@config)
+      @async_sender = AsyncSender.new(config)
+      @sync_sender = SyncSender.new(config)
       @perf_notifier = perf_notifier
 
       add_default_filters
@@ -58,15 +45,6 @@ module Airbrake
     # @macro see_public_api_method
     def notify_sync(exception, params = {}, &block)
       send_notice(exception, params, @sync_sender, &block).value
-    end
-
-    # @deprecated Update the airbrake gem to v8.1.0 or higher
-    def notify_request(request_info, promise = Promise.new)
-      @config.logger.info(
-        "#{LOG_LABEL} #{self.class}##{__method__} is deprecated. Update " \
-        'the airbrake gem to v8.1.0 or higher'
-      )
-      @perf_notifier.notify(Request.new(request_info), promise)
     end
 
     # @macro see_public_api_method
@@ -194,5 +172,4 @@ module Airbrake
     end
     # rubocop:enable Metrics/AbcSize
   end
-  # rubocop:enable Metrics/ClassLength
 end

--- a/lib/airbrake-ruby/performance_notifier.rb
+++ b/lib/airbrake-ruby/performance_notifier.rb
@@ -9,21 +9,9 @@ module Airbrake
 
     # @param [Airbrake::Config] config
     def initialize(config)
-      @config =
-        if config.is_a?(Config)
-          config
-        else
-          loc = caller_locations(1..1).first
-          signature = "#{self.class.name}##{__method__}"
-          warn(
-            "#{loc.path}:#{loc.lineno}: warning: passing a Hash to #{signature} " \
-            'is deprecated. Pass `Airbrake::Config` instead'
-          )
-          Config.new(config)
-        end
-
-      @flush_period = @config.performance_stats_flush_period
-      @sender = SyncSender.new(@config, :put)
+      @config = config
+      @flush_period = config.performance_stats_flush_period
+      @sender = SyncSender.new(config, :put)
       @payload = {}
       @schedule_flush = nil
       @mutex = Mutex.new

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -77,22 +77,8 @@ RSpec.describe Airbrake::Config do
         expect(config.whitelist_keys).to be_empty
       end
 
-      it "disables route stats by default (deprecated)" do
-        out = StringIO.new
-        config.logger = Logger.new(out)
-        expect(config.route_stats).to be_falsey
-        expect(out.string).to match(/'route_stats'.+is deprecated/)
-      end
-
       it "disables performance stats by default" do
         expect(config.performance_stats).to be_falsey
-      end
-
-      it "sets the default route_stats_flush_period (deprecated)" do
-        out = StringIO.new
-        config.logger = Logger.new(out)
-        expect(config.route_stats_flush_period).to eq(15)
-        expect(out.string).to match(/'route_stats_flush_period'.+is deprecated/)
       end
 
       it "sets the default performance_stats_flush_period" do


### PR DESCRIPTION
I've planned to keep this for a longer time, however fast pace with APM features requires a major version bump. This is a preparation for the major breaking change: making the Config object a singleton. The reasons for that will be described in the future, but for now we're just deleting stuff that shouldn't survive a major bump.

