### PR TITLE
airbrake-ruby: delete deprecated Airbrake#notifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Airbrake Ruby Changelog
 * `PerformanceNotifier`, `NoticeNotifier` & `DeployNotifier` stopped accepting
   deprecated Hash as a `config` object
 * Deleted deprecated `Airbrake#[]`
+* Deleted deprecated `Airbrake#notifiers`
 
 * Reduced clutter of `DeployNotifier` and `PerformanceNotifier` when
   `inspect`ing ([#423](https://github.com/airbrake/airbrake-ruby/pull/423))

--- a/README.md
+++ b/README.md
@@ -403,25 +403,6 @@ API
 
 ### Airbrake
 
-#### Airbrake.notifiers
-
-Returns a Hash with all notifiers (notice, performance, deploy).
-
-```ruby
-Airbrake.notifiers
-# {
-#   :notice => {
-#     :default => ...
-#   },
-#   :performance => {
-#     :default => ...
-#   },
-#   :deploy => {
-#     :default => ...
-#   }
-# }
-```
-
 #### Airbrake.notify
 
 Sends an exception to Airbrake asynchronously.

--- a/lib/airbrake-ruby.rb
+++ b/lib/airbrake-ruby.rb
@@ -79,7 +79,6 @@ require 'airbrake-ruby/request'
 #
 # @see Airbrake::NoticeNotifier
 # @since v1.0.0
-# rubocop:disable Metrics/ModuleLength
 module Airbrake
   # The general error that this library uses when it wants to raise.
   Error = Class.new(StandardError)
@@ -174,24 +173,6 @@ module Airbrake
   @deploy_notifiers = Hash.new(NilDeployNotifier.new)
 
   class << self
-    # @return [Hash{Symbol=>Array<Object>}] a Hash with all configured notifiers
-    #   (notice, performance, deploy)
-    # @since v3.2.0
-    def notifiers
-      loc = caller_locations(1..1).first
-      signature = "#{self}##{__method__}"
-      warn(
-        "#{loc.path}:#{loc.lineno}: warning: #{signature} is deprecated. It " \
-        "will be removed from airbrake-ruby v4 altogether."
-      )
-
-      {
-        notice: @notice_notifiers,
-        performance: @performance_notifiers,
-        deploy: @deploy_notifiers
-      }
-    end
-
     # Configures the Airbrake notifier.
     #
     # @example Configuring the default notifier
@@ -207,14 +188,9 @@ module Airbrake
     #   existing notifier
     # @raise [Airbrake::Error] when either +project_id+ or +project_key+
     #   is missing (or both)
-    # @note There's no way to reconfigure a notifier
     # @note There's no way to read config values outside of this library
     def configure
       yield config = Airbrake::Config.new
-
-      if @notice_notifiers.key?(:default)
-        raise Airbrake::Error, 'Airbrake was already configured'
-      end
 
       raise Airbrake::Error, config.validation_error_message unless config.valid?
 
@@ -536,4 +512,3 @@ module Airbrake
     end
   end
 end
-# rubocop:enable Metrics/ModuleLength

--- a/spec/airbrake_spec.rb
+++ b/spec/airbrake_spec.rb
@@ -1,25 +1,9 @@
 RSpec.describe Airbrake do
-  describe ".notifiers" do
-    it "returns a Hash of notifiers" do
-      expect(described_class.notifiers).to eq(
-        notice: {}, performance: {}, deploy: {}
-      )
-    end
-  end
-
-  let(:default_notifier) do
-    described_class.notifiers[:notice][:default]
+  before do
+    Airbrake.configure { |c| c.merge(project_id: 1, project_key: 'abc') }
   end
 
   describe ".configure" do
-    let(:config_params) { { project_id: 1, project_key: 'abc' } }
-
-    after do
-      described_class.instance_variable_get(:@notice_notifiers).clear
-      described_class.instance_variable_get(:@performance_notifiers).clear
-      described_class.instance_variable_get(:@deploy_notifiers).clear
-    end
-
     it "yields the config" do
       expect do |b|
         begin
@@ -28,15 +12,6 @@ RSpec.describe Airbrake do
           nil
         end
       end.to yield_with_args(Airbrake::Config)
-    end
-
-    context "when invoked twice" do
-      it "raises Airbrake::Error" do
-        described_class.configure { |c| c.merge(config_params) }
-        expect do
-          described_class.configure { |c| c.merge(config_params) }
-        end.to raise_error(Airbrake::Error, 'Airbrake was already configured')
-      end
     end
 
     context "when user config doesn't contain a project id" do
@@ -51,99 +26,6 @@ RSpec.describe Airbrake do
         expect { described_class.configure { |c| c.project_id = 1 } }.
           to raise_error(Airbrake::Error, ':project_key is required')
       end
-    end
-  end
-
-  describe ".configured?" do
-    it "forwards 'configured?' to the notifier" do
-      expect(default_notifier).to receive(:configured?)
-      described_class.configured?
-    end
-  end
-
-  describe ".notify" do
-    it "forwards 'notify' to the notifier" do
-      block = proc {}
-      expect(default_notifier).to receive(:notify).with('ex', foo: 'bar', &block)
-      described_class.notify('ex', foo: 'bar', &block)
-    end
-  end
-
-  describe ".notify_sync" do
-    it "forwards 'notify_sync' to the notifier" do
-      block = proc {}
-      expect(default_notifier).to receive(:notify).with('ex', foo: 'bar', &block)
-      described_class.notify('ex', foo: 'bar', &block)
-    end
-  end
-
-  describe ".add_filter" do
-    it "forwards 'add_filter' to the notifier" do
-      block = proc {}
-      expect(default_notifier).to receive(:add_filter).with(nil, &block)
-      described_class.add_filter(&block)
-    end
-  end
-
-  describe ".build_notice" do
-    it "forwards 'build_notice' to the notifier" do
-      expect(default_notifier).to receive(:build_notice).with('ex', foo: 'bar')
-      described_class.build_notice('ex', foo: 'bar')
-    end
-  end
-
-  describe ".close" do
-    it "forwards 'close' to the notifier" do
-      expect(default_notifier).to receive(:close)
-      described_class.close
-    end
-  end
-
-  describe ".notify_deploy" do
-    let(:default_notifier) { described_class.notifiers[:deploy][:default] }
-
-    it "calls 'notify' on the deploy notifier" do
-      expect(default_notifier).to receive(:notify).with(foo: 'bar')
-      described_class.notify_deploy(foo: 'bar')
-    end
-  end
-
-  describe ".merge_context" do
-    it "forwards 'merge_context' to the notifier" do
-      expect(default_notifier).to receive(:merge_context).with(foo: 'bar')
-      described_class.merge_context(foo: 'bar')
-    end
-  end
-
-  describe ".notify_request" do
-    let(:default_notifier) { described_class.notifiers[:performance][:default] }
-
-    it "calls 'notify' on the route notifier" do
-      params = {
-        method: 'GET',
-        route: '/foo',
-        status_code: 200,
-        start_time: Time.new(2018, 1, 1, 0, 20, 0, 0),
-        end_time: Time.new(2018, 1, 1, 0, 19, 0, 0)
-      }
-      expect(default_notifier).to receive(:notify).with(Airbrake::Request.new(params))
-      described_class.notify_request(params)
-    end
-  end
-
-  describe ".notify_query" do
-    let(:default_notifier) { described_class.notifiers[:performance][:default] }
-
-    it "calls 'notify' on the query notifier" do
-      params = {
-        method: 'GET',
-        route: '/foo',
-        query: 'SELECT * FROM foos',
-        start_time: Time.new(2018, 1, 1, 0, 20, 0, 0),
-        end_time: Time.new(2018, 1, 1, 0, 19, 0, 0)
-      }
-      expect(default_notifier).to receive(:notify).with(Airbrake::Query.new(params))
-      described_class.notify_query(params)
     end
   end
 end


### PR DESCRIPTION
This method is no longer needed because we no longer allow configuring multiple
notifiers.

I also deleted some tests: they are duplicative and we already test that
functionality in notifiers. The wrapper is trivial enough, it doesn't introduce
anything new.