### PR TITLE
stat: define custom #inspect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Airbrake Ruby Changelog
 
 * Improved performance of `PerformanceNotifier` (sic!)
   ([#490](https://github.com/airbrake/airbrake-ruby/pull/490))
+* Improved performance of `Airbrake::Stat` when logging (or inspecting)
+  ([#491](https://github.com/airbrake/airbrake-ruby/pull/491))
 
 ### [v4.5.0][v4.5.0] (June 25, 2019)
 

--- a/lib/airbrake-ruby/stat.rb
+++ b/lib/airbrake-ruby/stat.rb
@@ -1,5 +1,6 @@
 require 'base64'
 
+# rubocop:disable Metrics/BlockLength
 module Airbrake
   # Stat is a data structure that allows accumulating performance data (route
   # performance, SQL query performance and such). It's powered by TDigests.
@@ -58,5 +59,15 @@ module Airbrake
 
       tdigest.push(ms)
     end
+
+    # We define custom inspect so that we weed out uninformative TDigest, which
+    # is also very slow to dump when we log Airbrake::Stat.
+    #
+    # @return [String]
+    def inspect
+      "#<struct Airbrake::Stat count=#{count}, sum=#{sum}, sumsq=#{sumsq}>"
+    end
+    alias_method :pretty_print, :inspect
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/spec/stat_spec.rb
+++ b/spec/stat_spec.rb
@@ -30,4 +30,18 @@ RSpec.describe Airbrake::Stat do
       expect(subject.tdigest.size).to eq(1)
     end
   end
+
+  describe "#inspect" do
+    it "provides custom inspect output" do
+      expect(subject.inspect).to eq(
+        '#<struct Airbrake::Stat count=0, sum=0.0, sumsq=0.0>'
+      )
+    end
+  end
+
+  describe "#pretty_print" do
+    it "is an alias of #inspect" do
+      expect(subject.method(:pretty_print)).to eql(subject.method(:inspect))
+    end
+  end
 end


### PR DESCRIPTION
Hopefully fixes #488 (Increase in CPU usage when performance_stats = true)

I noticed that dumping TDigest is very slow. Here's performance payload with
TDigests:

```
Warming up --------------------------------------
                         1.553k i/100ms
Calculating -------------------------------------
                         15.906k (± 3.0%) i/s -     80.756k in   5.082704s
```

And here's the same payload but without TDigests.

```
Warming up --------------------------------------
                          4.443k i/100ms
Calculating -------------------------------------
                         45.498k (± 1.8%) i/s -    231.036k in   5.079495s
```

It makes sense to not dump TDigests because it's mostly clutter and it makes
performance much worse.