### PR TITLE
performance_notifier: attach 'environment' to the top level of JSON

### DIFF
--- a/lib/airbrake-ruby/performance_notifier.rb
+++ b/lib/airbrake-ruby/performance_notifier.rb
@@ -87,6 +87,7 @@ module Airbrake
       end
     end
 
+    # rubocop:disable Metrics/AbcSize
     def send(payload, promise)
       signature = "#{self.class.name}##{__method__}"
       raise "#{signature}: payload (#{payload}) cannot be empty. Race?" if payload.none?
@@ -94,8 +95,11 @@ module Airbrake
       @config.logger.debug("#{LOG_LABEL} #{signature}: #{payload}")
 
       payload.group_by { |k, _v| k.name }.each do |resource_name, data|
+        data = { resource_name => data.map { |k, v| k.to_h.merge!(v.to_h) } }
+        data['environment'] = @config.environment if @config.environment
+
         @sender.send(
-          { resource_name => data.map { |k, v| k.to_h.merge!(v.to_h) } },
+          data,
           promise,
           URI.join(
             @config.host,
@@ -104,5 +108,6 @@ module Airbrake
         )
       end
     end
+    # rubocop:enable Metrics/AbcSize
   end
 end

--- a/lib/airbrake-ruby/query.rb
+++ b/lib/airbrake-ruby/query.rb
@@ -6,14 +6,12 @@ module Airbrake
   # @since v3.2.0
   # rubocop:disable Metrics/ParameterLists, Metrics/BlockLength
   Query = Struct.new(
-    :environment, :method, :route, :query, :func, :file, :line, :start_time,
-    :end_time
+    :method, :route, :query, :func, :file, :line, :start_time, :end_time
   ) do
     include HashKeyable
     include Ignorable
 
     def initialize(
-      environment: nil,
       method:,
       route:,
       query:,
@@ -23,10 +21,7 @@ module Airbrake
       start_time:,
       end_time: Time.now
     )
-      super(
-        environment, method, route, query, func, file, line, start_time,
-        end_time
-      )
+      super(method, route, query, func, file, line, start_time, end_time)
     end
 
     def name
@@ -35,7 +30,6 @@ module Airbrake
 
     def to_h
       {
-        'environment' => environment,
         'method' => method,
         'route' => route,
         'query' => query,

--- a/lib/airbrake-ruby/request.rb
+++ b/lib/airbrake-ruby/request.rb
@@ -4,22 +4,18 @@ module Airbrake
   # @see Airbrake.notify_request
   # @api public
   # @since v3.2.0
-  # rubocop:disable Metrics/ParameterLists
-  Request = Struct.new(
-    :environment, :method, :route, :status_code, :start_time, :end_time
-  ) do
+  Request = Struct.new(:method, :route, :status_code, :start_time, :end_time) do
     include HashKeyable
     include Ignorable
 
     def initialize(
-      environment: nil,
       method:,
       route:,
       status_code:,
       start_time:,
       end_time: Time.now
     )
-      super(environment, method, route, status_code, start_time, end_time)
+      super(method, route, status_code, start_time, end_time)
     end
 
     def name
@@ -28,7 +24,6 @@ module Airbrake
 
     def to_h
       {
-        'environment' => environment,
         'method' => method,
         'route' => route,
         'statusCode' => status_code,
@@ -36,5 +31,4 @@ module Airbrake
       }.delete_if { |_key, val| val.nil? }
     end
   end
-  # rubocop:enable Metrics/ParameterLists
 end


### PR DESCRIPTION
There was a change in the backend: instead of sending environment information
with every request/query, we send it at the top level of the JSON payload.

This is a breaking change but the airbrake gem hasn't been updated yet to work
with environments, so it's not a huge deal.