### PR TITLE
Return a rejected promise on #notify when Airbrake is not configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Airbrake Ruby Changelog
 
 ### master
 
+* `add_filter` & `add_performance_filter` add filters even when Airbrake is not
+  configured ([#445](https://github.com/airbrake/airbrake-ruby/pull/445))
+
 ### [v4.0.1][v4.0.1] (Feburary 26, 2019)
 
 * Fixed bug in `Airbrake.configure` not setting `logger` properly

--- a/lib/airbrake-ruby.rb
+++ b/lib/airbrake-ruby.rb
@@ -77,71 +77,9 @@ module Airbrake
   # @!macro see_public_api_method
   #   @see Airbrake.$0
 
-  # NilNoticeNotifier is a no-op notice notifier, which mimics
-  # +Airbrake::NoticeNotifier+ and serves only the purpose of making the library
-  # API easier to use.
-  #
-  # @since v2.1.0
-  class NilNoticeNotifier
-    # @macro see_public_api_method
-    def notify(_exception, _params = {}, &block); end
-
-    # @macro see_public_api_method
-    def notify_sync(_exception, _params = {}, &block); end
-
-    # @macro see_public_api_method
-    def add_filter(_filter = nil, &_block); end
-
-    # @macro see_public_api_method
-    def delete_filter(_filter_class); end
-
-    # @macro see_public_api_method
-    def build_notice(_exception, _params = {}); end
-
-    # @macro see_public_api_method
-    def close; end
-
-    # @macro see_public_api_method
-    def configured?
-      false
-    end
-
-    # @macro see_public_api_method
-    def merge_context(_context); end
-  end
-
-  # NilPerformanceNotifier is a no-op notifier, which mimics
-  # {Airbrake::PerformanceNotifier} and serves only the purpose of making the
-  # library API easier to use.
-  #
-  # @since v3.2.0
-  class NilPerformanceNotifier
-    # @see Airbrake.notify_request
-    # @see Airbrake.notify_query
-    def notify(_performance_info); end
-
-    # @see Airbrake.notify_request
-    # @see Airbrake.notify_query
-    def add_filter(_filter = nil, &_block); end
-
-    # @see Airbrake.notify_request
-    # @see Airbrake.notify_query
-    def delete_filter(_filter_class); end
-  end
-
-  # NilDeployNotifier is a no-op notifier, which mimics
-  # {Airbrake::DeployNotifier} and serves only the purpose of making the library
-  # API easier to use.
-  #
-  # @since v3.2.0
-  class NilDeployNotifier
-    # @see Airbrake.notify_deploy
-    def notify(_deploy_info); end
-  end
-
-  @notice_notifier = NilNoticeNotifier.new
-  @performance_notifier = NilPerformanceNotifier.new
-  @deploy_notifier = NilDeployNotifier.new
+  @performance_notifier = PerformanceNotifier.new
+  @notice_notifier = NoticeNotifier.new
+  @deploy_notifier = DeployNotifier.new
 
   class << self
     # Configures the Airbrake notifier.
@@ -166,10 +104,6 @@ module Airbrake
       raise Airbrake::Error, config.validation_error_message unless config.valid?
 
       Airbrake::Loggable.instance = config.logger
-
-      @performance_notifier = PerformanceNotifier.new
-      @notice_notifier = NoticeNotifier.new
-      @deploy_notifier = DeployNotifier.new
     end
 
     # @return [Boolean] true if the notifier was configured, false otherwise
@@ -217,7 +151,7 @@ module Airbrake
     # @yield [notice] The notice to filter
     # @yieldparam [Airbrake::Notice]
     # @yieldreturn [void]
-    # @return [Hash{String=>String}] the reponse from the server
+    # @return [Airbrake::Promise]
     # @see .notify
     def notify_sync(exception, params = {}, &block)
       @notice_notifier.notify_sync(exception, params, &block)

--- a/lib/airbrake-ruby/deploy_notifier.rb
+++ b/lib/airbrake-ruby/deploy_notifier.rb
@@ -19,6 +19,10 @@ module Airbrake
 
     # @see Airbrake.notify_deploy
     def notify(deploy_info, promise = Airbrake::Promise.new)
+      unless @config.valid?
+        return promise.reject("Notice not sent: config is invalid or not configured")
+      end
+
       if @config.ignored_environment?
         return promise.reject("The '#{@config.environment}' environment is ignored")
       end

--- a/lib/airbrake-ruby/notice_notifier.rb
+++ b/lib/airbrake-ruby/notice_notifier.rb
@@ -96,6 +96,11 @@ module Airbrake
 
     def send_notice(exception, params, sender)
       promise = Airbrake::Promise.new
+
+      unless configured?
+        return promise.reject("Notice not sent: config is invalid or not configured")
+      end
+
       if @config.ignored_environment?
         return promise.reject("The '#{@config.environment}' environment is ignored")
       end

--- a/lib/airbrake-ruby/performance_notifier.rb
+++ b/lib/airbrake-ruby/performance_notifier.rb
@@ -23,6 +23,10 @@ module Airbrake
     # @see Airbrake.notify_query
     # @see Airbrake.notify_request
     def notify(resource, promise = Airbrake::Promise.new)
+      unless @config.valid?
+        return promise.reject("Notice not sent: config is invalid or not configured")
+      end
+
       if @config.ignored_environment?
         return promise.reject("The '#{@config.environment}' environment is ignored")
       end

--- a/spec/deploy_notifier_spec.rb
+++ b/spec/deploy_notifier_spec.rb
@@ -1,11 +1,26 @@
 RSpec.describe Airbrake::DeployNotifier do
-  before { Airbrake::Config.instance = Airbrake::Config.new(project_id: 1) }
+  before do
+    Airbrake::Config.instance = Airbrake::Config.new(
+      project_id: 1, project_key: 'abc'
+    )
+  end
 
   describe "#notify" do
     it "returns a promise" do
       stub_request(:post, 'https://api.airbrake.io/api/v4/projects/1/deploys').
         to_return(status: 201, body: '{}')
       expect(subject.notify({})).to be_an(Airbrake::Promise)
+    end
+
+    context "when config is invalid" do
+      before { Airbrake::Config.instance.merge(project_id: nil) }
+
+      it "returns a rejected promise" do
+        promise = subject.notify({})
+        expect(promise.value).to eq(
+          'error' => 'Notice not sent: config is invalid or not configured'
+        )
+      end
     end
 
     context "when environment is configured" do

--- a/spec/notice_notifier_spec.rb
+++ b/spec/notice_notifier_spec.rb
@@ -108,6 +108,17 @@ RSpec.describe Airbrake::NoticeNotifier do
       sleep 1
     end
 
+    context "when config is invalid" do
+      before { Airbrake::Config.instance.merge(project_id: nil) }
+
+      it "returns a rejected promise" do
+        promise = subject.notify({})
+        expect(promise.value).to eq(
+          'error' => 'Notice not sent: config is invalid or not configured'
+        )
+      end
+    end
+
     context "when a notice is not ignored" do
       it "yields the notice" do
         expect { |b| subject.notify('ex', &b) }

--- a/spec/performance_notifier_spec.rb
+++ b/spec/performance_notifier_spec.rb
@@ -238,6 +238,17 @@ RSpec.describe Airbrake::PerformanceNotifier do
       ).to have_been_made
     end
 
+    context "when config is invalid" do
+      before { Airbrake::Config.instance.merge(project_id: nil) }
+
+      it "returns a rejected promise" do
+        promise = subject.notify({})
+        expect(promise.value).to eq(
+          'error' => 'Notice not sent: config is invalid or not configured'
+        )
+      end
+    end
+
     describe "payload grouping" do
       let(:flush_period) { 0.5 }
 


### PR DESCRIPTION
We want to be able to `add_filter`'s to Airbrake even when it's not
"configured". This resolves the headache with load order in the Rails
integration: add whenever you can but notify only when configured.

It also resolves the problem with `notify` methods that return `nil`. Users of
our API had to perform annoying `nil` checking, now they don't need this and can
fully rely on promises.