### PR TITLE
airbrake-ruby: don't raise error when there's no project id/key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Airbrake Ruby Changelog
 
 ### master
 
+* Stopped raising `Airbrake::Error` when configuring Airbrake without a project
+  id or project key ([#458](https://github.com/airbrake/airbrake-ruby/pull/458))
+
 ### [v4.2.0][v4.2.0] (March 7, 2019)
 
 * Added `Airbrake.notify_performance_breakdown` that sends performance data by

--- a/lib/airbrake-ruby.rb
+++ b/lib/airbrake-ruby.rb
@@ -96,16 +96,9 @@ module Airbrake
     # @return [void]
     # @raise [Airbrake::Error] when trying to reconfigure already
     #   existing notifier
-    # @raise [Airbrake::Error] when either +project_id+ or +project_key+
-    #   is missing (or both)
     # @note There's no way to read config values outside of this library
     def configure
       yield config = Airbrake::Config.instance
-
-      if (result = config.validate).rejected?
-        raise Airbrake::Error, result.value['error']
-      end
-
       Airbrake::Loggable.instance = config.logger
     end
 

--- a/spec/airbrake_spec.rb
+++ b/spec/airbrake_spec.rb
@@ -22,19 +22,5 @@ RSpec.describe Airbrake do
 
       expect(Airbrake::Loggable.instance).to eql(logger)
     end
-
-    context "when user config doesn't contain a project id" do
-      it "raises error" do
-        expect { described_class.configure { |c| c.project_key = '1' } }
-          .to raise_error(Airbrake::Error, ':project_id is required')
-      end
-    end
-
-    context "when user config doesn't contain a project key" do
-      it "raises error" do
-        expect { described_class.configure { |c| c.project_id = 1 } }
-          .to raise_error(Airbrake::Error, ':project_key is required')
-      end
-    end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/airbrake/airbrake/issues/931.
(`Airbrake::Error: :project_id is required` is thrown for ignored environment)

This is technically not a bug since we even test that we raise an error, but an
oversight.