### PR TITLE
airbrake-ruby: deprecate Airbrake#[]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Airbrake Ruby Changelog
 * Deprecated `Airbrake.create_deploy` in favour of `Airbrake.notify_deploy`
 * Deprecated `Airbrake.configure(:name)` in favour of `Airbrake.configure` or
   `Airbrake::NoticeNotifier.new`
+* Deprecated `Airbrake#[]` in favour of `Airbrake::NoticeNotifier.new`
 
 ### [v3.2.5][v3.2.5] (Feburary 20, 2019)
 

--- a/lib/airbrake-ruby.rb
+++ b/lib/airbrake-ruby.rb
@@ -191,6 +191,13 @@ module Airbrake
     # @return [Airbrake::NoticeNotifier, NilClass]
     # @since v1.8.0
     def [](notifier_name)
+      loc = caller_locations(1..1).first
+      signature = "#{self}##{__method__}"
+      warn(
+        "#{loc.path}:#{loc.lineno}: warning: #{signature} is deprecated. It " \
+        "will be removed from airbrake-ruby v4 altogether."
+      )
+
       @notice_notifiers[notifier_name]
     end
 


### PR DESCRIPTION
This goes in line with `Airbrake.configure(:name)` deprecation.