### PR TITLE
performance_notifier: always join the background thread

### DIFF
--- a/lib/airbrake-ruby/performance_notifier.rb
+++ b/lib/airbrake-ruby/performance_notifier.rb
@@ -62,14 +62,18 @@ module Airbrake
     end
 
     def schedule_flush(promise)
-      @schedule_flush ||= Thread.new do
+      if @schedule_flush
+        return if @schedule_flush.alive?
+        @schedule_flush.join
+      end
+
+      @schedule_flush = Thread.new do
         sleep(@flush_period)
 
         payload = nil
         @mutex.synchronize do
           payload = @payload
           @payload = {}
-          @schedule_flush = nil
         end
 
         send(payload, promise)


### PR DESCRIPTION
In the current version of the code the background thread clears the variable
that the parent thread reserved for it. This is illogical and probably error
prone.

With this change the parent thread takes care of cleaning up the child, so that
the child knows nothing of how it is managed. This makes much more sense.