### PR TITLE
airbrake-ruby: deprecate #create_deploy in favour of #notify_deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Airbrake Ruby Changelog
 
 * Reduced clutter of `DeployNotifier` and `PerformanceNotifier` when
   `inspect`ing ([#423](https://github.com/airbrake/airbrake-ruby/pull/423))
+* Deprecated `Airbrake.create_deploy` in favour of `Airbrake.notify_deploy`
 
 ### [v3.2.5][v3.2.5] (Feburary 20, 2019)
 

--- a/lib/airbrake-ruby.rb
+++ b/lib/airbrake-ruby.rb
@@ -379,8 +379,7 @@ module Airbrake
       @notice_notifiers[:default].close
     end
 
-    # Pings the Airbrake Deploy API endpoint about the occurred deploy. This
-    # method is used by the airbrake gem for various integrations.
+    # Pings the Airbrake Deploy API endpoint about the occurred deploy.
     #
     # @param [Hash{Symbol=>String}] deploy_info The params for the API
     # @option deploy_info [Symbol] :environment
@@ -389,8 +388,19 @@ module Airbrake
     # @option deploy_info [Symbol] :revision
     # @option deploy_info [Symbol] :version
     # @return [void]
-    def create_deploy(deploy_info)
+    def notify_deploy(deploy_info)
       @deploy_notifiers[:default].notify(deploy_info)
+    end
+
+    # @see notify_deploy
+    def create_deploy(deploy_info)
+      loc = caller_locations(1..1).first
+      signature = "#{self}##{__method__}"
+      warn(
+        "#{loc.path}:#{loc.lineno}: warning: #{signature} is deprecated. Call " \
+        "#{self}#notify_deploy instead"
+      )
+      notify_deploy(deploy_info)
     end
 
     # Merges +context+ with the current context.

--- a/spec/airbrake_spec.rb
+++ b/spec/airbrake_spec.rb
@@ -121,12 +121,12 @@ RSpec.describe Airbrake do
     end
   end
 
-  describe ".create_deploy" do
+  describe ".notify_deploy" do
     let(:default_notifier) { described_class.notifiers[:deploy][:default] }
 
     it "calls 'notify' on the deploy notifier" do
       expect(default_notifier).to receive(:notify).with(foo: 'bar')
-      described_class.create_deploy(foo: 'bar')
+      described_class.notify_deploy(foo: 'bar')
     end
   end
 


### PR DESCRIPTION
This change is consistent with the rest of the notify methods:

* notify_query
* notify_request