### PR TITLE
Delete NilNotifiers and rely on notifier config checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Airbrake Ruby Changelog
 
 ### master
 
+* `add_filter` & `add_performance_filter` add filters even when Airbrake is not
+  configured ([#445](https://github.com/airbrake/airbrake-ruby/pull/445),
+  [#451](https://github.com/airbrake/airbrake-ruby/pull/451))
+
 ### [v4.0.1][v4.0.1] (Feburary 26, 2019)
 
 * Fixed bug in `Airbrake.configure` not setting `logger` properly

--- a/spec/deploy_notifier_spec.rb
+++ b/spec/deploy_notifier_spec.rb
@@ -10,6 +10,15 @@ RSpec.describe Airbrake::DeployNotifier do
       expect(subject.notify({})).to be_an(Airbrake::Promise)
     end
 
+    context "when config is invalid" do
+      before { Airbrake::Config.instance.merge(project_id: nil) }
+
+      it "returns a rejected promise" do
+        promise = subject.notify({})
+        expect(promise).to be_rejected
+      end
+    end
+
     context "when environment is configured" do
       before { Airbrake::Config.instance.merge(environment: 'fooenv') }
 

--- a/spec/notice_notifier_spec.rb
+++ b/spec/notice_notifier_spec.rb
@@ -107,6 +107,15 @@ RSpec.describe Airbrake::NoticeNotifier do
       sleep 1
     end
 
+    context "when config is invalid" do
+      before { Airbrake::Config.instance.merge(project_id: nil) }
+
+      it "returns a rejected promise" do
+        promise = subject.notify({})
+        expect(promise).to be_rejected
+      end
+    end
+
     context "when a notice is not ignored" do
       it "yields the notice" do
         expect { |b| subject.notify('ex', &b) }

--- a/spec/performance_notifier_spec.rb
+++ b/spec/performance_notifier_spec.rb
@@ -238,6 +238,15 @@ RSpec.describe Airbrake::PerformanceNotifier do
       ).to have_been_made
     end
 
+    context "when config is invalid" do
+      before { Airbrake::Config.instance.merge(project_id: nil) }
+
+      it "returns a rejected promise" do
+        promise = subject.notify({})
+        expect(promise).to be_rejected
+      end
+    end
+
     describe "payload grouping" do
       let(:flush_period) { 0.5 }
 


### PR DESCRIPTION
When a notifier is not configured, we can `add_filter` but `notify` won't have
effect. This accompanies https://github.com/airbrake/airbrake-ruby/pull/445.