### PR TITLE
performance_notifier: delay string conversion of payload on logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Airbrake Ruby Changelog
 
 ### master
 
+* Improved performance of `PerformanceNotifier` (sic!)
+  ([#490](https://github.com/airbrake/airbrake-ruby/pull/490))
+
 ### [v4.5.0][v4.5.0] (June 25, 2019)
 
 * Fixed `AsyncSender` returning `nil` instead of a rejected promise when it

--- a/lib/airbrake-ruby/performance_notifier.rb
+++ b/lib/airbrake-ruby/performance_notifier.rb
@@ -82,7 +82,7 @@ module Airbrake
       signature = "#{self.class.name}##{__method__}"
       raise "#{signature}: payload (#{payload}) cannot be empty. Race?" if payload.none?
 
-      logger.debug("#{LOG_LABEL} #{signature}: #{payload}")
+      logger.debug { "#{LOG_LABEL} #{signature}: #{payload}" }
 
       with_grouped_payload(payload) do |resource_hash, destination|
         url = URI.join(


### PR DESCRIPTION
In #488 a lot of users mentioned that they see performance slowdown when they
enable APM. My theory is that this is due to the fact that we log debug
output. Converting `payload` to string is expensive. The Logger library offers
another way to log:

https://ruby-doc.org/stdlib-2.4.0/libdoc/logger/rdoc/Logger.html#class-Logger-label-How+to+log+a+message
> The block form allows you to create potentially complex log messages, but to
> delay their evaluation until and unless the message is logged.

This should help with performance. I dropped a `binding.pry` in the context of
the debug statement and ran benchmarks to verify this (logger level is
`Logger::ERROR`):

```
[7] pry(#<Airbrake::PerformanceNotifier>)> ::Benchmark.ips do |ips|
[7] pry(#<Airbrake::PerformanceNotifier>)*   ips.report('inline') do
[7] pry(#<Airbrake::PerformanceNotifier>)*     logger.debug("#{LOG_LABEL} #{signature}: #{payload}")
[7] pry(#<Airbrake::PerformanceNotifier>)*   end
[7] pry(#<Airbrake::PerformanceNotifier>)*   ips.report('block') do
[7] pry(#<Airbrake::PerformanceNotifier>)*     logger.debug { "#{LOG_LABEL} #{signature}: #{payload}" }
[7] pry(#<Airbrake::PerformanceNotifier>)*   end
[7] pry(#<Airbrake::PerformanceNotifier>)* end
Warming up --------------------------------------
              inline     3.006k i/100ms
               block   101.266k i/100ms
Calculating -------------------------------------
              inline     31.775k (± 2.3%) i/s -    159.318k in   5.016549s
               block      1.341M (± 6.4%) i/s -      6.684M in   5.001161s
```

This is a huge difference. Production apps usually don't debug production, so
they shouldn't be suffering this performance hit. That said, the issue is not
completely solved since apps that do use the `debug` severity still suffer a
performance hit. This should be resolved separately.