### PR TITLE
Factor out Logger to the Loggable module

### DIFF
--- a/lib/airbrake-ruby.rb
+++ b/lib/airbrake-ruby.rb
@@ -7,6 +7,7 @@ require 'socket'
 require 'time'
 
 require 'airbrake-ruby/version'
+require 'airbrake-ruby/loggable'
 require 'airbrake-ruby/config'
 require 'airbrake-ruby/config/validator'
 require 'airbrake-ruby/promise'
@@ -163,6 +164,8 @@ module Airbrake
       yield config = Airbrake::Config.new
 
       raise Airbrake::Error, config.validation_error_message unless config.valid?
+
+      Airbrake::Loggable.instance = config.logger
 
       @performance_notifier = PerformanceNotifier.new(config)
       @notice_notifier = NoticeNotifier.new(config)

--- a/lib/airbrake-ruby/backtrace.rb
+++ b/lib/airbrake-ruby/backtrace.rb
@@ -7,7 +7,7 @@ module Airbrake
   #   begin
   #     raise 'Oops!'
   #   rescue
-  #     Backtrace.parse($!, Logger.new(STDOUT))
+  #     Backtrace.parse($!)
   #   end
   #
   # @api private
@@ -114,6 +114,8 @@ module Airbrake
     end
 
     class << self
+      include Loggable
+
       private
 
       def best_regexp_for(exception)
@@ -140,7 +142,7 @@ module Airbrake
         false
       end
 
-      def stack_frame(config, regexp, stackframe)
+      def stack_frame(regexp, stackframe)
         if (match = match_frame(regexp, stackframe))
           return {
             file: match[:file],
@@ -149,7 +151,7 @@ module Airbrake
           }
         end
 
-        config.logger.error(
+        logger.error(
           "can't parse '#{stackframe}' (please file an issue so we can fix " \
           "it: https://github.com/airbrake/airbrake-ruby/issues/new)"
         )
@@ -168,7 +170,7 @@ module Airbrake
         root_directory = config.root_directory.to_s
 
         exception.backtrace.map.with_index do |stackframe, i|
-          frame = stack_frame(config, regexp, stackframe)
+          frame = stack_frame(regexp, stackframe)
           next(frame) if !config.code_hunks || frame[:file].nil?
 
           if !root_directory.empty?

--- a/lib/airbrake-ruby/code_hunk.rb
+++ b/lib/airbrake-ruby/code_hunk.rb
@@ -9,6 +9,8 @@ module Airbrake
     # @return [Integer] how many lines should be read around the base line
     NLINES = 2
 
+    include Loggable
+
     def initialize(config)
       @config = config
     end
@@ -31,7 +33,7 @@ module Airbrake
     def get_from_cache(file)
       Airbrake::FileCache[file] ||= File.foreach(file)
     rescue StandardError => ex
-      @config.logger.error(
+      logger.error(
         "#{self.class.name}: can't read code hunk for #{file}: #{ex}"
       )
       nil

--- a/lib/airbrake-ruby/config.rb
+++ b/lib/airbrake-ruby/config.rb
@@ -97,7 +97,6 @@ module Airbrake
 
     # @param [Hash{Symbol=>Object}] user_config the hash to be used to build the
     #   config
-    # rubocop:disable Metrics/AbcSize
     def initialize(user_config = {})
       @validator = Config::Validator.new(self)
 
@@ -105,10 +104,7 @@ module Airbrake
       self.queue_size = 100
       self.workers = 1
       self.code_hunks = true
-
-      self.logger = Logger.new(STDOUT)
-      logger.level = Logger::WARN
-
+      self.logger = ::Logger.new(File::NULL)
       self.project_id = user_config[:project_id]
       self.project_key = user_config[:project_key]
       self.host = 'https://api.airbrake.io'
@@ -131,7 +127,6 @@ module Airbrake
 
       merge(user_config)
     end
-    # rubocop:enable Metrics/AbcSize
 
     # The full URL to the Airbrake Notice API. Based on the +:host+ option.
     # @return [URI] the endpoint address

--- a/lib/airbrake-ruby/filters/exception_attributes_filter.rb
+++ b/lib/airbrake-ruby/filters/exception_attributes_filter.rb
@@ -6,8 +6,9 @@ module Airbrake
     # @api private
     # @since v2.10.0
     class ExceptionAttributesFilter
-      def initialize(logger)
-        @logger = logger
+      include Loggable
+
+      def initialize
         @weight = 118
       end
 
@@ -20,13 +21,13 @@ module Airbrake
         begin
           attributes = exception.to_airbrake
         rescue StandardError => ex
-          @logger.error(
+          logger.error(
             "#{LOG_LABEL} #{exception.class}#to_airbrake failed. #{ex.class}: #{ex}"
           )
         end
 
         unless attributes.is_a?(Hash)
-          @logger.error(
+          logger.error(
             "#{LOG_LABEL} #{self.class}: wanted Hash, got #{attributes.class}"
           )
           return

--- a/lib/airbrake-ruby/filters/git_last_checkout_filter.rb
+++ b/lib/airbrake-ruby/filters/git_last_checkout_filter.rb
@@ -20,11 +20,11 @@ module Airbrake
       #   file (checkout information is omitted)
       MIN_HEAD_COLS = 6
 
-      # @param [Logger] logger
+      include Loggable
+
       # @param [String] root_directory
-      def initialize(logger, root_directory)
+      def initialize(root_directory)
         @git_path = File.join(root_directory, '.git')
-        @logger = logger
         @weight = 116
         @last_checkout = nil
       end
@@ -45,12 +45,13 @@ module Airbrake
 
       private
 
+      # rubocop:disable Metrics/AbcSize
       def last_checkout
         return unless (line = last_checkout_line)
 
         parts = line.chomp.split("\t").first.split(' ')
         if parts.size < MIN_HEAD_COLS
-          @logger.error(
+          logger.error(
             "#{LOG_LABEL} Airbrake::#{self.class.name}: can't parse line: #{line}"
           )
           return
@@ -64,6 +65,7 @@ module Airbrake
           time: timestamp(parts[-2].to_i)
         }
       end
+      # rubocop:enable Metrics/AbcSize
 
       def last_checkout_line
         head_path = File.join(@git_path, 'logs', 'HEAD')

--- a/lib/airbrake-ruby/filters/keys_blacklist.rb
+++ b/lib/airbrake-ruby/filters/keys_blacklist.rb
@@ -5,7 +5,6 @@ module Airbrake
     #
     # @example
     #   filter = Airbrake::Filters::KeysBlacklist.new(
-    #     Logger.new(STDOUT),
     #     [:email, /credit/i, 'password']
     #   )
     #   airbrake.add_filter(filter)

--- a/lib/airbrake-ruby/filters/keys_filter.rb
+++ b/lib/airbrake-ruby/filters/keys_filter.rb
@@ -26,16 +26,16 @@ module Airbrake
       #   be modified by blacklist/whitelist filters
       FILTERABLE_CONTEXT_KEYS = %i[user headers].freeze
 
+      include Loggable
+
       # @return [Integer]
       attr_reader :weight
 
       # Creates a new KeysBlacklist or KeysWhitelist filter that uses the given
       # +patterns+ for filtering a notice's payload.
       #
-      # @param [Logger, #error] logger
       # @param [Array<String,Regexp,Symbol>] patterns
-      def initialize(logger, patterns)
-        @logger = logger
+      def initialize(patterns)
         @patterns = patterns
         @valid_patterns = false
       end
@@ -122,7 +122,7 @@ module Airbrake
 
         return if @valid_patterns
 
-        @logger.error(
+        logger.error(
           "#{LOG_LABEL} one of the patterns in #{self.class} is invalid. " \
           "Known patterns: #{@patterns}"
         )

--- a/lib/airbrake-ruby/filters/keys_whitelist.rb
+++ b/lib/airbrake-ruby/filters/keys_whitelist.rb
@@ -5,7 +5,6 @@ module Airbrake
     #
     # @example
     #   filter = Airbrake::Filters::KeysBlacklist.new(
-    #     Logger.new(STDOUT),
     #     [:email, /credit/i, 'password']
     #   )
     #   airbrake.add_filter(filter)

--- a/lib/airbrake-ruby/loggable.rb
+++ b/lib/airbrake-ruby/loggable.rb
@@ -1,0 +1,31 @@
+module Airbrake
+  # Loggable is included into any class that wants to be able to log.
+  #
+  # By default, Loggable defines a null logger that doesn't do anything. You are
+  # supposed to overwrite it via the {instance} method before calling {logger}.
+  #
+  # @example
+  #   class A
+  #     include Loggable
+  #
+  #     def initialize
+  #       logger.debug('Initialized A')
+  #     end
+  #   end
+  #
+  # @since v4.0.0
+  # @api private
+  module Loggable
+    @instance = ::Logger.new(File::NULL)
+
+    class << self
+      # @return [Logger]
+      attr_accessor :instance
+    end
+
+    # @return [Logger] standard Ruby logger object
+    def logger
+      Loggable.instance
+    end
+  end
+end

--- a/lib/airbrake-ruby/notice.rb
+++ b/lib/airbrake-ruby/notice.rb
@@ -50,6 +50,7 @@ module Airbrake
     DEFAULT_SEVERITY = 'error'.freeze
 
     include Ignorable
+    include Loggable
 
     # @since v1.7.0
     # @return [Hash{Symbol=>Object}] the hash with arbitrary objects to be used
@@ -84,7 +85,7 @@ module Airbrake
         begin
           json = @payload.to_json
         rescue *JSON_EXCEPTIONS => ex
-          @config.logger.debug("#{LOG_LABEL} `notice.to_json` failed: #{ex.class}: #{ex}")
+          logger.debug("#{LOG_LABEL} `notice.to_json` failed: #{ex.class}: #{ex}")
         else
           return json if json && json.bytesize <= MAX_NOTICE_SIZE
         end
@@ -152,7 +153,7 @@ module Airbrake
 
       new_max_size = @truncator.reduce_max_size
       if new_max_size == 0
-        @config.logger.error(
+        logger.error(
           "#{LOG_LABEL} truncation failed. File an issue at " \
           "https://github.com/airbrake/airbrake-ruby " \
           "and attach the following payload: #{@payload}"

--- a/lib/airbrake-ruby/performance_notifier.rb
+++ b/lib/airbrake-ruby/performance_notifier.rb
@@ -6,6 +6,7 @@ module Airbrake
   # @since v3.2.0
   class PerformanceNotifier
     include Inspectable
+    include Loggable
 
     # @param [Airbrake::Config] config
     def initialize(config)
@@ -79,7 +80,7 @@ module Airbrake
       signature = "#{self.class.name}##{__method__}"
       raise "#{signature}: payload (#{payload}) cannot be empty. Race?" if payload.none?
 
-      @config.logger.debug("#{LOG_LABEL} #{signature}: #{payload}")
+      logger.debug("#{LOG_LABEL} #{signature}: #{payload}")
 
       payload.group_by { |k, _v| k.name }.each do |resource_name, data|
         @sender.send(

--- a/lib/airbrake-ruby/response.rb
+++ b/lib/airbrake-ruby/response.rb
@@ -11,13 +11,16 @@ module Airbrake
     # @return [Integer] HTTP code returned when an IP sends over 10k/min notices
     TOO_MANY_REQUESTS = 429
 
+    class << self
+      include Loggable
+    end
+
     # Parses HTTP responses from the Airbrake API.
     #
     # @param [Net::HTTPResponse] response
-    # @param [Logger] logger
     # @return [Hash{String=>String}] parsed response
     # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
-    def self.parse(response, logger)
+    def self.parse(response)
       code = response.code.to_i
       body = response.body
 

--- a/lib/airbrake-ruby/sync_sender.rb
+++ b/lib/airbrake-ruby/sync_sender.rb
@@ -9,6 +9,8 @@ module Airbrake
     # @return [String] body for HTTP requests
     CONTENT_TYPE = 'application/json'.freeze
 
+    include Loggable
+
     # @param [Airbrake::Config] config
     def initialize(config, method = :post)
       @config = config
@@ -35,11 +37,11 @@ module Airbrake
         response = https.request(req)
       rescue StandardError => ex
         reason = "#{LOG_LABEL} HTTP error: #{ex}"
-        @config.logger.error(reason)
+        logger.error(reason)
         return promise.reject(reason)
       end
 
-      parsed_resp = Response.parse(response, @config.logger)
+      parsed_resp = Response.parse(response)
       if parsed_resp.key?('rate_limit_reset')
         @rate_limit_reset = parsed_resp['rate_limit_reset']
       end
@@ -101,7 +103,7 @@ module Airbrake
 
       if missing
         reason = "#{LOG_LABEL} data was not sent because of missing body"
-        @config.logger.error(reason)
+        logger.error(reason)
         promise.reject(reason)
       end
 

--- a/spec/async_sender_spec.rb
+++ b/spec/async_sender_spec.rb
@@ -1,91 +1,108 @@
 RSpec.describe Airbrake::AsyncSender do
-  before do
-    stub_request(:post, /.*/).to_return(status: 201, body: '{}')
+  let(:endpoint) { 'https://api.airbrake.io/api/v3/projects/1/notices' }
+  let(:queue_size) { 10 }
+
+  let(:config) do
+    Airbrake::Config.new(
+      project_id: '1',
+      workers: 3,
+      queue_size: queue_size
+    )
   end
 
+  let(:notice) { Airbrake::Notice.new(config, AirbrakeTestError.new) }
+
+  before do
+    stub_request(:post, endpoint).to_return(status: 201, body: '{}')
+    allow(Airbrake::Loggable.instance).to receive(:debug)
+    expect(subject).to have_workers
+  end
+
+  subject { described_class.new(config) }
+
   describe "#send" do
-    it "limits the size of the queue" do
-      stdout = StringIO.new
-      notices_count = 1000
-      queue_size = 10
-      config = Airbrake::Config.new(
-        logger: Logger.new(stdout), workers: 3, queue_size: queue_size
-      )
-      sender = described_class.new(config)
-      expect(sender).to have_workers
+    it "sends payload to Airbrake" do
+      2.times do
+        subject.send(notice, Airbrake::Promise.new)
+      end
+      subject.close
 
-      notice = Airbrake::Notice.new(config, AirbrakeTestError.new)
-      notices_count.times { sender.send(notice, Airbrake::Promise.new) }
-      sender.close
+      expect(a_request(:post, endpoint)).to have_been_made.twice
+    end
 
-      log = stdout.string.split("\n")
-      notices_sent    = log.grep(/\*\*Airbrake: Airbrake::Response \(201\): \{\}/).size
-      notices_dropped = log.grep(/\*\*Airbrake:.*not.*delivered/).size
-      expect(notices_sent).to be >= queue_size
-      expect(notices_sent + notices_dropped).to eq(notices_count)
+    context "when the queue is full" do
+      before do
+        allow(subject.unsent).to receive(:size).and_return(queue_size)
+      end
+
+      it "discards payload" do
+        200.times do
+          subject.send(notice, Airbrake::Promise.new)
+        end
+        subject.close
+
+        expect(a_request(:post, endpoint)).not_to have_been_made
+      end
+
+      it "logs discarded payload" do
+        expect(Airbrake::Loggable.instance).to receive(:error).with(
+          /reached its capacity/
+        ).exactly(15).times
+
+        15.times do
+          subject.send(notice, Airbrake::Promise.new)
+        end
+        subject.close
+      end
     end
   end
 
   describe "#close" do
-    before do
-      @stderr = StringIO.new
-      config = Airbrake::Config.new(logger: Logger.new(@stderr))
-      @sender = described_class.new(config)
-      expect(@sender).to have_workers
-    end
-
     context "when there are no unsent notices" do
       it "joins the spawned thread" do
-        workers = @sender.instance_variable_get(:@workers).list
-
+        workers = subject.workers.list
         expect(workers).to all(be_alive)
-        @sender.close
+
+        subject.close
         expect(workers).to all(be_stop)
       end
     end
 
     context "when there are some unsent notices" do
-      before do
-        notice = Airbrake::Notice.new(Airbrake::Config.new, AirbrakeTestError.new)
-        300.times { @sender.send(notice, Airbrake::Promise.new) }
-        expect(@sender.instance_variable_get(:@unsent).size).not_to be_zero
-        @sender.close
-      end
+      it "logs how many notices are left to send" do
+        expect(Airbrake::Loggable.instance).to receive(:debug).with(
+          /waiting to send \d+ unsent notice\(s\)/
+        )
+        expect(Airbrake::Loggable.instance).to receive(:debug).with(/closed/)
 
-      it "warns about the number of notices" do
-        expect(@stderr.string).to match(/waiting to send \d+ unsent notice/)
-      end
-
-      it "prints the correct number of log messages" do
-        log = @stderr.string.split("\n")
-        notices_sent    = log.grep(/\*\*Airbrake: Airbrake::Response \(201\): \{\}/).size
-        notices_dropped = log.grep(/\*\*Airbrake:.*not.*delivered/).size
-        expect(notices_sent).to be >= @sender.instance_variable_get(:@unsent).max
-        expect(notices_sent + notices_dropped).to eq(300)
+        300.times { subject.send(notice, Airbrake::Promise.new) }
+        subject.close
       end
 
       it "waits until the unsent notices queue is empty" do
-        expect(@sender.instance_variable_get(:@unsent).size).to be_zero
+        subject.close
+        expect(subject.unsent.size).to be_zero
       end
     end
 
     context "when it was already closed" do
       it "doesn't increase the unsent queue size" do
         begin
-          @sender.close
+          subject.close
         rescue Airbrake::Error
           nil
         end
 
-        expect(@sender.instance_variable_get(:@unsent).size).to be_zero
+        expect(subject.unsent.size).to be_zero
       end
 
       it "raises error" do
-        @sender.close
+        subject.close
 
-        expect(@sender).to be_closed
-        expect { @sender.close }.
-          to raise_error(Airbrake::Error, 'attempted to close already closed sender')
+        expect(subject).to be_closed
+        expect { subject.close }.to raise_error(
+          Airbrake::Error, 'attempted to close already closed sender'
+        )
       end
     end
 
@@ -100,55 +117,38 @@ RSpec.describe Airbrake::AsyncSender do
   end
 
   describe "#has_workers?" do
-    before do
-      @sender = described_class.new(Airbrake::Config.new)
-      expect(@sender).to have_workers
-    end
-
     it "returns false when the sender is not closed, but has 0 workers" do
-      @sender.instance_variable_get(:@workers).list.each(&:kill)
-      sleep 1
-      expect(@sender).not_to have_workers
+      subject.workers.list.each do |worker|
+        worker.kill.join
+      end
+      expect(subject).not_to have_workers
     end
 
     it "returns false when the sender is closed" do
-      @sender.close
-      expect(@sender).not_to have_workers
+      subject.close
+      expect(subject).not_to have_workers
     end
 
     it "respawns workers on fork()", skip: %w[jruby rbx].include?(RUBY_ENGINE) do
-      pid = fork do
-        expect(@sender).to have_workers
-      end
+      pid = fork { expect(subject).to have_workers }
       Process.wait(pid)
-      @sender.close
-      expect(@sender).not_to have_workers
+      subject.close
+      expect(subject).not_to have_workers
     end
   end
 
   describe "#spawn_workers" do
     it "spawns alive threads in an enclosed ThreadGroup" do
-      sender = described_class.new(Airbrake::Config.new)
-      expect(sender).to have_workers
+      expect(subject.workers).to be_a(ThreadGroup)
+      expect(subject.workers.list).to all(be_alive)
+      expect(subject.workers).to be_enclosed
 
-      workers = sender.instance_variable_get(:@workers)
-
-      expect(workers).to be_a(ThreadGroup)
-      expect(workers.list).to all(be_alive)
-      expect(workers).to be_enclosed
-
-      sender.close
+      subject.close
     end
 
     it "spawns exactly config.workers workers" do
-      workers_count = 5
-      sender = described_class.new(Airbrake::Config.new(workers: workers_count))
-      expect(sender).to have_workers
-
-      workers = sender.instance_variable_get(:@workers)
-
-      expect(workers.list.size).to eq(workers_count)
-      sender.close
+      expect(subject.workers.list.size).to eq(config.workers)
+      subject.close
     end
   end
 end

--- a/spec/backtrace_spec.rb
+++ b/spec/backtrace_spec.rb
@@ -182,14 +182,11 @@ RSpec.describe Airbrake::Backtrace do
         ).to eq([file: nil, line: nil, function: 'a b c 1 23 321 .rb'])
       end
 
-      it "logs unknown frames as errors" do
-        out = StringIO.new
-        config.logger = Logger.new(out)
-
-        expect { described_class.parse(config, ex) }.
-          to change { out.string }.
-          from('').
-          to(/ERROR -- : can't parse 'a b c 1 23 321 .rb'/)
+      it "logs frames that cannot be parsed" do
+        expect(Airbrake::Loggable.instance).to receive(:error).with(
+          /can't parse 'a b c 1 23 321 .rb'/
+        )
+        described_class.parse(config, ex)
       end
     end
 

--- a/spec/code_hunk_spec.rb
+++ b/spec/code_hunk_spec.rb
@@ -1,6 +1,8 @@
 RSpec.describe Airbrake::CodeHunk do
   let(:config) { Airbrake::Config.new }
 
+  subject { described_class.new(config) }
+
   after do
     %w[empty_file.rb code.rb banana.rb short_file.rb long_line.txt].each do |f|
       Airbrake::FileCache[project_root_path(f)] = nil
@@ -105,13 +107,12 @@ RSpec.describe Airbrake::CodeHunk do
       end
 
       it "logs error and returns nil" do
-        out = StringIO.new
-        config = Airbrake::Config.new
-        config.logger = Logger.new(out)
-        expect(described_class.new(config).get(project_root_path('code.rb'), 1)).to(
+        expect(Airbrake::Loggable.instance).to receive(:error).with(
+          /can't read code hunk.+Permission denied/
+        )
+        expect(subject.get(project_root_path('code.rb'), 1)).to(
           eq(1 => '')
         )
-        expect(out.string).to match(/can't read code hunk.+Permission denied/)
       end
     end
   end

--- a/spec/filters/exception_attributes_filter_spec.rb
+++ b/spec/filters/exception_attributes_filter_spec.rb
@@ -1,9 +1,6 @@
 RSpec.describe Airbrake::Filters::ExceptionAttributesFilter do
   describe "#call" do
-    let(:out) { StringIO.new }
     let(:notice) { Airbrake::Notice.new(Airbrake::Config.new, ex) }
-
-    subject { described_class.new(Logger.new(out)) }
 
     context "when #to_airbrake returns a non-Hash object" do
       let(:ex) do
@@ -17,11 +14,6 @@ RSpec.describe Airbrake::Filters::ExceptionAttributesFilter do
       it "doesn't raise" do
         expect { subject.call(notice) }.not_to raise_error
         expect(notice[:params]).to be_empty
-      end
-
-      it "logs the error" do
-        expect { subject.call(notice) }.not_to raise_error
-        expect(out.string).to match(/wanted Hash, got Object/)
       end
     end
 
@@ -37,11 +29,6 @@ RSpec.describe Airbrake::Filters::ExceptionAttributesFilter do
       it "doesn't raise" do
         expect { subject.call(notice) }.not_to raise_error
         expect(notice[:params]).to be_empty
-      end
-
-      it "logs the error" do
-        expect { subject.call(notice) }.not_to raise_error
-        expect(out.string).to match(/#to_airbrake failed.+ZeroDivisionError/)
       end
     end
 

--- a/spec/filters/git_last_checkout_filter_spec.rb
+++ b/spec/filters/git_last_checkout_filter_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Airbrake::Filters::GitLastCheckoutFilter do
-  subject { described_class.new(Logger.new(STDOUT), '.') }
+  subject { described_class.new('.') }
 
   let(:notice) do
     Airbrake::Notice.new(Airbrake::Config.new, AirbrakeTestError.new)
@@ -14,7 +14,7 @@ RSpec.describe Airbrake::Filters::GitLastCheckoutFilter do
   end
 
   context "when .git directory doesn't exist" do
-    subject { described_class.new(Logger.new(STDOUT), 'root/dir') }
+    subject { described_class.new('root/dir') }
 
     it "doesn't attach anything to context/lastCheckout" do
       subject.call(notice)

--- a/spec/filters/keys_blacklist_spec.rb
+++ b/spec/filters/keys_blacklist_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Airbrake::Filters::KeysBlacklist do
-  subject { described_class.new(Logger.new('/dev/null'), patterns) }
+  subject { described_class.new(patterns) }
 
   let(:notice) do
     Airbrake::Notice.new(Airbrake::Config.new, AirbrakeTestError.new)
@@ -92,14 +92,11 @@ RSpec.describe Airbrake::Filters::KeysBlacklist do
       )
 
       it "logs an error" do
-        out = StringIO.new
-        logger = Logger.new(out)
-        keys_blacklist = described_class.new(logger, patterns)
-        keys_blacklist.call(notice)
-
-        expect(out.string).to(
-          match(/ERROR.+KeysBlacklist is invalid.+patterns: \[#<Object:.+>\]/)
+        expect(Airbrake::Loggable.instance).to receive(:error).with(
+          /KeysBlacklist is invalid.+patterns: \[#<Object:.+>\]/
         )
+        keys_blacklist = described_class.new(patterns)
+        keys_blacklist.call(notice)
       end
     end
 
@@ -108,14 +105,11 @@ RSpec.describe Airbrake::Filters::KeysBlacklist do
 
       context "and when the filter is called once" do
         it "logs an error" do
-          out = StringIO.new
-          logger = Logger.new(out)
-          keys_blacklist = described_class.new(logger, patterns)
-          keys_blacklist.call(notice)
-
-          expect(out.string).to(
-            match(/ERROR.+KeysBlacklist is invalid.+patterns: \[#<Proc:.+>\]/)
+          expect(Airbrake::Loggable.instance).to receive(:error).with(
+            /KeysBlacklist is invalid.+patterns: \[#<Proc:.+>\]/
           )
+          keys_blacklist = described_class.new(patterns)
+          keys_blacklist.call(notice)
         end
       end
 
@@ -140,14 +134,11 @@ RSpec.describe Airbrake::Filters::KeysBlacklist do
     )
 
     it "logs an error" do
-      out = StringIO.new
-      logger = Logger.new(out)
-      keys_blacklist = described_class.new(logger, patterns)
-      keys_blacklist.call(notice)
-
-      expect(out.string).to(
-        match(/ERROR.+KeysBlacklist is invalid.+patterns: \[#<Object:.+>\]/)
+      expect(Airbrake::Loggable.instance).to receive(:error).with(
+        /KeysBlacklist is invalid.+patterns: \[#<Object:.+>\]/
       )
+      keys_blacklist = described_class.new(patterns)
+      keys_blacklist.call(notice)
     end
   end
 

--- a/spec/filters/keys_whitelist_spec.rb
+++ b/spec/filters/keys_whitelist_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Airbrake::Filters::KeysWhitelist do
-  subject { described_class.new(Logger.new('/dev/null'), patterns) }
+  subject { described_class.new(patterns) }
 
   let(:notice) do
     Airbrake::Notice.new(Airbrake::Config.new, AirbrakeTestError.new)
@@ -71,14 +71,11 @@ RSpec.describe Airbrake::Filters::KeysWhitelist do
       )
 
       it "logs an error" do
-        out = StringIO.new
-        logger = Logger.new(out)
-        keys_whitelist = described_class.new(logger, patterns)
-        keys_whitelist.call(notice)
-
-        expect(out.string).to(
-          match(/ERROR.+KeysWhitelist is invalid.+patterns: \[#<Object:.+>\]/)
+        expect(Airbrake::Loggable.instance).to receive(:error).with(
+          /KeysWhitelist is invalid.+patterns: \[#<Object:.+>\]/
         )
+        keys_whitelist = described_class.new(patterns)
+        keys_whitelist.call(notice)
       end
     end
 
@@ -87,14 +84,11 @@ RSpec.describe Airbrake::Filters::KeysWhitelist do
 
       context "and when the filter is called once" do
         it "logs an error" do
-          out = StringIO.new
-          logger = Logger.new(out)
-          keys_whitelist = described_class.new(logger, patterns)
-          keys_whitelist.call(notice)
-
-          expect(out.string).to(
-            match(/ERROR.+KeysWhitelist is invalid.+patterns: \[#<Proc:.+>\]/)
+          expect(Airbrake::Loggable.instance).to receive(:error).with(
+            /KeysWhitelist is invalid.+patterns: \[#<Proc:.+>\]/
           )
+          keys_whitelist = described_class.new(patterns)
+          keys_whitelist.call(notice)
         end
 
         include_examples(
@@ -120,14 +114,11 @@ RSpec.describe Airbrake::Filters::KeysWhitelist do
     )
 
     it "logs an error" do
-      out = StringIO.new
-      logger = Logger.new(out)
-      keys_whitelist = described_class.new(logger, patterns)
-      keys_whitelist.call(notice)
-
-      expect(out.string).to(
-        match(/ERROR.+KeysWhitelist is invalid.+patterns: \[#<Object:.+>\]/)
+      expect(Airbrake::Loggable.instance).to receive(:error).with(
+        /KeysWhitelist is invalid.+patterns: \[#<Object:.+>\]/
       )
+      keys_whitelist = described_class.new(patterns)
+      keys_whitelist.call(notice)
     end
   end
 


### PR DESCRIPTION
Since the Airbrake module holds only one instance of every notifier, it opens
the gate to centralised logging. We no longer need to toss logger instances
around and inject them into every class that needs logging.

It always bothered me that we were doing it but it was the only way to go if we
wanted to maintain a fat wrapper that the Airbrake module was. Loggable is super
easy to use and I was able to `include` and it "just worked". Moreover, testing
is a ton easier now.