### PR TITLE
filters/git_revision: fix sporadic failure

### DIFF
--- a/spec/filters/git_revision_filter_spec.rb
+++ b/spec/filters/git_revision_filter_spec.rb
@@ -1,7 +1,9 @@
 RSpec.describe Airbrake::Filters::GitRevisionFilter do
   subject { described_class.new('root/dir') }
 
-  let(:notice) { Airbrake::Notice.new(AirbrakeTestError.new) }
+  # 'let!', not 'let' to make sure Notice doesn't call File.exist? with
+  # unexpected arguments.
+  let!(:notice) { Airbrake::Notice.new(AirbrakeTestError.new) }
 
   context "when context/revision is defined" do
     it "doesn't attach anything to context/revision" do


### PR DESCRIPTION
This failure can be reproduced with:

```
bundle exec rspec --seed 59264

         expected: ("root/dir/.git/HEAD")
              got: ("/home/kyrylo/code/airbrake/ruby/spec/spec_helper.rb")
```

The problem is that `let` lazily instantiates `Airbrake::Notice`, which calls
`File.exist?` in CodeHunk with unexpected arguments.