### PR TITLE
Rewrite Config::Validator to support promises

### DIFF
--- a/lib/airbrake-ruby.rb
+++ b/lib/airbrake-ruby.rb
@@ -163,7 +163,9 @@ module Airbrake
     def configure
       yield config = Airbrake::Config.instance
 
-      raise Airbrake::Error, config.validation_error_message unless config.valid?
+      unless (result = config.validate.value) == :ok
+        raise Airbrake::Error, result['error']
+      end
 
       Airbrake::Loggable.instance = config.logger
 


### PR DESCRIPTION
We can easily return promises from the Validator. The old API was not very
well done (looking at you, `@config.validation_error_message`). With help of
promises (aka Result object) we are able to pass result (ok or not ok) and error
message at the same time.

This new Validator is a static class. The old Validator didn't carry any state
and it didn't look clean to me when we instantiated it.

The new Validator acquired a new method: `#check_notify_ability`. This change
will help in cleaning Notifier classes, which have repetitive guards.

I also cleaned up tests, to make them less repetitive.