### PR TITLE
performance_notifier: reuse the same thread for flushing

### DIFF
--- a/lib/airbrake-ruby.rb
+++ b/lib/airbrake-ruby.rb
@@ -253,6 +253,7 @@ module Airbrake
     # @return [void]
     def close
       notice_notifier.close
+      performance_notifier.close
     end
 
     # Pings the Airbrake Deploy API endpoint about the occurred deploy.

--- a/spec/filters/thread_filter_spec.rb
+++ b/spec/filters/thread_filter_spec.rb
@@ -245,12 +245,12 @@ RSpec.describe Airbrake::Filters::ThreadFilter do
 
   it "appends thread inspect (self)" do
     subject.call(notice)
-    expect(notice[:params][:thread][:self]).to match(/\A#<Thread:.+ run>\z/)
+    expect(notice[:params][:thread][:self]).to match(/\A#<Thread:.+>\z/)
   end
 
   it "appends thread group" do
     subject.call(notice)
-    expect(notice[:params][:thread][:group][0]).to match(/\A#<Thread:.+ run>\z/)
+    expect(notice[:params][:thread][:group][0]).to match(/\A#<Thread:.+>\z/)
   end
 
   it "appends priority" do


### PR DESCRIPTION
Previously, we would spawn a new thread every 15 seconds. According to
RackMiniProfile, this would use around 1.05MB of memory per request on my route
that makes a few SQL queries, which makes it #1 gem that wastes memory for my
Rails 5 app (both allocated and retained).

Spawning threads implies significant overhead, so I realised we don't actually
need to spawn anything. We can have just one thread that sleeps until more work
is given. Then this timer thread would fire and sleep again (unless there's more
work to do).

As result, we use a lot less memory (basically, only the memory needed to
pass payload to the worker thread). The downside is that we no longer support
promises properly (if a request fails in background, the promise will not tell),
but this seems to be a reasonable compromise for the benefit we gain.