### PR TITLE
airbrake-ruby: initialize notice notifier with filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Airbrake Ruby Changelog
 
 * Added `Airbrake::Benchmark` for measuring time of execution of Ruby
   operations ([#467](https://github.com/airbrake/airbrake-ruby/pull/467))
+* Fixed `KeysBlacklist` & `KeysWhitelist` filters not being added
+  ([#469](https://github.com/airbrake/airbrake-ruby/pull/469))
 
 ### [v4.2.3][v4.2.3] (April 8, 2019)
 

--- a/spec/airbrake_spec.rb
+++ b/spec/airbrake_spec.rb
@@ -98,6 +98,88 @@ RSpec.describe Airbrake do
         expect(described_class.deploy_notifier).to eql(deploy_notifier)
       end
     end
+
+    context "when blacklist_keys gets configured" do
+      before { allow(Airbrake.notice_notifier).to receive(:add_filter) }
+
+      it "adds blacklist filter" do
+        expect(Airbrake.notice_notifier).to receive(:add_filter)
+          .with(an_instance_of(Airbrake::Filters::KeysBlacklist))
+        described_class.configure { |c| c.blacklist_keys = %w[password] }
+      end
+
+      it "initializes blacklist with specified parameters" do
+        expect(Airbrake::Filters::KeysBlacklist).to receive(:new).with(%w[password])
+        described_class.configure { |c| c.blacklist_keys = %w[password] }
+      end
+    end
+
+    context "when whitelist_keys gets configured" do
+      before { allow(Airbrake.notice_notifier).to receive(:add_filter) }
+
+      it "adds whitelist filter" do
+        expect(Airbrake.notice_notifier).to receive(:add_filter)
+          .with(an_instance_of(Airbrake::Filters::KeysWhitelist))
+        described_class.configure { |c| c.whitelist_keys = %w[banana] }
+      end
+
+      it "initializes whitelist with specified parameters" do
+        expect(Airbrake::Filters::KeysWhitelist).to receive(:new).with(%w[banana])
+        described_class.configure { |c| c.whitelist_keys = %w[banana] }
+      end
+    end
+
+    context "when root_directory gets configured" do
+      before { allow(Airbrake.notice_notifier).to receive(:add_filter) }
+
+      it "adds root directory filter" do
+        expect(Airbrake.notice_notifier).to receive(:add_filter)
+          .with(an_instance_of(Airbrake::Filters::RootDirectoryFilter))
+        described_class.configure { |c| c.root_directory = '/my/path' }
+      end
+
+      it "initializes root directory filter with specified path" do
+        expect(Airbrake::Filters::RootDirectoryFilter)
+          .to receive(:new).with('/my/path')
+        described_class.configure { |c| c.root_directory = '/my/path' }
+      end
+
+      it "adds git revision filter" do
+        expect(Airbrake.notice_notifier).to receive(:add_filter)
+          .with(an_instance_of(Airbrake::Filters::GitRevisionFilter))
+        described_class.configure { |c| c.root_directory = '/my/path' }
+      end
+
+      it "initializes git revision filter with correct root directory" do
+        expect(Airbrake::Filters::GitRevisionFilter)
+          .to receive(:new).with('/my/path')
+        described_class.configure { |c| c.root_directory = '/my/path' }
+      end
+
+      it "adds git repository filter" do
+        expect(Airbrake.notice_notifier).to receive(:add_filter)
+          .with(an_instance_of(Airbrake::Filters::GitRepositoryFilter))
+        described_class.configure { |c| c.root_directory = '/my/path' }
+      end
+
+      it "initializes git repository filter with correct root directory" do
+        expect(Airbrake::Filters::GitRepositoryFilter)
+          .to receive(:new).with('/my/path')
+        described_class.configure { |c| c.root_directory = '/my/path' }
+      end
+
+      it "adds git last checkout filter" do
+        expect(Airbrake.notice_notifier).to receive(:add_filter)
+          .with(an_instance_of(Airbrake::Filters::GitLastCheckoutFilter))
+        described_class.configure { |c| c.root_directory = '/my/path' }
+      end
+
+      it "initializes git last checkout filter with correct root directory" do
+        expect(Airbrake::Filters::GitLastCheckoutFilter)
+          .to receive(:new).with('/my/path')
+        described_class.configure { |c| c.root_directory = '/my/path' }
+      end
+    end
   end
 
   describe "#reset" do

--- a/spec/notice_notifier_spec.rb
+++ b/spec/notice_notifier_spec.rb
@@ -23,62 +23,6 @@ RSpec.describe Airbrake::NoticeNotifier do
           .with(instance_of(Airbrake::Filters::ExceptionAttributesFilter))
         subject
       end
-
-      context "when user config has some whitelist keys" do
-        before { Airbrake::Config.instance.merge(whitelist_keys: %w[foo]) }
-
-        it "appends the whitelist filter" do
-          expect_any_instance_of(Airbrake::FilterChain).to receive(:add_filter)
-            .with(instance_of(Airbrake::Filters::KeysWhitelist))
-          subject
-        end
-      end
-
-      context "when user config doesn't have any whitelist keys" do
-        it "doesn't append the whitelist filter" do
-          expect_any_instance_of(Airbrake::FilterChain).not_to receive(:add_filter)
-            .with(instance_of(Airbrake::Filters::KeysWhitelist))
-          subject
-        end
-      end
-
-      context "when user config has some blacklist keys" do
-        before { Airbrake::Config.instance.merge(blacklist_keys: %w[bar]) }
-
-        it "appends the blacklist filter" do
-          expect_any_instance_of(Airbrake::FilterChain).to receive(:add_filter)
-            .with(instance_of(Airbrake::Filters::KeysBlacklist))
-          subject
-        end
-      end
-
-      context "when user config doesn't have any blacklist keys" do
-        it "doesn't append the blacklist filter" do
-          expect_any_instance_of(Airbrake::FilterChain).not_to receive(:add_filter)
-            .with(instance_of(Airbrake::Filters::KeysBlacklist))
-          subject
-        end
-      end
-
-      context "when user config specifies a root directory" do
-        before { Airbrake::Config.instance.merge(root_directory: '/foo') }
-
-        it "appends the root directory filter" do
-          expect_any_instance_of(Airbrake::FilterChain).to receive(:add_filter)
-            .with(instance_of(Airbrake::Filters::RootDirectoryFilter))
-          subject
-        end
-      end
-
-      context "when user config doesn't specify a root directory" do
-        it "doesn't append the root directory filter" do
-          expect_any_instance_of(Airbrake::Config).to receive(:root_directory)
-            .and_return(nil)
-          expect_any_instance_of(Airbrake::FilterChain).not_to receive(:add_filter)
-            .with(instance_of(Airbrake::Filters::RootDirectoryFilter))
-          subject
-        end
-      end
     end
   end
 

--- a/spec/notice_notifier_spec/options_spec.rb
+++ b/spec/notice_notifier_spec/options_spec.rb
@@ -63,7 +63,9 @@ RSpec.describe Airbrake::NoticeNotifier do
 
     describe ":root_directory" do
       before do
-        Airbrake::Config.instance.merge(root_directory: '/home/kyrylo/code')
+        subject.add_filter(
+          Airbrake::Filters::RootDirectoryFilter.new('/home/kyrylo/code')
+        )
       end
 
       it "filters out frames" do


### PR DESCRIPTION
Fixes #468 (blacklist_keys not being filtered out in version 4.2.3)

The problem was that at the time when we initialize NoticeNotifier (on library
load) the Config has no blacklist/whitelist keys specified. Therefore, when we
`configure` Airbrake, newly set values have no effect.

With this change we move conditional filter initialization out of
NoticeNotifier. The risk is that calling `configure` twice will append the same
conditional filters twice. Therefore, `reset` must be called prior to second
`configure` (but it's probably a good idea not to call it twice and it should be
very uncommon).