### PR TITLE
Improve Promise with #rejected? & #resolved?

### DIFF
--- a/lib/airbrake-ruby/config.rb
+++ b/lib/airbrake-ruby/config.rb
@@ -167,7 +167,7 @@ module Airbrake
     # @return [Boolean] true if the config meets the requirements, false
     #   otherwise
     def valid?
-      validate.value == :ok
+      validate.resolved?
     end
 
     # @return [Promise] resolved if the config is valid, rejected otherwise
@@ -178,7 +178,7 @@ module Airbrake
     # @return [Boolean] true if the config ignores current environment, false
     #   otherwise
     def ignored_environment?
-      Validator.check_notify_ability(self).value != :ok
+      Validator.check_notify_ability(self).rejected?
     end
 
     private

--- a/lib/airbrake-ruby/promise.rb
+++ b/lib/airbrake-ruby/promise.rb
@@ -95,5 +95,10 @@ module Airbrake
 
       self
     end
+
+    # @return [Bool]
+    def rejected?
+      @value.key?('error')
+    end
   end
 end

--- a/lib/airbrake-ruby/promise.rb
+++ b/lib/airbrake-ruby/promise.rb
@@ -7,12 +7,6 @@ module Airbrake
   # @see https://github.com/ruby-concurrency/concurrent-ruby/blob/master/lib/concurrent/promise.rb
   # @since v1.7.0
   class Promise
-    # @api private
-    # @return [Hash<String,String>] either successful response containing the
-    #   +id+ key or unsuccessful response containing the +error+ key
-    # @note This is a non-blocking call!
-    attr_reader :value
-
     def initialize
       @on_resolved = []
       @on_rejected = []
@@ -83,7 +77,7 @@ module Airbrake
     #
     # @param reason [String]
     # @return [self]
-    def reject(reason)
+    def reject(reason = 'rejected')
       @mutex.synchronize do
         @value['error'] = reason
         @on_rejected.each { |callback| callback.call(reason) }
@@ -100,6 +94,16 @@ module Airbrake
     # @return [Boolean]
     def resolved?
       @value.key?('ok')
+    end
+
+    # @return [Hash<String,String>] either successful response containing the
+    #   +id+ key or unsuccessful response containing the +error+ key
+    # @note This is a non-blocking call!
+    # @todo Get rid of this method and use an accessor. The resolved guard is
+    #   needed for compatibility but it shouldn't exist in the future
+    def value
+      return @value['ok'] if resolved?
+      @value
     end
   end
 end

--- a/lib/airbrake-ruby/promise.rb
+++ b/lib/airbrake-ruby/promise.rb
@@ -32,8 +32,8 @@ module Airbrake
     # @return [self]
     def then(&block)
       @mutex.synchronize do
-        if @value.key?('id')
-          yield(@value)
+        if @value.key?('ok')
+          yield(@value['ok'])
           return self
         end
 
@@ -64,41 +64,42 @@ module Airbrake
       self
     end
 
-    # Resolves the promise.
-    #
     # @example
     #   Airbrake::Promise.new.resolve('id' => '123')
     #
-    # @param response [Hash<String,String>]
+    # @param reason [Object]
     # @return [self]
-    def resolve(response)
+    def resolve(reason = 'resolved')
       @mutex.synchronize do
-        @value = response
-        @on_resolved.each { |callback| callback.call(response) }
+        @value['ok'] = reason
+        @on_resolved.each { |callback| callback.call(reason) }
       end
 
       self
     end
 
-    # Rejects the promise.
-    #
     # @example
     #   Airbrake::Promise.new.reject('Something went wrong')
     #
-    # @param error [String]
+    # @param reason [String]
     # @return [self]
-    def reject(error)
+    def reject(reason)
       @mutex.synchronize do
-        @value['error'] = error
-        @on_rejected.each { |callback| callback.call(error) }
+        @value['error'] = reason
+        @on_rejected.each { |callback| callback.call(reason) }
       end
 
       self
     end
 
-    # @return [Bool]
+    # @return [Boolean]
     def rejected?
       @value.key?('error')
+    end
+
+    # @return [Boolean]
+    def resolved?
+      @value.key?('ok')
     end
   end
 end

--- a/spec/config/validator_spec.rb
+++ b/spec/config/validator_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Airbrake::Config::Validator do
 
       it "returns a resolved promise" do
         promise = described_class.validate(config)
-        expect(promise.value).to eq(:ok)
+        expect(promise).to be_resolved
       end
     end
 
@@ -18,7 +18,7 @@ RSpec.describe Airbrake::Config::Validator do
 
       it "returns a resolved promise" do
         promise = described_class.validate(config)
-        expect(promise.value).to eq(:ok)
+        expect(promise).to be_resolved
       end
     end
 
@@ -54,7 +54,7 @@ RSpec.describe Airbrake::Config::Validator do
 
       it "returns a resolved promise" do
         promise = described_class.validate(config)
-        expect(promise.value).to eq(:ok)
+        expect(promise).to be_resolved
       end
     end
 
@@ -83,7 +83,7 @@ RSpec.describe Airbrake::Config::Validator do
 
       it "returns a resolved promise" do
         promise = described_class.validate(config)
-        expect(promise.value).to eq(:ok)
+        expect(promise).to be_resolved
       end
     end
 
@@ -94,7 +94,7 @@ RSpec.describe Airbrake::Config::Validator do
 
       it "returns a resolved promise" do
         promise = described_class.validate(config)
-        expect(promise.value).to eq(:ok)
+        expect(promise).to be_resolved
       end
     end
 
@@ -105,7 +105,7 @@ RSpec.describe Airbrake::Config::Validator do
 
       it "returns a resolved promise" do
         promise = described_class.validate(config)
-        expect(promise.value).to eq(:ok)
+        expect(promise).to be_resolved
       end
     end
 
@@ -136,7 +136,7 @@ RSpec.describe Airbrake::Config::Validator do
 
       it "returns a resolved promise" do
         promise = described_class.validate(config)
-        expect(promise.value).to eq(:ok)
+        expect(promise).to be_resolved
       end
     end
   end
@@ -171,7 +171,7 @@ RSpec.describe Airbrake::Config::Validator do
 
       it "returns a rejected promise" do
         promise = described_class.check_notify_ability(config)
-        expect(promise.value).to eq(:ok)
+        expect(promise).to be_resolved
       end
 
       it "warns about 'no effect'" do

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Airbrake::Config do
-  let(:resolved_promise) { OpenStruct.new(value: :ok) }
-  let(:rejected_promise) { OpenStruct.new(value: { 'error' => '' }) }
+  let(:resolved_promise) { Airbrake::Promise.new.resolve }
+  let(:rejected_promise) { Airbrake::Promise.new.reject }
 
   its(:project_id) { is_expected.to be_nil }
   its(:project_key) { is_expected.to be_nil }

--- a/spec/promise_spec.rb
+++ b/spec/promise_spec.rb
@@ -162,4 +162,15 @@ RSpec.describe Airbrake::Promise do
       expect(array).to match_array([999])
     end
   end
+
+  describe "#rejected?" do
+    context "when it was rejected" do
+      before { subject.reject(1) }
+      it { is_expected.to be_rejected }
+    end
+
+    context "when it wasn't rejected" do
+      it { is_expected.not_to be_rejected }
+    end
+  end
 end

--- a/spec/promise_spec.rb
+++ b/spec/promise_spec.rb
@@ -172,5 +172,26 @@ RSpec.describe Airbrake::Promise do
     context "when it wasn't rejected" do
       it { is_expected.not_to be_rejected }
     end
+
+    context "when it was resolved" do
+      before { subject.resolve }
+      it { is_expected.not_to be_rejected }
+    end
+  end
+
+  describe "#resolved?" do
+    context "when it was resolved" do
+      before { subject.resolve }
+      it { is_expected.to be_resolved }
+    end
+
+    context "when it wasn't resolved" do
+      it { is_expected.not_to be_resolved }
+    end
+
+    context "when it was rejected" do
+      before { subject.reject(1) }
+      it { is_expected.not_to be_resolved }
+    end
   end
 end


### PR DESCRIPTION
We shouldn't be littering with `value == :ok` checks. `#rejected?` & `#resolved?` improve readability.