### PR TITLE
Implement and use Config#check_configuration in notifiers

### DIFF
--- a/lib/airbrake-ruby/config.rb
+++ b/lib/airbrake-ruby/config.rb
@@ -170,15 +170,31 @@ module Airbrake
       validate.resolved?
     end
 
-    # @return [Promise] resolved if the config is valid, rejected otherwise
+    # @return [Promise]
+    # @see Validator.validate
     def validate
       Validator.validate(self)
+    end
+
+    # @return [Promise]
+    # @see Validator.check_notify_ability
+    def check_notify_ability
+      Validator.check_notify_ability(self)
     end
 
     # @return [Boolean] true if the config ignores current environment, false
     #   otherwise
     def ignored_environment?
-      Validator.check_notify_ability(self).rejected?
+      check_notify_ability.rejected?
+    end
+
+    # @return [Promise] resolved promise if config is valid & can notify,
+    #   rejected otherwise
+    def check_configuration
+      promise = validate
+      return promise if promise.rejected?
+
+      check_notify_ability
     end
 
     private

--- a/lib/airbrake-ruby/deploy_notifier.rb
+++ b/lib/airbrake-ruby/deploy_notifier.rb
@@ -18,11 +18,11 @@ module Airbrake
     end
 
     # @see Airbrake.notify_deploy
-    def notify(deploy_info, promise = Airbrake::Promise.new)
-      if @config.ignored_environment?
-        return promise.reject("The '#{@config.environment}' environment is ignored")
-      end
+    def notify(deploy_info)
+      promise = @config.check_configuration
+      return promise if promise.rejected?
 
+      promise = Airbrake::Promise.new
       deploy_info[:environment] ||= @config.environment
       @sender.send(
         deploy_info,

--- a/lib/airbrake-ruby/notice_notifier.rb
+++ b/lib/airbrake-ruby/notice_notifier.rb
@@ -95,16 +95,14 @@ module Airbrake
     end
 
     def send_notice(exception, params, sender)
-      promise = Airbrake::Promise.new
-
-      if @config.ignored_environment?
-        return promise.reject("The '#{@config.environment}' environment is ignored")
-      end
+      promise = @config.check_configuration
+      return promise if promise.rejected?
 
       notice = build_notice(exception, params)
       yield notice if block_given?
       @filter_chain.refine(notice)
 
+      promise = Airbrake::Promise.new
       return promise.reject("#{notice} was marked as ignored") if notice.ignored?
 
       sender.send(notice, promise)

--- a/lib/airbrake-ruby/notice_notifier.rb
+++ b/lib/airbrake-ruby/notice_notifier.rb
@@ -96,6 +96,7 @@ module Airbrake
 
     def send_notice(exception, params, sender)
       promise = Airbrake::Promise.new
+
       if @config.ignored_environment?
         return promise.reject("The '#{@config.environment}' environment is ignored")
       end

--- a/lib/airbrake-ruby/performance_notifier.rb
+++ b/lib/airbrake-ruby/performance_notifier.rb
@@ -19,14 +19,13 @@ module Airbrake
     end
 
     # @param [Hash] resource
-    # @param [Airbrake::Promise] promise
     # @see Airbrake.notify_query
     # @see Airbrake.notify_request
-    def notify(resource, promise = Airbrake::Promise.new)
-      if @config.ignored_environment?
-        return promise.reject("The '#{@config.environment}' environment is ignored")
-      end
+    def notify(resource)
+      promise = @config.check_configuration
+      return promise if promise.rejected?
 
+      promise = Airbrake::Promise.new
       unless @config.performance_stats
         return promise.reject("The Performance Stats feature is disabled")
       end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -2,6 +2,8 @@ RSpec.describe Airbrake::Config do
   let(:resolved_promise) { Airbrake::Promise.new.resolve }
   let(:rejected_promise) { Airbrake::Promise.new.reject }
 
+  let(:valid_params) { { project_id: 1, project_key: '2' } }
+
   its(:project_id) { is_expected.to be_nil }
   its(:project_key) { is_expected.to be_nil }
   its(:logger) { is_expected.to be_a(Logger) }
@@ -60,7 +62,6 @@ RSpec.describe Airbrake::Config do
   end
 
   describe "#endpoint" do
-    let(:valid_params) { { project_id: 1, project_key: '2' } }
     subject { described_class.new(valid_params.merge(user_config)) }
 
     context "when host ends with a URL with a slug with a trailing slash" do
@@ -82,5 +83,38 @@ RSpec.describe Airbrake::Config do
 
   describe "#validate" do
     its(:validate) { is_expected.to be_an(Airbrake::Promise) }
+  end
+
+  describe "#check_configuration" do
+    let(:user_config) { {} }
+
+    subject { described_class.new(valid_params.merge(user_config)) }
+
+    its(:check_configuration) { is_expected.to be_an(Airbrake::Promise) }
+
+    context "when config is invalid" do
+      let(:user_config) { { project_id: nil } }
+
+      it "rejects the promise" do
+        promise = subject.check_configuration
+        expect(promise).to be_rejected
+      end
+    end
+
+    context "when current environment is ignored" do
+      let(:user_config) { { environment: 'test', ignore_environments: ['test'] } }
+
+      it "rejects the promise" do
+        promise = subject.check_configuration
+        expect(promise).to be_rejected
+      end
+    end
+
+    context "when config is valid and allows notifying" do
+      it "doesn't reject the promise" do
+        promise = subject.check_configuration
+        expect(promise).not_to be_rejected
+      end
+    end
   end
 end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -94,27 +94,16 @@ RSpec.describe Airbrake::Config do
 
     context "when config is invalid" do
       let(:user_config) { { project_id: nil } }
-
-      it "rejects the promise" do
-        promise = subject.check_configuration
-        expect(promise).to be_rejected
-      end
+      its(:check_configuration) { is_expected.to be_rejected }
     end
 
     context "when current environment is ignored" do
       let(:user_config) { { environment: 'test', ignore_environments: ['test'] } }
-
-      it "rejects the promise" do
-        promise = subject.check_configuration
-        expect(promise).to be_rejected
-      end
+      its(:check_configuration) { is_expected.to be_rejected }
     end
 
     context "when config is valid and allows notifying" do
-      it "doesn't reject the promise" do
-        promise = subject.check_configuration
-        expect(promise).not_to be_rejected
-      end
+      its(:check_configuration) { is_expected.not_to be_rejected }
     end
   end
 end

--- a/spec/deploy_notifier_spec.rb
+++ b/spec/deploy_notifier_spec.rb
@@ -1,5 +1,7 @@
 RSpec.describe Airbrake::DeployNotifier do
-  before { Airbrake::Config.instance = Airbrake::Config.new(project_id: 1) }
+  before do
+    Airbrake::Config.instance = Airbrake::Config.new(project_id: 1, project_key: '123')
+  end
 
   describe "#notify" do
     it "returns a promise" do

--- a/spec/notice_notifier_spec.rb
+++ b/spec/notice_notifier_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe Airbrake::NoticeNotifier do
 
       it "returns a rejected promise" do
         promise = subject.notify('foo', bingo: 'bango')
-        expect(promise.value).to eq('error' => "The 'test' environment is ignored")
+        expect(promise.value).to eq('error' => "current environment 'test' is ignored")
       end
     end
   end
@@ -252,7 +252,7 @@ RSpec.describe Airbrake::NoticeNotifier do
 
       it "returns an error hash" do
         expect(subject.notify_sync('foo'))
-          .to eq('error' => "The 'test' environment is ignored")
+          .to eq('error' => "current environment 'test' is ignored")
       end
     end
   end

--- a/spec/notice_notifier_spec/options_spec.rb
+++ b/spec/notice_notifier_spec/options_spec.rb
@@ -211,7 +211,7 @@ RSpec.describe Airbrake::NoticeNotifier do
         it "returns early and doesn't try to parse the given exception" do
           expect(Airbrake::Notice).not_to receive(:new)
           expect(subject.notify_sync(ex))
-            .to eq('error' => "The 'development' environment is ignored")
+            .to eq('error' => "current environment 'development' is ignored")
           expect(a_request(:post, endpoint)).not_to have_been_made
         end
       end

--- a/spec/performance_notifier_spec.rb
+++ b/spec/performance_notifier_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe Airbrake::PerformanceNotifier do
       )
 
       expect(a_request(:put, routes)).not_to have_been_made
-      expect(promise.value).to eq('error' => "The 'test' environment is ignored")
+      expect(promise.value).to eq('error' => "current environment 'test' is ignored")
     end
 
     it "sends environment when it's specified" do


### PR DESCRIPTION
We want to be able to add_filter's to Airbrake even when it's not
"configured". This resolves the headache with load order in the Rails
integration: add whenever you can but notify only when configured.

It also resolves the problem with notify methods that return nil. Users of
our API had to perform annoying nil checking, now they don't need this and can
fully rely on promises.