### PR TITLE
Add the ability to send performance breakdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Airbrake Ruby Changelog
 
 ### master
 
+* Added `Airbrake.notify_performance_breakdown` that sends performance data by
+  arbitrary groups ([#454](https://github.com/airbrake/airbrake-ruby/pull/454))
+
 ### [v4.1.0][v4.1.0] (Feburary 28, 2019)
 
 * `add_filter` & `add_performance_filter` add filters even when Airbrake is not

--- a/README.md
+++ b/README.md
@@ -738,7 +738,6 @@ displayed on the Performance tab of your project.
 
 ```ruby
 Airbrake.notify_query(
-  environment: 'production', # optional
   method: 'GET',
   route: '/things/1',
   query: 'SELECT * FROM foos',
@@ -755,6 +754,22 @@ a rejected promise.
 
 When [`config.performance_stats = true`](#performance_stats), then it aggregates
 statistics and sends as a batch every 15 seconds.
+
+#### Airbrake.notify_performance_breakdown
+
+Sends performance breakdown statistics by groups to Airbrake. The groups are
+arbitrary (database, views, HTTP calls, etc.), but there can be only up to 10
+groups per route in total.
+
+```ruby
+Airbrake.notify_performance_breakdown(
+  method: 'GET',
+  route: '/things/1',
+  response_type: 'json',
+  groups: { db: 24.0, view: 0.4 }, # ms
+  start_time: Time.new
+)
+```
 
 #### Airbrake.add_performance_filter
 

--- a/lib/airbrake-ruby.rb
+++ b/lib/airbrake-ruby.rb
@@ -46,6 +46,7 @@ require 'airbrake-ruby/time_truncate'
 require 'airbrake-ruby/tdigest'
 require 'airbrake-ruby/query'
 require 'airbrake-ruby/request'
+require 'airbrake-ruby/performance_breakdown'
 
 # Airbrake is a thin wrapper around instances of the notifier classes (such as
 # notice, performance & deploy notifiers). It creates a way to access them via a
@@ -352,7 +353,6 @@ module Airbrake
     #   )
     #
     # @param [Hash{Symbol=>Object}] query_info
-    # @option request_info [String] :environment (optional)
     # @option request_info [String] :method The HTTP method that triggered this
     #   SQL query (optional)
     # @option request_info [String] :route The route that triggered this SQL
@@ -365,6 +365,30 @@ module Airbrake
     # @see Airbrake::PerformanceNotifier#notify
     def notify_query(query_info)
       @performance_notifier.notify(Query.new(query_info))
+    end
+
+    # Increments performance breakdown statistics of a certain route.
+    #
+    # @example
+    #   Airbrake.notify_request(
+    #     method: 'POST',
+    #     route: '/thing/:id/create',
+    #     response_type: 'json',
+    #     groups: { db: 24.0, view: 0.4 }, # ms
+    #     start_time: timestamp,
+    #     end_time: Time.now
+    #   )
+    #
+    # @param [Hash{Symbol=>Object}] breakdown_info
+    # @option breakdown_info [String] :method HTTP method
+    # @option breakdown_info [String] :route
+    # @option breakdown_info [String] :response_type
+    # @option breakdown_info [Array<Hash{Symbol=>Float}>] :groups
+    # @option breakdown_info [Date] :start_time
+    # @return [void]
+    # @since v4.2.0
+    def notify_performance_breakdown(breakdown_info)
+      @performance_notifier.notify(PerformanceBreakdown.new(breakdown_info))
     end
 
     # Runs a callback before {.notify_request} or {.notify_query} kicks in. This

--- a/lib/airbrake-ruby/performance_breakdown.rb
+++ b/lib/airbrake-ruby/performance_breakdown.rb
@@ -1,0 +1,44 @@
+module Airbrake
+  # PerformanceBreakdown holds data that shows how much time a request spent
+  # doing certaing subtasks such as (DB querying, view rendering, etc).  request
+  #
+  # @see Airbrake.notify_breakdown
+  # @api public
+  # @since v4.3.0
+  # rubocop:disable Metrics/BlockLength, Metrics/ParameterLists
+  PerformanceBreakdown = Struct.new(
+    :method, :route, :response_type, :groups, :start_time, :end_time
+  ) do
+    include HashKeyable
+    include Ignorable
+
+    def initialize(
+      method:,
+      route:,
+      response_type:,
+      groups:,
+      start_time:,
+      end_time: Time.now
+    )
+      super(method, route, response_type, groups, start_time, end_time)
+    end
+
+    def destination
+      'routes-breakdowns'
+    end
+
+    def cargo
+      'routes'
+    end
+
+    def to_h
+      {
+        'method' => method,
+        'route' => route,
+        'responseType' => response_type,
+        'time' => TimeTruncate.utc_truncate_minutes(start_time)
+      }.delete_if { |_key, val| val.nil? }
+    end
+  end
+  # rubocop:enable Metrics/BlockLength, Metrics/ParameterLists
+end

--- a/lib/airbrake-ruby/query.rb
+++ b/lib/airbrake-ruby/query.rb
@@ -32,6 +32,10 @@ module Airbrake
       'queries'
     end
 
+    def groups
+      {}
+    end
+
     def to_h
       {
         'method' => method,

--- a/lib/airbrake-ruby/request.rb
+++ b/lib/airbrake-ruby/request.rb
@@ -4,6 +4,7 @@ module Airbrake
   # @see Airbrake.notify_request
   # @api public
   # @since v3.2.0
+  # rubocop:disable Metrics/BlockLength
   Request = Struct.new(:method, :route, :status_code, :start_time, :end_time) do
     include HashKeyable
     include Ignorable
@@ -26,6 +27,10 @@ module Airbrake
       'routes'
     end
 
+    def groups
+      {}
+    end
+
     def to_h
       {
         'method' => method,
@@ -35,4 +40,5 @@ module Airbrake
       }.delete_if { |_key, val| val.nil? }
     end
   end
+  # rubocop:enable Metrics/BlockLength
 end

--- a/lib/airbrake-ruby/stat.rb
+++ b/lib/airbrake-ruby/stat.rb
@@ -43,10 +43,16 @@ module Airbrake
     # @return [void]
     def increment(start_time, end_time = nil)
       end_time ||= Time.new
+      increment_ms((end_time - start_time) * 1000)
+    end
 
+    # Increments count and updates performance with given +ms+ value.
+    #
+    # @param [Float] ms
+    # @return [void]
+    def increment_ms(ms)
       self.count += 1
 
-      ms = (end_time - start_time) * 1000
       self.sum += ms
       self.sumsq += ms * ms
 

--- a/spec/stat_spec.rb
+++ b/spec/stat_spec.rb
@@ -12,21 +12,19 @@ RSpec.describe Airbrake::Stat do
 
   describe "#increment" do
     let(:start_time) { Time.new(2018, 1, 1, 0, 0, 20, 0) }
-    let(:end_time) { Time.new(2018, 1, 1, 0, 0, 21, 0) }
+    let(:end_time) { Time.new(2018, 1, 1, 0, 0, 22, 0) }
 
     before { subject.increment(start_time, end_time) }
 
-    it "increments count" do
-      expect(subject.count).to eq(1)
-    end
+    its(:sum) { is_expected.to eq(2000) }
+  end
 
-    it "updates sum" do
-      expect(subject.sum).to eq(1000)
-    end
+  describe "#increment_ms" do
+    before { subject.increment_ms(1000) }
 
-    it "updates sumsq" do
-      expect(subject.sumsq).to eq(1000000)
-    end
+    its(:count) { is_expected.to eq(1) }
+    its(:sum) { is_expected.to eq(1000) }
+    its(:sumsq) { is_expected.to eq(1000000) }
 
     it "updates tdigest" do
       expect(subject.tdigest.size).to eq(1)


### PR DESCRIPTION
`Airbrake.notify_performance_breakdown` increments performance breakdown
statistics of a certain route.

Performance breakdown consists of groups such as `db`, `view`, `http`, etc. (up
to 10). Names are arbitrary.