### PR TITLE
async_sender: return a rejected promise when capacity is maxed out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Airbrake Ruby Changelog
 
 ### master
 
+* Fixed `AsyncSender` returning `nil` instead of a rejected promise when it
+  reaches its capacity
+  ([#484](https://github.com/airbrake/airbrake-ruby/pull/484))
+
 ### [v4.4.0][v4.4.0] (May 9, 2019)
 
 * Added `Airbrake::Query#stash`, `Airbrake::Request#stash`,

--- a/spec/async_sender_spec.rb
+++ b/spec/async_sender_spec.rb
@@ -49,6 +49,14 @@ RSpec.describe Airbrake::AsyncSender do
         end
         subject.close
       end
+
+      it "returns a rejected promise" do
+        promise = Airbrake::Promise.new
+        200.times { subject.send(notice, promise) }
+        expect(promise.value).to eq(
+          'error' => "AsyncSender has reached its capacity of #{queue_size}"
+        )
+      end
     end
   end
 


### PR DESCRIPTION
Fixes #483 ("NoMethodError: undefined method `then' for nil:NilClass" when
sending first notice with a promise)