### PR TITLE
performance_notifier: make resource name independent

### DIFF
--- a/lib/airbrake-ruby/query.rb
+++ b/lib/airbrake-ruby/query.rb
@@ -24,7 +24,11 @@ module Airbrake
       super(method, route, query, func, file, line, start_time, end_time)
     end
 
-    def name
+    def destination
+      'queries-stats'
+    end
+
+    def cargo
       'queries'
     end
 

--- a/lib/airbrake-ruby/request.rb
+++ b/lib/airbrake-ruby/request.rb
@@ -18,7 +18,11 @@ module Airbrake
       super(method, route, status_code, start_time, end_time)
     end
 
-    def name
+    def destination
+      'routes-stats'
+    end
+
+    def cargo
       'routes'
     end
 


### PR DESCRIPTION
Currently, we require that endpoint destination should match the resource
name. This is rather convenient since we can rely on convention, however if the
backend doesn't follow it, our code breaks (if we add new models).

With this change we use the cargo->destination metaphor and add it to our
models, so every model declares what it carries and where it should be
sent. PerformanceNotifier doesn't make any assumptions anymore.