### PR TITLE
Implement the "query_stats" option and disable it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Airbrake Ruby Changelog
   have effect because `performance_stats` has higher precedence. It's also
   disabled by default, and it's currently in alpha (works only for some
   accounts). Enabling is not recommended for now.
-  ([#491](https://github.com/airbrake/airbrake-ruby/pull/491))
+  ([#495](https://github.com/airbrake/airbrake-ruby/pull/495))
 
 ### [v4.5.1][v4.5.1] (July 29, 2019)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ Airbrake Ruby Changelog
 
 ### master
 
+* Added the `query_stats` option that configures SQL performance
+  monitoring. If `performance_stats` is `false`, setting this to `true` won't
+  have effect because `performance_stats` has higher precedence. It's also
+  disabled by default, and it's currently in alpha (works only for some
+  accounts). Enabling is not recommended for now.
+  ([#491](https://github.com/airbrake/airbrake-ruby/pull/491))
+
 ### [v4.5.1][v4.5.1] (July 29, 2019)
 
 * Improved performance of `PerformanceNotifier` (sic!)

--- a/README.md
+++ b/README.md
@@ -358,17 +358,35 @@ end
 #### performance_stats
 
 Configures [Airbrake Performance Monitoring][airbrake-performance-monitoring]
-statistics collection (routes, SQL queries). These are displayed on the
+statistics collection aggregated per route. These are displayed on the
 Performance tab of your project. By default, it's enabled.
 
 The statistics is sent via:
 
 * [`Airbrake.notify_request`](#airbrakenotify_request)
-* [`Airbrake.notify_query`](#airbrakenotify_query)
 
 ```ruby
 Airbrake.configure do |c|
   c.performance_stats = true
+end
+```
+
+#### query_stats
+
+Configures [Airbrake Performance Monitoring][airbrake-performance-monitoring]
+query collection. These are displayed on the Performance tab of your project. If
+`performance_stats` is `false`, setting this to `true` won't have effect because
+`performance_stats` has higher precedence. By default, it's disabled.
+**WARNING**: this feature is currently in alpha and it's not available for all
+accounts.
+
+The statistics is sent via:
+
+* [`Airbrake.notify_query`](#airbrakenotify_query)
+
+```ruby
+Airbrake.configure do |c|
+  c.query_stats = false
 end
 ```
 

--- a/lib/airbrake-ruby/config.rb
+++ b/lib/airbrake-ruby/config.rb
@@ -83,8 +83,8 @@ module Airbrake
     # @since v2.5.0
     attr_accessor :code_hunks
 
-    # @return [Boolean] true if the library should send performance stats
-    #   information to Airbrake (routes, SQL queries), false otherwise
+    # @return [Boolean] true if the library should send route performance stats
+    #   to Airbrake, false otherwise
     # @api public
     # @since v3.2.0
     attr_accessor :performance_stats
@@ -94,6 +94,12 @@ module Airbrake
     # @api public
     # @since v3.2.0
     attr_accessor :performance_stats_flush_period
+
+    # @return [Boolean] true if the library should send SQL stats to Airbrake,
+    #   false otherwise
+    # @api public
+    # @since v4.6.0
+    attr_accessor :query_stats
 
     class << self
       # @return [Config]
@@ -132,6 +138,7 @@ module Airbrake
       self.versions = {}
       self.performance_stats = true
       self.performance_stats_flush_period = 15
+      self.query_stats = false
 
       merge(user_config)
     end
@@ -195,6 +202,20 @@ module Airbrake
       return promise if promise.rejected?
 
       check_notify_ability
+    end
+
+    # @return [Promise] resolved promise if neither of the performance options
+    #   reject it, false otherwise
+    def check_performance_options(resource)
+      promise = Airbrake::Promise.new
+
+      if !performance_stats
+        promise.reject("The Performance Stats feature is disabled")
+      elsif resource.is_a?(Airbrake::Query) && !query_stats
+        promise.reject("The Query Stats feature is disabled")
+      else
+        promise
+      end
     end
 
     private

--- a/lib/airbrake-ruby/config.rb
+++ b/lib/airbrake-ruby/config.rb
@@ -91,7 +91,7 @@ module Airbrake
 
     # @return [Integer] how many seconds to wait before sending collected route
     #   stats
-    # @api public
+    # @api private
     # @since v3.2.0
     attr_accessor :performance_stats_flush_period
 

--- a/lib/airbrake-ruby/performance_notifier.rb
+++ b/lib/airbrake-ruby/performance_notifier.rb
@@ -25,10 +25,8 @@ module Airbrake
       promise = @config.check_configuration
       return promise if promise.rejected?
 
-      promise = Airbrake::Promise.new
-      unless @config.performance_stats
-        return promise.reject("The Performance Stats feature is disabled")
-      end
+      promise = @config.check_performance_options(resource)
+      return promise if promise.rejected?
 
       @filter_chain.refine(resource)
       return if resource.ignored?

--- a/spec/performance_notifier_spec.rb
+++ b/spec/performance_notifier_spec.rb
@@ -285,19 +285,13 @@ RSpec.describe Airbrake::PerformanceNotifier do
       expect(promise.value).to eq('' => nil)
     end
 
-    it "doesn't send route stats when current environment is ignored" do
-      Airbrake::Config.instance.merge(
-        performance_stats: true, environment: 'test', ignore_environments: %w[test]
+    it "checks performance stat configuration" do
+      request = Airbrake::Request.new(
+        method: 'GET', route: '/foo', status_code: 200, start_time: Time.new
       )
-
-      promise = subject.notify(
-        Airbrake::Request.new(
-          method: 'GET', route: '/foo', status_code: 200, start_time: Time.new
-        )
-      )
-
-      expect(a_request(:put, routes)).not_to have_been_made
-      expect(promise.value).to eq('error' => "current environment 'test' is ignored")
+      expect(Airbrake::Config.instance).to receive(:check_performance_options)
+        .with(request).and_return(Airbrake::Promise.new)
+      subject.notify(request)
     end
 
     it "sends environment when it's specified" do

--- a/spec/performance_notifier_spec.rb
+++ b/spec/performance_notifier_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe Airbrake::PerformanceNotifier do
       project_id: 1,
       project_key: 'banana',
       performance_stats: true,
-      performance_stats_flush_period: 0
+      performance_stats_flush_period: 0,
+      query_stats: true
     )
   end
 
@@ -282,21 +283,6 @@ RSpec.describe Airbrake::PerformanceNotifier do
       )
       expect(promise).to be_an(Airbrake::Promise)
       expect(promise.value).to eq('' => nil)
-    end
-
-    it "doesn't send route stats when performance stats are disabled" do
-      Airbrake::Config.instance.merge(performance_stats: false)
-
-      promise = subject.notify(
-        Airbrake::Request.new(
-          method: 'GET', route: '/foo', status_code: 200, start_time: Time.new
-        )
-      )
-
-      expect(a_request(:put, routes)).not_to have_been_made
-      expect(promise.value).to eq(
-        'error' => "The Performance Stats feature is disabled"
-      )
     end
 
     it "doesn't send route stats when current environment is ignored" do


### PR DESCRIPTION
Likely fixes:

* airbrake/airbrake#994 (Memory usage)
* airbrake/airbrake#990 (CPU and Average Response
  increased after version 7)

The SQL query collection feature is still in alpha and we display it only for
certain accounts. Therefore, the vast majority of our customers cannot even see
what airbrake-ruby collects. Since the feature is still in alpha, it is
currently buggy (in a sense that it consumes too much memory & CPU power).

I profiled a Rails app on a certain route with `memory_profiler` for Rack Mini
Profiler and I can see a significant increase of memory usage.

=== performance_stats = false

```
Total allocated: 12434583 bytes (145711 objects)
Total retained:  508023 bytes (3346 objects)

allocated memory by gem

       264  airbrake/lib
```

=== performance_stats = true && query_stats = false

```
Total allocated: 12461685 bytes (146002 objects)
Total retained:  508431 bytes (3353 objects)

allocated memory by gem

      3816  airbrake/lib
```

=== performance_stats = true && query_stats = true

```
Total allocated: 186535107 bytes (1447037 objects)
Total retained:  35810972 bytes (349882 objects)

allocated memory by gem

    709720  airbrake/lib
```

According to these reports memory usage ramped up by 700% compared to the route
stats feature. The route stats feature itself is already quite expensive and the
query collection feature is just too much.