### PR TITLE
airbrake-ruby: fix notifier accessors returning wrong notifiers

### DIFF
--- a/lib/airbrake-ruby.rb
+++ b/lib/airbrake-ruby.rb
@@ -113,7 +113,7 @@ module Airbrake
     # @since v4.2.3
     # @api private
     def performance_notifier
-      @performance_notifier ||= NoticeNotifier.new
+      @performance_notifier ||= PerformanceNotifier.new
     end
 
     # @since v4.2.3
@@ -125,7 +125,7 @@ module Airbrake
     # @since v4.2.3
     # @api private
     def deploy_notifier
-      @deploy_notifier ||= PerformanceNotifier.new
+      @deploy_notifier ||= DeployNotifier.new
     end
 
     # @return [Boolean] true if the notifier was configured, false otherwise

--- a/spec/airbrake_spec.rb
+++ b/spec/airbrake_spec.rb
@@ -194,4 +194,23 @@ RSpec.describe Airbrake do
       end
     end
   end
+
+  describe ".performance_notifier" do
+    it "returns a performance notifier" do
+      expect(described_class.performance_notifier)
+        .to be_an(Airbrake::PerformanceNotifier)
+    end
+  end
+
+  describe ".notice_notifier" do
+    it "returns a notice notifier" do
+      expect(described_class.notice_notifier).to be_an(Airbrake::NoticeNotifier)
+    end
+  end
+
+  describe ".deploy_notifier" do
+    it "returns a deploy notifier" do
+      expect(described_class.deploy_notifier).to be_an(Airbrake::DeployNotifier)
+    end
+  end
 end


### PR DESCRIPTION
Fixes #471 (airbrake:deploy issue with airbrake-ruby (4.2.4))