### PR TITLE
airbrake-ruby: delete deprecated Airbrake#[]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Airbrake Ruby Changelog
 * Deleted deprecated `Config#route_stats`, `Config#route_stats_flush_period`
 * `PerformanceNotifier`, `NoticeNotifier` & `DeployNotifier` stopped accepting
   deprecated Hash as a `config` object
+* Deleted deprecated `Airbrake#[]`
 
 * Reduced clutter of `DeployNotifier` and `PerformanceNotifier` when
   `inspect`ing ([#423](https://github.com/airbrake/airbrake-ruby/pull/423))

--- a/README.md
+++ b/README.md
@@ -403,17 +403,6 @@ API
 
 ### Airbrake
 
-#### Airbrake.[]
-
-Retrieves a configured *notice* notifier.
-
-```ruby
-Airbrake[:my_notifier] #=> Airbrake::NoticeNotifier
-```
-
-If the notifier is not configured, returns an instance of
-`Airbrake::NilNotifier` (a no-op version of `Airbrake::NoticeNotifier`).
-
 #### Airbrake.notifiers
 
 Returns a Hash with all notifiers (notice, performance, deploy).

--- a/lib/airbrake-ruby.rb
+++ b/lib/airbrake-ruby.rb
@@ -173,26 +173,6 @@ module Airbrake
   @deploy_notifiers = Hash.new(NilDeployNotifier.new)
 
   class << self
-    # Retrieves configured notifiers.
-    #
-    # @example
-    #   Airbrake[:my_notifier].notify('oops')
-    #
-    # @param [Symbol] notifier_name the name of the notice notifier you want to
-    #   use
-    # @return [Airbrake::NoticeNotifier, NilClass]
-    # @since v1.8.0
-    def [](notifier_name)
-      loc = caller_locations(1..1).first
-      signature = "#{self}##{__method__}"
-      warn(
-        "#{loc.path}:#{loc.lineno}: warning: #{signature} is deprecated. It " \
-        "will be removed from airbrake-ruby v4 altogether."
-      )
-
-      @notice_notifiers[notifier_name]
-    end
-
     # @return [Hash{Symbol=>Array<Object>}] a Hash with all configured notifiers
     #   (notice, performance, deploy)
     # @since v3.2.0

--- a/spec/airbrake_spec.rb
+++ b/spec/airbrake_spec.rb
@@ -1,10 +1,4 @@
 RSpec.describe Airbrake do
-  describe ".[]" do
-    it "returns a NilNotifier" do
-      expect(described_class[:test]).to be_an(Airbrake::NilNoticeNotifier)
-    end
-  end
-
   describe ".notifiers" do
     it "returns a Hash of notifiers" do
       expect(described_class.notifiers).to eq(
@@ -14,7 +8,7 @@ RSpec.describe Airbrake do
   end
 
   let(:default_notifier) do
-    described_class[:default]
+    described_class.notifiers[:notice][:default]
   end
 
   describe ".configure" do


### PR DESCRIPTION
This method is not needed now since `Airbrake[:default]` == `Airbrake`.