### PR TITLE
airbrake-ruby: don't overwrite notifiers on #configure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Airbrake Ruby Changelog
 
 ### master
 
+* Stopped resetting default notifiers on `Airbrake.configure`, which can lead to
+  bugs where default filters are not installed
+  ([#464](https://github.com/airbrake/airbrake-ruby/pull/464))
+
 ### [v4.2.2][v4.2.2] (March 27, 2019)
 
 * Fixed `blacklist_keys/whitelist_keys` options not working

--- a/spec/airbrake_spec.rb
+++ b/spec/airbrake_spec.rb
@@ -1,12 +1,24 @@
 RSpec.describe Airbrake do
-  before do
-    Airbrake::Config.instance = Airbrake::Config.new
-    described_class.reset
+  it "gets initialized with a performance notifier" do
+    expect(described_class.performance_notifier).not_to be_nil
   end
 
-  after { described_class.reset }
+  it "gets initialized with a notice notifier" do
+    expect(described_class.notice_notifier).not_to be_nil
+  end
+
+  it "gets initialized with a deploy notifier" do
+    expect(described_class.deploy_notifier).not_to be_nil
+  end
 
   describe ".configure" do
+    before do
+      Airbrake::Config.instance = Airbrake::Config.new
+      described_class.reset
+    end
+
+    after { described_class.reset }
+
     it "yields the config" do
       expect do |b|
         begin
@@ -41,18 +53,18 @@ RSpec.describe Airbrake do
 
     context "when a notifier was configured" do
       before do
-        expect(described_class).to receive(:configured?).twice.and_return(true)
+        expect(described_class).to receive(:configured?).and_return(true)
       end
 
       it "closes previously configured notice notifier" do
-        expect(described_class).to receive(:close).twice
+        expect(described_class).to receive(:close)
         described_class.configure {}
       end
     end
 
     context "when a notifier wasn't configured" do
       before do
-        expect(described_class).to receive(:configured?).twice.and_return(false)
+        expect(described_class).to receive(:configured?).and_return(false)
       end
 
       it "doesn't close previously configured notice notifier" do
@@ -60,16 +72,42 @@ RSpec.describe Airbrake do
         described_class.configure {}
       end
     end
+
+    context "when called multiple times" do
+      it "doesn't overwrite performance notifier" do
+        described_class.configure {}
+        performance_notifier = described_class.performance_notifier
+
+        described_class.configure {}
+        expect(described_class.performance_notifier).to eql(performance_notifier)
+      end
+
+      it "doesn't overwrite notice notifier" do
+        described_class.configure {}
+        notice_notifier = described_class.notice_notifier
+
+        described_class.configure {}
+        expect(described_class.notice_notifier).to eql(notice_notifier)
+      end
+
+      it "doesn't overwrite deploy notifier" do
+        described_class.configure {}
+        deploy_notifier = described_class.deploy_notifier
+
+        described_class.configure {}
+        expect(described_class.deploy_notifier).to eql(deploy_notifier)
+      end
+    end
   end
 
   describe "#reset" do
     context "when Airbrake was previously configured" do
       before do
-        expect(described_class).to receive(:configured?).twice.and_return(true)
+        expect(described_class).to receive(:configured?).and_return(true)
       end
 
       it "closes notice notifier" do
-        expect(described_class).to receive(:close).twice
+        expect(described_class).to receive(:close)
         subject.reset
       end
     end


### PR DESCRIPTION
The `reset` method introduced in v4.2.2 was resetting Airbrake every time we
call `configure`. This can result in default filters being lost. E.g. we
`add_filter` and then `configure`.

There are two solutions:

* we add filters within `configure`
* we don't call reset when notifiers are already registered

I chose the latter because it's a simpler approach and it does the job. I will
keep in mind the first approach since it sounds more logical to me. Currently,
we decouple "configuration" and filters, however they are the same thing and
adding filters *is* configuration. That said, this approach has caveats. For
example, I wan't to add some filters in some integration. I don't want to
reconfigure the whole thing, I just want to append my tiny little filter.