### PR TITLE
Fixed incorrect "instance" definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Airbrake Ruby Changelog
 
 * Fixed bug in `Airbrake.configure` not setting `logger` properly
   ([#442](https://github.com/airbrake/airbrake-ruby/pull/442))
+* Fixed bug with `Airbrake::Config.instance` returning a broken Config instance
+  ([#443](https://github.com/airbrake/airbrake-ruby/pull/443))
 
 ### [v4.0.0][v4.0.0] (Feburary 25, 2019)
 

--- a/lib/airbrake-ruby/config.rb
+++ b/lib/airbrake-ruby/config.rb
@@ -5,13 +5,6 @@ module Airbrake
   # @api public
   # @since v1.0.0
   class Config
-    @instance = new
-
-    class << self
-      # @return [Config]
-      attr_accessor :instance
-    end
-
     # @return [Integer] the project identificator. This value *must* be set.
     # @api public
     attr_accessor :project_id
@@ -101,6 +94,16 @@ module Airbrake
     # @api public
     # @since v3.2.0
     attr_accessor :performance_stats_flush_period
+
+    class << self
+      # @param [Config] new_instance
+      attr_writer :instance
+
+      # @return [Config]
+      def instance
+        @instance ||= new
+      end
+    end
 
     # @param [Hash{Symbol=>Object}] user_config the hash to be used to build the
     #   config

--- a/lib/airbrake-ruby/loggable.rb
+++ b/lib/airbrake-ruby/loggable.rb
@@ -16,11 +16,14 @@ module Airbrake
   # @since v4.0.0
   # @api private
   module Loggable
-    @instance = ::Logger.new(File::NULL)
-
     class << self
+      # @param [Logger] logger
+      attr_writer :instance
+
       # @return [Logger]
-      attr_accessor :instance
+      def instance
+        @instance ||= ::Logger.new(File::NULL)
+      end
     end
 
     # @return [Logger] standard Ruby logger object


### PR DESCRIPTION
There's a bug in v4.0.0, which prevents using `Airbrake.configure`. This is
because we instantiate in a weird way: the objects we instantiate don't have any
implementation *yet* and they contain no methods.

If we instantiate after the class has methods, everything will operate normally.