### PR TITLE
filters/sql: apply more aggressive grouping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Airbrake Ruby Changelog
 
 ### master
 
+* Improved grouping of some SQL queries
+  ([#504](https://github.com/airbrake/airbrake-ruby/pull/504))
+
 ### [v4.6.0][v4.6.0] (August 5, 2019)
 
 * Added the `query_stats` option that configures SQL performance

--- a/lib/airbrake-ruby/filters/sql_filter.rb
+++ b/lib/airbrake-ruby/filters/sql_filter.rb
@@ -37,6 +37,10 @@ module Airbrake
         # rubocop:enable Metrics/LineLength
       }.freeze
 
+      # @return [Regexp] the regexp that is applied after the feature regexps
+      #   were used
+      POST_FILTER = /(?<=[values|in ]\().+(?=\))/i
+
       # @return [Hash{Symbol=>Array<Symbol>}] a set of features that corresponds
       #   to a certain dialect
       DIALECT_FEATURES = {
@@ -96,6 +100,7 @@ module Airbrake
         return unless resource.respond_to?(:query)
 
         q = resource.query.gsub(@regexp, FILTERED)
+        q.gsub!(POST_FILTER, FILTERED) if q =~ POST_FILTER
         q = ERROR_MSG if UNMATCHED_PAIR[@dialect] =~ q
         resource.query = q
       end

--- a/spec/filters/sql_filter_spec.rb
+++ b/spec/filters/sql_filter_spec.rb
@@ -60,7 +60,11 @@ RSpec.describe Airbrake::Filters::SqlFilter do
       dialects: %i[postgres]
     }, {
       input: "INSERT INTO `X` values(\"test\",0, 1 , 2, 'test')",
-      output: "INSERT INTO `X` values(?,?, ? , ?, ?)",
+      output: "INSERT INTO `X` values(?)",
+      dialects: %i[mysql]
+    }, {
+      input: "INSERT INTO `X` values(\"test\",0, 1 , 2, 'test')",
+      output: "INSERT INTO `X` values(?)",
       dialects: %i[mysql]
     }, {
       input: "SELECT c11.col1, c22.col2 FROM table c11, table c22 WHERE value='nothing'",
@@ -68,7 +72,7 @@ RSpec.describe Airbrake::Filters::SqlFilter do
       dialects: ALL_DIALECTS
     }, {
       input: "INSERT INTO X VALUES(1, 23456, 123.456, 99+100)",
-      output: "INSERT INTO X VALUES(?, ?, ?, ?+?)",
+      output: "INSERT INTO X VALUES(?)",
       dialects: ALL_DIALECTS
     }, {
       input: "SELECT * FROM table WHERE name=\"foo\" AND value=\"don't\"",
@@ -117,7 +121,7 @@ RSpec.describe Airbrake::Filters::SqlFilter do
       dialects: ALL_DIALECTS
     }, {
       input: "INSERT INTO X values('', 'a''b c',0, 1 , 'd''e f''s h')",
-      output: "INSERT INTO X values(?, ?,?, ? , ?)",
+      output: "INSERT INTO X values(?)",
       dialects: ALL_DIALECTS
     }, {
       input: "SELECT * FROM t WHERE -- '\n  bar='baz' -- '",
@@ -153,7 +157,7 @@ RSpec.describe Airbrake::Filters::SqlFilter do
       dialects: %i[postgres]
     }, {
       input: "INSERT INTO \"foo\" (\"bar\", \"baz\", \"qux\") VALUES ($1, $2, $3) RETURNING \"id\"",
-      output: "INSERT INTO \"foo\" (\"bar\", \"baz\", \"qux\") VALUES ($?, $?, $?) RETURNING \"id\"",
+      output: "INSERT INTO \"foo\" (?) RETURNING \"id\"",
       dialects: %i[postgres]
     }, {
       input: "select * from foo where bar = 'some\\tthing' and baz = 10",


### PR DESCRIPTION
The number of arguments to `VALUES` or `IN` shouldn't matter. With this change
our grouping is more consistent.