### PR TITLE
Remove the ability to configure multiple notifiers

### DIFF
--- a/lib/airbrake-ruby.rb
+++ b/lib/airbrake-ruby.rb
@@ -205,7 +205,6 @@ module Airbrake
     #     c.project_key = 'fd04e13d806a90f96614ad8e529b2822'
     #   end
     #
-    # @param [Symbol] notifier_name the name to be associated with the notifier
     # @yield [config] The configuration object
     # @yieldparam config [Airbrake::Config]
     # @return [void]
@@ -215,33 +214,18 @@ module Airbrake
     #   is missing (or both)
     # @note There's no way to reconfigure a notifier
     # @note There's no way to read config values outside of this library
-    def configure(notifier_name = :default)
-      unless notifier_name == :default
-        loc = caller_locations(1..1).first
-        warn(
-          "#{loc.path}:#{loc.lineno}: warning: configuring a notifier with a " \
-          "custom name is deprecated. This feature will be removed from " \
-          "airbrake-ruby v4 altogether."
-        )
-      end
-
+    def configure
       yield config = Airbrake::Config.new
 
-      if @notice_notifiers.key?(notifier_name)
-        raise Airbrake::Error,
-              "the '#{notifier_name}' notifier was already configured"
+      if @notice_notifiers.key?(:default)
+        raise Airbrake::Error, 'Airbrake was already configured'
       end
 
       raise Airbrake::Error, config.validation_error_message unless config.valid?
 
-      # TODO: Kludge to avoid
-      # https://github.com/airbrake/airbrake-ruby/issues/406
-      # Stop passing perf_notifier to NoticeNotifier as soon as possible.
-      perf_notifier = PerformanceNotifier.new(config)
-      @performance_notifiers[notifier_name] = perf_notifier
-      @notice_notifiers[notifier_name] = NoticeNotifier.new(config, perf_notifier)
-
-      @deploy_notifiers[notifier_name] = DeployNotifier.new(config)
+      @performance_notifiers[:default] = PerformanceNotifier.new(config)
+      @notice_notifiers[:default] = NoticeNotifier.new(config)
+      @deploy_notifiers[:default] = DeployNotifier.new(config)
     end
 
     # @return [Boolean] true if the notifier was configured, false otherwise

--- a/lib/airbrake-ruby/notice_notifier.rb
+++ b/lib/airbrake-ruby/notice_notifier.rb
@@ -26,13 +26,12 @@ module Airbrake
     #   notice_notifier = Airbrake::NoticeNotifier.new(config)
     #
     # @param [Airbrake::Config] config
-    def initialize(config, perf_notifier = nil)
+    def initialize(config)
       @config = config
       @context = {}
       @filter_chain = FilterChain.new
       @async_sender = AsyncSender.new(config)
       @sync_sender = SyncSender.new(config)
-      @perf_notifier = perf_notifier
 
       add_default_filters
     end

--- a/spec/airbrake_spec.rb
+++ b/spec/airbrake_spec.rb
@@ -36,28 +36,12 @@ RSpec.describe Airbrake do
       end.to yield_with_args(Airbrake::Config)
     end
 
-    context "when invoked with a notice notifier name" do
-      it "sets notice notifier name to the provided name" do
-        described_class.configure(:test) { |c| c.merge(config_params) }
-        expect(described_class[:test]).to be_an(Airbrake::NoticeNotifier)
-      end
-    end
-
-    context "when invoked without a notifier name" do
-      it "defaults to the :default notifier name" do
-        described_class.configure { |c| c.merge(config_params) }
-        expect(described_class[:default]).to be_an(Airbrake::NoticeNotifier)
-      end
-    end
-
-    context "when invoked twice with the same notifier name" do
+    context "when invoked twice" do
       it "raises Airbrake::Error" do
         described_class.configure { |c| c.merge(config_params) }
         expect do
           described_class.configure { |c| c.merge(config_params) }
-        end.to raise_error(
-          Airbrake::Error, "the 'default' notifier was already configured"
-        )
+        end.to raise_error(Airbrake::Error, 'Airbrake was already configured')
       end
     end
 


### PR DESCRIPTION
This feature starts getting in the way of future development of the library:

* We have to maintain a complex API to support different configurations for many
  notifiers (we have 3 now vs 1 when we were releasing this functionality). We
  want a simple API

* It's hard to pass the config object around. If a component that sits at the
  bottom layer of the library architecture suddenly needs to read some config
  value, we have to pass it through all the layers, from the top to the
  bottom. This was a compromise since the very beginning but back then it was
  easy to maintain it (although it always bugged me). We now rapidly add new
  features and this approach does not scale well - too much clutter

* Classes know more than they really need. As a result, testing becomes harder
  since we need to inject the config (sometimes with "correct" values).

An alternative way would be exposing the config through
`Airbrake.notifiers[:default][:notice].config.config_value`. This only adds to
the clutter since the API becomes more complex and less malleable.

On the other hand, this feature is likely not used by 90% of our customers. We
have a solid Rails workflow that never involves more than 1 notifier. If people
need another notifier, they can easily instantiate it directly through
`Airbrake::NoticeNotifier.new`.