### PR TITLE
request,query,breakdown: calculate UTC start time on initialization

### DIFF
--- a/lib/airbrake-ruby/performance_breakdown.rb
+++ b/lib/airbrake-ruby/performance_breakdown.rb
@@ -21,6 +21,7 @@ module Airbrake
       start_time:,
       end_time: Time.now
     )
+      @start_time_utc = TimeTruncate.utc_truncate_minutes(start_time)
       super(method, route, response_type, groups, start_time, end_time)
     end
 
@@ -37,7 +38,7 @@ module Airbrake
         'method' => method,
         'route' => route,
         'responseType' => response_type,
-        'time' => TimeTruncate.utc_truncate_minutes(start_time)
+        'time' => @start_time_utc
       }.delete_if { |_key, val| val.nil? }
     end
   end

--- a/lib/airbrake-ruby/query.rb
+++ b/lib/airbrake-ruby/query.rb
@@ -22,6 +22,7 @@ module Airbrake
       start_time:,
       end_time: Time.now
     )
+      @start_time_utc = TimeTruncate.utc_truncate_minutes(start_time)
       super(method, route, query, func, file, line, start_time, end_time)
     end
 
@@ -42,7 +43,7 @@ module Airbrake
         'method' => method,
         'route' => route,
         'query' => query,
-        'time' => TimeTruncate.utc_truncate_minutes(start_time),
+        'time' => @start_time_utc,
         'function' => func,
         'file' => file,
         'line' => line

--- a/lib/airbrake-ruby/request.rb
+++ b/lib/airbrake-ruby/request.rb
@@ -17,6 +17,7 @@ module Airbrake
       start_time:,
       end_time: Time.now
     )
+      @start_time_utc = TimeTruncate.utc_truncate_minutes(start_time)
       super(method, route, status_code, start_time, end_time)
     end
 
@@ -37,7 +38,7 @@ module Airbrake
         'method' => method,
         'route' => route,
         'statusCode' => status_code,
-        'time' => TimeTruncate.utc_truncate_minutes(start_time)
+        'time' => @start_time_utc
       }.delete_if { |_key, val| val.nil? }
     end
   end


### PR DESCRIPTION
This reduces memory consumption by TimeTruncate from 13000 bytes down to ~135
per request according to `memory_profiler` and a Rails 5 app.