### PR TITLE
rubocop: enforce trailing commas

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -86,3 +86,12 @@ Naming/UncommunicativeMethodParamName:
 
 Gemspec/RequiredRubyVersion:
   Enabled: false
+
+Style/TrailingCommaInArguments:
+  EnforcedStyleForMultiline: comma
+
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: comma
+
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: comma

--- a/benchmarks/benchmark_helpers.rb
+++ b/benchmarks/benchmark_helpers.rb
@@ -128,7 +128,7 @@ BIG_EXCEPTION.set_backtrace(
    "bin/spring:48:in `<top (required)>'",
    "lib/spring/binstub.rb:11:in `<top (required)>'",
    "lin/spring:13:in `<top (required)>'",
-   "bin/rails:3:in `<main>'"]
+   "bin/rails:3:in `<main>'"],
 )
 
 SMALL_EXCEPTION = RuntimeError.new('App crashed!')
@@ -145,7 +145,7 @@ SMALL_EXCEPTION.set_backtrace(
    "/home/kyrylo/.gem/ruby/2.2.2/gems/rspec-core-3.3.2/lib/rspec/core/runner.rb:88:in `run'",
    "/home/kyrylo/.gem/ruby/2.2.2/gems/rspec-core-3.3.2/lib/rspec/core/runner.rb:73:in `run'",
    "/home/kyrylo/.gem/ruby/2.2.2/gems/rspec-core-3.3.2/lib/rspec/core/runner.rb:41:in `invoke'",
-   "/home/kyrylo/.gem/ruby/2.2.2/gems/rspec-core-3.3.2/exe/rspec:4:in `<main>'"]
+   "/home/kyrylo/.gem/ruby/2.2.2/gems/rspec-core-3.3.2/exe/rspec:4:in `<main>'"],
 )
 # rubocop:enable Metrics/LineLength
 

--- a/benchmarks/notify_async_workers.rb
+++ b/benchmarks/notify_async_workers.rb
@@ -19,7 +19,7 @@ config_hash = {
   project_id: 112261,
   project_key: 'c7aaceb2ccb579e6b710cea9da22c526',
   logger: Logger.new('/dev/null'),
-  host: 'http://localhost:8080'
+  host: 'http://localhost:8080',
 }
 
 Airbrake.configure(:workers_1) do |c|

--- a/benchmarks/performance.rb
+++ b/benchmarks/performance.rb
@@ -16,7 +16,7 @@ query = {
   file: 'foo.rb',
   line: 123,
   start_time: Time.new - 200,
-  end_time: Time.new
+  end_time: Time.new,
 }
 
 request = {
@@ -24,7 +24,7 @@ request = {
   route: '/things/1',
   status_code: 200,
   start_time: Time.new - 200,
-  end_time: Time.new
+  end_time: Time.new,
 }
 
 breakdown = {
@@ -32,7 +32,7 @@ breakdown = {
   route: '/things/1',
   response_type: 'json',
   groups: { db: 24.0, view: 0.4 },
-  start_time: Time.new
+  start_time: Time.new,
 }
 
 Benchmark.ips do |ips|

--- a/lib/airbrake-ruby.rb
+++ b/lib/airbrake-ruby.rb
@@ -535,7 +535,7 @@ module Airbrake
         Airbrake::Filters::RootDirectoryFilter,
         Airbrake::Filters::GitRevisionFilter,
         Airbrake::Filters::GitRepositoryFilter,
-        Airbrake::Filters::GitLastCheckoutFilter
+        Airbrake::Filters::GitLastCheckoutFilter,
       ].each do |filter|
         notice_notifier.add_filter(filter.new(config.root_directory))
       end

--- a/lib/airbrake-ruby/async_sender.rb
+++ b/lib/airbrake-ruby/async_sender.rb
@@ -54,7 +54,7 @@ module Airbrake
         ThreadPool.new(
           worker_size: @config.workers,
           queue_size: @config.queue_size,
-          block: proc { |args| sender.send(*args) }
+          block: proc { |args| sender.send(*args) },
         )
       end
     end
@@ -71,8 +71,8 @@ module Airbrake
           message: error[:message],
           backtrace: error[:backtrace].map do |line|
             "#{line[:file]}:#{line[:line]} in `#{line[:function]}'"
-          end.join("\n")
-        )
+          end.join("\n"),
+        ),
       )
       promise.reject("AsyncSender has reached its capacity of #{@config.queue_size}")
     end

--- a/lib/airbrake-ruby/backtrace.rb
+++ b/lib/airbrake-ruby/backtrace.rb
@@ -147,13 +147,13 @@ module Airbrake
           return {
             file: match[:file],
             line: (Integer(match[:line]) if match[:line]),
-            function: match[:function]
+            function: match[:function],
           }
         end
 
         logger.error(
           "can't parse '#{stackframe}' (please file an issue so we can fix " \
-          "it: https://github.com/airbrake/airbrake-ruby/issues/new)"
+          "it: https://github.com/airbrake/airbrake-ruby/issues/new)",
         )
         { file: nil, line: nil, function: stackframe }
       end

--- a/lib/airbrake-ruby/code_hunk.rb
+++ b/lib/airbrake-ruby/code_hunk.rb
@@ -30,7 +30,7 @@ module Airbrake
       Airbrake::FileCache[file] ||= File.foreach(file)
     rescue StandardError => ex
       logger.error(
-        "#{self.class.name}: can't read code hunk for #{file}: #{ex}"
+        "#{self.class.name}: can't read code hunk for #{file}: #{ex}",
       )
       nil
     end

--- a/lib/airbrake-ruby/config.rb
+++ b/lib/airbrake-ruby/config.rb
@@ -132,7 +132,7 @@ module Airbrake
 
       self.root_directory = File.realpath(
         (defined?(Bundler) && Bundler.root) ||
-        Dir.pwd
+        Dir.pwd,
       )
 
       self.versions = {}

--- a/lib/airbrake-ruby/config/validator.rb
+++ b/lib/airbrake-ruby/config/validator.rb
@@ -29,7 +29,7 @@ module Airbrake
             return promise.reject(
               "the 'environment' option must be configured " \
               "with a Symbol (or String), but '#{config.environment.class}' was " \
-              "provided: #{config.environment}"
+              "provided: #{config.environment}",
             )
           end
 
@@ -46,7 +46,7 @@ module Airbrake
 
           if ignored_environment?(config)
             return promise.reject(
-              "current environment '#{config.environment}' is ignored"
+              "current environment '#{config.environment}' is ignored",
             )
           end
 
@@ -74,7 +74,7 @@ module Airbrake
           if config.ignore_environments.any? && config.environment.nil?
             config.logger.warn(
               "#{LOG_LABEL} the 'environment' option is not set, " \
-              "'ignore_environments' has no effect"
+              "'ignore_environments' has no effect",
             )
           end
 

--- a/lib/airbrake-ruby/deploy_notifier.rb
+++ b/lib/airbrake-ruby/deploy_notifier.rb
@@ -27,7 +27,7 @@ module Airbrake
       @sender.send(
         deploy_info,
         promise,
-        URI.join(@config.host, "api/v4/projects/#{@config.project_id}/deploys")
+        URI.join(@config.host, "api/v4/projects/#{@config.project_id}/deploys"),
       )
 
       promise

--- a/lib/airbrake-ruby/filters/exception_attributes_filter.rb
+++ b/lib/airbrake-ruby/filters/exception_attributes_filter.rb
@@ -22,13 +22,13 @@ module Airbrake
           attributes = exception.to_airbrake
         rescue StandardError => ex
           logger.error(
-            "#{LOG_LABEL} #{exception.class}#to_airbrake failed. #{ex.class}: #{ex}"
+            "#{LOG_LABEL} #{exception.class}#to_airbrake failed. #{ex.class}: #{ex}",
           )
         end
 
         unless attributes.is_a?(Hash)
           logger.error(
-            "#{LOG_LABEL} #{self.class}: wanted Hash, got #{attributes.class}"
+            "#{LOG_LABEL} #{self.class}: wanted Hash, got #{attributes.class}",
           )
           return
         end

--- a/lib/airbrake-ruby/filters/git_last_checkout_filter.rb
+++ b/lib/airbrake-ruby/filters/git_last_checkout_filter.rb
@@ -52,7 +52,7 @@ module Airbrake
         parts = line.chomp.split("\t").first.split(' ')
         if parts.size < MIN_HEAD_COLS
           logger.error(
-            "#{LOG_LABEL} Airbrake::#{self.class.name}: can't parse line: #{line}"
+            "#{LOG_LABEL} Airbrake::#{self.class.name}: can't parse line: #{line}",
           )
           return
         end
@@ -62,7 +62,7 @@ module Airbrake
           username: author[0..1].join(' '),
           email: parts[-3][1..-2],
           revision: parts[1],
-          time: timestamp(parts[-2].to_i)
+          time: timestamp(parts[-2].to_i),
         }
       end
       # rubocop:enable Metrics/AbcSize

--- a/lib/airbrake-ruby/filters/keys_filter.rb
+++ b/lib/airbrake-ruby/filters/keys_filter.rb
@@ -124,7 +124,7 @@ module Airbrake
 
         logger.error(
           "#{LOG_LABEL} one of the patterns in #{self.class} is invalid. " \
-          "Known patterns: #{@patterns}"
+          "Known patterns: #{@patterns}",
         )
       end
 

--- a/lib/airbrake-ruby/filters/sql_filter.rb
+++ b/lib/airbrake-ruby/filters/sql_filter.rb
@@ -64,7 +64,7 @@ module Airbrake
         cassandra: %i[
           single_quotes uuids numeric_literals boolean_literals
           hexadecimal_literals comments multi_line_comments
-        ].freeze
+        ].freeze,
       }.freeze
 
       # @return [Hash{Symbol=>Regexp}] a set of regexps to check for unmatches
@@ -76,7 +76,7 @@ module Airbrake
         sqlite: %r{'|/\*|\*/},
         cassandra: %r{'|/\*|\*/},
         oracle: %r{'|/\*|\*/},
-        oracle_enhanced: %r{'|/\*|\*/}
+        oracle_enhanced: %r{'|/\*|\*/},
       }.freeze
 
       # @return [Array<Regexp>] the list of queries to be ignored
@@ -89,7 +89,7 @@ module Airbrake
         /FROM pg_attribute/i,
         /FROM pg_index/i,
         /FROM pg_class/i,
-        /FROM pg_type/i
+        /FROM pg_type/i,
       ].freeze
 
       def initialize(dialect)

--- a/lib/airbrake-ruby/filters/thread_filter.rb
+++ b/lib/airbrake-ruby/filters/thread_filter.rb
@@ -16,7 +16,7 @@ module Airbrake
         String,
         Symbol,
         Regexp,
-        Numeric
+        Numeric,
       ].freeze
 
       # Variables starting with this prefix are not attached to a notice.

--- a/lib/airbrake-ruby/inspectable.rb
+++ b/lib/airbrake-ruby/inspectable.rb
@@ -21,7 +21,7 @@ module Airbrake
         project_id: @config.project_id,
         project_key: @config.project_key,
         host: @config.host,
-        filter_chain: @filter_chain.inspect
+        filter_chain: @filter_chain.inspect,
       )
     end
 
@@ -30,7 +30,7 @@ module Airbrake
       q.text("#<#{self.class}:0x#{(object_id << 1).to_s(16).rjust(16, '0')} ")
       q.text(
         "project_id=\"#{@config.project_id}\" project_key=\"#{@config.project_key}\" " \
-        "host=\"#{@config.host}\" filter_chain="
+        "host=\"#{@config.host}\" filter_chain=",
       )
       q.pp(@filter_chain)
       q.text('>')

--- a/lib/airbrake-ruby/notice.rb
+++ b/lib/airbrake-ruby/notice.rb
@@ -8,7 +8,7 @@ module Airbrake
     NOTIFIER = {
       name: 'airbrake-ruby'.freeze,
       version: Airbrake::AIRBRAKE_RUBY_VERSION,
-      url: 'https://github.com/airbrake/airbrake-ruby'.freeze
+      url: 'https://github.com/airbrake/airbrake-ruby'.freeze,
     }.freeze
 
     # @return [Hash{Symbol=>String,Hash}] the information to be displayed in the
@@ -16,7 +16,7 @@ module Airbrake
     CONTEXT = {
       os: RUBY_PLATFORM,
       language: "#{RUBY_ENGINE}/#{RUBY_VERSION}".freeze,
-      notifier: NOTIFIER
+      notifier: NOTIFIER,
     }.freeze
 
     # @return [Integer] the maxium size of the JSON payload in bytes
@@ -32,7 +32,7 @@ module Airbrake
       IOError,
       NotImplementedError,
       JSON::GeneratorError,
-      Encoding::UndefinedConversionError
+      Encoding::UndefinedConversionError,
     ].freeze
 
     # @return [Array<Symbol>] the list of keys that can be be overwritten with
@@ -60,10 +60,10 @@ module Airbrake
         errors: NestedException.new(exception).as_json,
         context: context,
         environment: {
-          program_name: $PROGRAM_NAME
+          program_name: $PROGRAM_NAME,
         },
         session: {},
-        params: params
+        params: params,
       }
       @truncator = Airbrake::Truncator.new(PAYLOAD_MAX_SIZE)
 
@@ -138,7 +138,7 @@ module Airbrake
         # Make sure we always send hostname.
         hostname: HOSTNAME,
 
-        severity: DEFAULT_SEVERITY
+        severity: DEFAULT_SEVERITY,
       }.merge(CONTEXT).delete_if { |_key, val| val.nil? || val.empty? }
     end
 
@@ -152,7 +152,7 @@ module Airbrake
         logger.error(
           "#{LOG_LABEL} truncation failed. File an issue at " \
           "https://github.com/airbrake/airbrake-ruby " \
-          "and attach the following payload: #{@payload}"
+          "and attach the following payload: #{@payload}",
         )
       end
 

--- a/lib/airbrake-ruby/notice_notifier.rb
+++ b/lib/airbrake-ruby/notice_notifier.rb
@@ -116,7 +116,7 @@ module Airbrake
 
       logger.warn(
         "#{LOG_LABEL} falling back to sync delivery because there are no " \
-        "running async workers"
+        "running async workers",
       )
       @sync_sender
     end

--- a/lib/airbrake-ruby/performance_breakdown.rb
+++ b/lib/airbrake-ruby/performance_breakdown.rb
@@ -39,7 +39,7 @@ module Airbrake
         'method' => method,
         'route' => route,
         'responseType' => response_type,
-        'time' => @start_time_utc
+        'time' => @start_time_utc,
       }.delete_if { |_key, val| val.nil? }
     end
   end

--- a/lib/airbrake-ruby/performance_notifier.rb
+++ b/lib/airbrake-ruby/performance_notifier.rb
@@ -120,7 +120,7 @@ module Airbrake
       with_grouped_payload(payload) do |resource_hash, destination|
         url = URI.join(
           @config.host,
-          "api/v5/projects/#{@config.project_id}/#{destination}"
+          "api/v5/projects/#{@config.project_id}/#{destination}",
         )
         @sender.send(resource_hash, promise, url)
       end

--- a/lib/airbrake-ruby/query.rb
+++ b/lib/airbrake-ruby/query.rb
@@ -44,7 +44,7 @@ module Airbrake
         'time' => @start_time_utc,
         'function' => func,
         'file' => file,
-        'line' => line
+        'line' => line,
       }.delete_if { |_key, val| val.nil? }
     end
     # rubocop:enable Metrics/ParameterLists, Metrics/BlockLength

--- a/lib/airbrake-ruby/queue.rb
+++ b/lib/airbrake-ruby/queue.rb
@@ -33,14 +33,14 @@ module Airbrake
       {
         'queue' => queue,
         'errorCount' => error_count,
-        'time' => @start_time_utc
+        'time' => @start_time_utc,
       }
     end
 
     def hash
       {
         'queue' => queue,
-        'time' => @start_time_utc
+        'time' => @start_time_utc,
       }.hash
     end
 

--- a/lib/airbrake-ruby/request.rb
+++ b/lib/airbrake-ruby/request.rb
@@ -36,7 +36,7 @@ module Airbrake
         'method' => method,
         'route' => route,
         'statusCode' => status_code,
-        'time' => @start_time_utc
+        'time' => @start_time_utc,
       }.delete_if { |_key, val| val.nil? }
     end
   end

--- a/lib/airbrake-ruby/stat.rb
+++ b/lib/airbrake-ruby/stat.rb
@@ -32,7 +32,7 @@ module Airbrake
         'count' => count,
         'sum' => sum,
         'sumsq' => sumsq,
-        'tdigest' => Base64.strict_encode64(tdigest.as_small_bytes)
+        'tdigest' => Base64.strict_encode64(tdigest.as_small_bytes),
       }
     end
 

--- a/spec/airbrake_spec.rb
+++ b/spec/airbrake_spec.rb
@@ -206,7 +206,7 @@ RSpec.describe Airbrake do
           method: 'GET',
           route: '/',
           status_code: 200,
-          start_time: Time.now
+          start_time: Time.now,
         )
       end
     end
@@ -222,9 +222,9 @@ RSpec.describe Airbrake do
             method: 'GET',
             route: '/',
             status_code: 200,
-            start_time: Time.now
+            start_time: Time.now,
           },
-          request_id: 1
+          request_id: 1,
         )
       end
     end
@@ -241,7 +241,7 @@ RSpec.describe Airbrake do
           method: 'GET',
           route: '/',
           query: '',
-          start_time: Time.now
+          start_time: Time.now,
         )
       end
     end
@@ -257,9 +257,9 @@ RSpec.describe Airbrake do
             method: 'GET',
             route: '/',
             query: '',
-            start_time: Time.now
+            start_time: Time.now,
           },
-          request_id: 1
+          request_id: 1,
         )
       end
     end
@@ -276,7 +276,7 @@ RSpec.describe Airbrake do
           method: 'GET',
           route: '/',
           query: '',
-          start_time: Time.now
+          start_time: Time.now,
         )
       end
     end
@@ -284,7 +284,7 @@ RSpec.describe Airbrake do
     context "when :stash key is provided" do
       it "adds the value as the stash of the performance breakdown" do
         expect(
-          described_class.performance_notifier
+          described_class.performance_notifier,
         ).to receive(:notify) do |performance_breakdown|
           expect(performance_breakdown.stash).to eq(request_id: 1)
         end
@@ -295,9 +295,9 @@ RSpec.describe Airbrake do
             route: '/',
             response_type: :html,
             groups: {},
-            start_time: Time.now
+            start_time: Time.now,
           },
-          request_id: 1
+          request_id: 1,
         )
       end
     end
@@ -312,7 +312,7 @@ RSpec.describe Airbrake do
 
         described_class.notify_queue(
           queue: 'bananas',
-          error_count: 10
+          error_count: 10,
         )
       end
     end
@@ -326,9 +326,9 @@ RSpec.describe Airbrake do
         described_class.notify_queue(
           {
             queue: 'bananas',
-            error_count: 10
+            error_count: 10,
           },
-          request_id: 1
+          request_id: 1,
         )
       end
     end

--- a/spec/async_sender_spec.rb
+++ b/spec/async_sender_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Airbrake::AsyncSender do
     Airbrake::Config.instance = Airbrake::Config.new(
       project_id: '1',
       workers: 3,
-      queue_size: 10
+      queue_size: 10,
     )
   end
 
@@ -35,7 +35,7 @@ RSpec.describe Airbrake::AsyncSender do
         Airbrake::Config.instance = Airbrake::Config.new(
           project_id: '1',
           workers: 0,
-          queue_size: 1
+          queue_size: 1,
         )
       end
 
@@ -55,13 +55,13 @@ RSpec.describe Airbrake::AsyncSender do
 
         expect(promise).to be_rejected
         expect(promise.value).to eq(
-          'error' => "AsyncSender has reached its capacity of 1"
+          'error' => "AsyncSender has reached its capacity of 1",
         )
       end
 
       it "logs discarded notice" do
         expect(Airbrake::Loggable.instance).to receive(:error).with(
-          /reached its capacity/
+          /reached its capacity/,
         ).at_least(:once)
 
         15.times { subject.send(notice, Airbrake::Promise.new) }

--- a/spec/backtrace_spec.rb
+++ b/spec/backtrace_spec.rb
@@ -172,13 +172,13 @@ RSpec.describe Airbrake::Backtrace do
 
       it "returns array of hashes where each unknown frame is marked as 'function'" do
         expect(
-          described_class.parse(ex)
+          described_class.parse(ex),
         ).to eq([file: nil, line: nil, function: 'a b c 1 23 321 .rb'])
       end
 
       it "logs frames that cannot be parsed" do
         expect(Airbrake::Loggable.instance).to receive(:error).with(
-          /can't parse 'a b c 1 23 321 .rb'/
+          /can't parse 'a b c 1 23 321 .rb'/,
         )
         described_class.parse(ex)
       end
@@ -280,18 +280,18 @@ RSpec.describe Airbrake::Backtrace do
                 # rubocop:disable Metrics/LineLength,Lint/InterpolationCheck
                 96 => '          @config.logger.debug("#{LOG_LABEL} `notice.to_json` failed: #{ex.class}: #{ex}")',
                 # rubocop:enable Metrics/LineLength,Lint/InterpolationCheck
-              }
+              },
             },
             {
               file: fixture_path('notroot.txt'),
               line: 3,
-              function: 'pineapple'
+              function: 'pineapple',
             },
             {
               file: project_root_path('vendor/bundle/ignored_file.rb'),
               line: 2,
-              function: 'ignore_me'
-            }
+              function: 'ignore_me',
+            },
           ]
         end
 
@@ -300,7 +300,7 @@ RSpec.describe Airbrake::Backtrace do
           backtrace = [
             project_root_path('code.rb') + ":94:in `to_json'",
             fixture_path('notroot.txt' + ":3:in `pineapple'"),
-            project_root_path('vendor/bundle/ignored_file.rb') + ":2:in `ignore_me'"
+            project_root_path('vendor/bundle/ignored_file.rb') + ":2:in `ignore_me'",
           ]
           ex.set_backtrace(backtrace)
           expect(described_class.parse(ex)).to eq(parsed_backtrace)
@@ -310,7 +310,7 @@ RSpec.describe Airbrake::Backtrace do
       context "and when root_directory is a Pathname" do
         before do
           Airbrake::Config.instance.merge(
-            root_directory: Pathname.new(project_root_path(''))
+            root_directory: Pathname.new(project_root_path('')),
           )
         end
 
@@ -328,8 +328,8 @@ RSpec.describe Airbrake::Backtrace do
                 # rubocop:disable Metrics/LineLength,Lint/InterpolationCheck
                 96 => '          @config.logger.debug("#{LOG_LABEL} `notice.to_json` failed: #{ex.class}: #{ex}")',
                 # rubocop:enable Metrics/LineLength,Lint/InterpolationCheck
-              }
-            }
+              },
+            },
           ]
         end
 
@@ -360,7 +360,7 @@ RSpec.describe Airbrake::Backtrace do
                 # rubocop:disable Metrics/LineLength,Lint/InterpolationCheck
                 96 => '          @config.logger.debug("#{LOG_LABEL} `notice.to_json` failed: #{ex.class}: #{ex}")',
                 # rubocop:enable Metrics/LineLength,Lint/InterpolationCheck
-              }
+              },
             },
             {
               file: project_root_path('code.rb'),
@@ -373,14 +373,14 @@ RSpec.describe Airbrake::Backtrace do
                 # rubocop:disable Metrics/LineLength,Lint/InterpolationCheck
                 96 => '          @config.logger.debug("#{LOG_LABEL} `notice.to_json` failed: #{ex.class}: #{ex}")',
                 # rubocop:enable Metrics/LineLength,Lint/InterpolationCheck
-                97 => '        else'
-              }
+                97 => '        else',
+              },
             },
             {
               file: project_root_path('code.rb'),
               line: 96,
-              function: 'to_json'
-            }
+              function: 'to_json',
+            },
           ]
         end
 
@@ -389,7 +389,7 @@ RSpec.describe Airbrake::Backtrace do
           backtrace = [
             project_root_path('code.rb') + ":94:in `to_json'",
             project_root_path('code.rb') + ":95:in `to_json'",
-            project_root_path('code.rb') + ":96:in `to_json'"
+            project_root_path('code.rb') + ":96:in `to_json'",
           ]
           ex.set_backtrace(backtrace)
           expect(described_class.parse(ex)).to eq(parsed_backtrace)
@@ -410,8 +410,8 @@ RSpec.describe Airbrake::Backtrace do
             {
               file: project_root_path('code.rb'),
               line: 94,
-              function: 'to_json'
-            }
+              function: 'to_json',
+            },
           ]
         end
 

--- a/spec/code_hunk_spec.rb
+++ b/spec/code_hunk_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Airbrake::CodeHunk do
             # rubocop:disable Metrics/LineLength
             3 => '  # Represents a chunk of information that is meant to be either sent to',
             # rubocop:enable Metrics/LineLength
-          )
+          ),
         )
       end
     end
@@ -49,8 +49,8 @@ RSpec.describe Airbrake::CodeHunk do
         is_expected.to(
           eq(
             220 => '  end',
-            221 => 'end'
-          )
+            221 => 'end',
+          ),
         )
       end
     end
@@ -65,8 +65,8 @@ RSpec.describe Airbrake::CodeHunk do
           eq(
             1 => 'module Banana',
             2 => '  attr_reader :bingo',
-            3 => 'end'
-          )
+            3 => 'end',
+          ),
         )
       end
     end
@@ -81,8 +81,8 @@ RSpec.describe Airbrake::CodeHunk do
             99 => '        end',
             100 => '',
             101 => '        break if truncate == 0',
-            102 => '      end'
-          )
+            102 => '      end',
+          ),
         )
       end
     end
@@ -104,10 +104,10 @@ RSpec.describe Airbrake::CodeHunk do
 
       it "logs error and returns nil" do
         expect(Airbrake::Loggable.instance).to receive(:error).with(
-          /can't read code hunk.+Permission denied/
+          /can't read code hunk.+Permission denied/,
         )
         expect(subject.get(project_root_path('code.rb'), 1)).to(
-          eq(1 => '')
+          eq(1 => ''),
         )
       end
     end

--- a/spec/config/validator_spec.rb
+++ b/spec/config/validator_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe Airbrake::Config::Validator do
         promise = described_class.validate(config)
         expect(promise.value).to eq(
           'error' => "the 'environment' option must be configured with a " \
-                     "Symbol (or String), but 'Float' was provided: 1.0"
+                     "Symbol (or String), but 'Float' was provided: 1.0",
         )
       end
     end
@@ -130,7 +130,7 @@ RSpec.describe Airbrake::Config::Validator do
         {
           project_id: valid_id,
           project_key: valid_key,
-          environment: string_inquirer.new('test')
+          environment: string_inquirer.new('test'),
         }
       end
 
@@ -148,14 +148,14 @@ RSpec.describe Airbrake::Config::Validator do
           project_id: valid_id,
           project_key: valid_key,
           environment: 'test',
-          ignore_environments: ['test']
+          ignore_environments: ['test'],
         }
       end
 
       it "returns a rejected promise" do
         promise = described_class.check_notify_ability(config)
         expect(promise.value).to eq(
-          'error' => "current environment 'test' is ignored"
+          'error' => "current environment 'test' is ignored",
         )
       end
     end
@@ -165,7 +165,7 @@ RSpec.describe Airbrake::Config::Validator do
         {
           project_id: valid_id,
           project_key: valid_key,
-          ignore_environments: ['test']
+          ignore_environments: ['test'],
         }
       end
 

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe Airbrake::Config do
   describe "#check_performance_options" do
     it "returns a promise" do
       resource = Airbrake::Query.new(
-        method: '', route: '', query: '', start_time: Time.now
+        method: '', route: '', query: '', start_time: Time.now,
       )
       expect(subject.check_performance_options(resource))
         .to be_an(Airbrake::Promise)
@@ -122,14 +122,14 @@ RSpec.describe Airbrake::Config do
 
       let(:resource) do
         Airbrake::Request.new(
-          method: 'GET', route: '/foo', status_code: 200, start_time: Time.new
+          method: 'GET', route: '/foo', status_code: 200, start_time: Time.new,
         )
       end
 
       it "returns a rejected promise" do
         promise = subject.check_performance_options(resource)
         expect(promise.value).to eq(
-          'error' => "The Performance Stats feature is disabled"
+          'error' => "The Performance Stats feature is disabled",
         )
       end
     end
@@ -139,14 +139,14 @@ RSpec.describe Airbrake::Config do
 
       let(:resource) do
         Airbrake::Query.new(
-          method: 'GET', route: '/foo', query: '', start_time: Time.new
+          method: 'GET', route: '/foo', query: '', start_time: Time.new,
         )
       end
 
       it "returns a rejected promise" do
         promise = subject.check_performance_options(resource)
         expect(promise.value).to eq(
-          'error' => "The Query Stats feature is disabled"
+          'error' => "The Query Stats feature is disabled",
         )
       end
     end

--- a/spec/deploy_notifier_spec.rb
+++ b/spec/deploy_notifier_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Airbrake::DeployNotifier do
         expect_any_instance_of(Airbrake::SyncSender).to receive(:send).with(
           { environment: 'barenv' },
           instance_of(Airbrake::Promise),
-          URI('https://api.airbrake.io/api/v4/projects/1/deploys')
+          URI('https://api.airbrake.io/api/v4/projects/1/deploys'),
         )
         subject.notify(environment: 'barenv')
       end
@@ -39,7 +39,7 @@ RSpec.describe Airbrake::DeployNotifier do
         expect_any_instance_of(Airbrake::SyncSender).to receive(:send).with(
           { environment: 'fooenv' },
           instance_of(Airbrake::Promise),
-          URI('https://api.airbrake.io/api/v4/projects/1/deploys')
+          URI('https://api.airbrake.io/api/v4/projects/1/deploys'),
         )
         subject.notify({})
       end

--- a/spec/filter_chain_spec.rb
+++ b/spec/filter_chain_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Airbrake::FilterChain do
 
       foo_filter_mock = double
       expect(foo_filter_mock).to(
-        receive(:name).at_least(:once).and_return('FooFilter')
+        receive(:name).at_least(:once).and_return('FooFilter'),
       )
       subject.delete_filter(foo_filter_mock)
 

--- a/spec/filters/dependency_filter_spec.rb
+++ b/spec/filters/dependency_filter_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Airbrake::Filters::DependencyFilter do
     it "attaches loaded dependencies to context/versions/dependencies" do
       subject.call(notice)
       expect(notice[:context][:versions][:dependencies]).to include(
-        'airbrake-ruby' => Airbrake::AIRBRAKE_RUBY_VERSION
+        'airbrake-ruby' => Airbrake::AIRBRAKE_RUBY_VERSION,
       )
     end
   end

--- a/spec/filters/gem_root_filter_spec.rb
+++ b/spec/filters/gem_root_filter_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Airbrake::Filters::GemRootFilter do
       { file: "/home/kyrylo/code/airbrake/ruby/spec/spec_helper.rb" },
       { file: "#{root1}/gems/rspec-core-3.3.2/lib/rspec/core/configuration.rb" },
       { file: "/opt/rubies/ruby-2.2.2/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb" },
-      { file: "#{root2}/gems/rspec-core-3.3.2/exe/rspec" }
+      { file: "#{root2}/gems/rspec-core-3.3.2/exe/rspec" },
     ]
     # rubocop:enable Metrics/LineLength
 
@@ -25,9 +25,9 @@ RSpec.describe Airbrake::Filters::GemRootFilter do
           { file: "/home/kyrylo/code/airbrake/ruby/spec/spec_helper.rb" },
           { file: "/GEM_ROOT/gems/rspec-core-3.3.2/lib/rspec/core/configuration.rb" },
           { file: "/opt/rubies/ruby-2.2.2/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb" },
-          { file: "/GEM_ROOT/gems/rspec-core-3.3.2/exe/rspec" }
-        ]
-      )
+          { file: "/GEM_ROOT/gems/rspec-core-3.3.2/exe/rspec" },
+        ],
+      ),
     )
     # rubocop:enable Metrics/LineLength
   end
@@ -35,7 +35,7 @@ RSpec.describe Airbrake::Filters::GemRootFilter do
   it "does not filter file when it is nil" do
     expect(notice[:errors].first[:file]).to be_nil
     expect { subject.call(notice) }.not_to(
-      change { notice[:errors].first[:file] }
+      change { notice[:errors].first[:file] },
     )
   end
 end

--- a/spec/filters/git_last_checkout_filter_spec.rb
+++ b/spec/filters/git_last_checkout_filter_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Airbrake::Filters::GitLastCheckoutFilter do
 
     it "attaches last checkouted email" do
       expect(notice[:context][:lastCheckout][:email]).to(
-        match(/\A\w+[\w.-]*@\w+\.?\w+?\z/)
+        match(/\A\w+[\w.-]*@\w+\.?\w+?\z/),
       )
     end
 

--- a/spec/filters/git_repository_filter.rb
+++ b/spec/filters/git_repository_filter.rb
@@ -46,7 +46,7 @@ RSpec.describe Airbrake::Filters::GitRepositoryFilter do
     it "attaches context/repository" do
       subject.call(notice)
       expect(notice[:context][:repository]).to eq(
-        'ssh://git@github.com/airbrake/airbrake-ruby.git'
+        'ssh://git@github.com/airbrake/airbrake-ruby.git',
       )
     end
   end

--- a/spec/filters/git_revision_filter_spec.rb
+++ b/spec/filters/git_revision_filter_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Airbrake::Filters::GitRevisionFilter do
       context "and also when HEAD doesn't start with 'ref: '" do
         before do
           expect(File).to(
-            receive(:read).with('root/dir/.git/HEAD').and_return('refs/foo')
+            receive(:read).with('root/dir/.git/HEAD').and_return('refs/foo'),
           )
         end
 
@@ -57,17 +57,17 @@ RSpec.describe Airbrake::Filters::GitRevisionFilter do
       context "and also when HEAD starts with 'ref: " do
         before do
           expect(File).to(
-            receive(:read).with('root/dir/.git/HEAD').and_return("ref: refs/foo\n")
+            receive(:read).with('root/dir/.git/HEAD').and_return("ref: refs/foo\n"),
           )
         end
 
         context "when the ref exists" do
           before do
             expect(File).to(
-              receive(:exist?).with('root/dir/.git/refs/foo').and_return(true)
+              receive(:exist?).with('root/dir/.git/refs/foo').and_return(true),
             )
             expect(File).to(
-              receive(:read).with('root/dir/.git/refs/foo').and_return("d34db33f\n")
+              receive(:read).with('root/dir/.git/refs/foo').and_return("d34db33f\n"),
             )
           end
 
@@ -80,14 +80,14 @@ RSpec.describe Airbrake::Filters::GitRevisionFilter do
         context "when the ref doesn't exist" do
           before do
             expect(File).to(
-              receive(:exist?).with('root/dir/.git/refs/foo').and_return(false)
+              receive(:exist?).with('root/dir/.git/refs/foo').and_return(false),
             )
           end
 
           context "and when '.git/packed-refs' exists" do
             before do
               expect(File).to(
-                receive(:exist?).with('root/dir/.git/packed-refs').and_return(true)
+                receive(:exist?).with('root/dir/.git/packed-refs').and_return(true),
               )
               expect(File).to(
                 receive(:readlines).with('root/dir/.git/packed-refs').and_return(
@@ -95,9 +95,9 @@ RSpec.describe Airbrake::Filters::GitRevisionFilter do
                     "# pack-refs with: peeled fully-peeled\n",
                     "ccb316eecff79c7528d1ad43e5fa165f7a44d52e refs/tags/v3.0.30\n",
                     "^d358900f73ee5bfd6ca3a592cf23ac6e82df83c1",
-                    "d34db33f refs/foo\n"
-                  ]
-                )
+                    "d34db33f refs/foo\n",
+                  ],
+                ),
               )
             end
 
@@ -110,7 +110,7 @@ RSpec.describe Airbrake::Filters::GitRevisionFilter do
           context "and when '.git/packed-refs' doesn't exist" do
             before do
               expect(File).to(
-                receive(:exist?).with('root/dir/.git/packed-refs').and_return(false)
+                receive(:exist?).with('root/dir/.git/packed-refs').and_return(false),
               )
             end
 

--- a/spec/filters/keys_blacklist_spec.rb
+++ b/spec/filters/keys_blacklist_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe Airbrake::Filters::KeysBlacklist do
       [/\Abon/],
       [
         { bongo: 'bango' },
-        { bongo: '[Filtered]' }
-      ]
+        { bongo: '[Filtered]' },
+      ],
     )
 
     context "and when a key is a hash" do
@@ -40,8 +40,8 @@ RSpec.describe Airbrake::Filters::KeysBlacklist do
       [:bingo],
       [
         { bingo: 'bango' },
-        { bingo: '[Filtered]' }
-      ]
+        { bingo: '[Filtered]' },
+      ],
     )
   end
 
@@ -51,8 +51,8 @@ RSpec.describe Airbrake::Filters::KeysBlacklist do
       ['bingo'],
       [
         { bingo: 'bango' },
-        { bingo: '[Filtered]' }
-      ]
+        { bingo: '[Filtered]' },
+      ],
     )
   end
 
@@ -62,8 +62,8 @@ RSpec.describe Airbrake::Filters::KeysBlacklist do
       ['bingo'],
       [
         { array: [{ bingo: 'bango' }, []] },
-        { array: [{ bingo: '[Filtered]' }, []] }
-      ]
+        { array: [{ bingo: '[Filtered]' }, []] },
+      ],
     )
   end
 
@@ -74,8 +74,8 @@ RSpec.describe Airbrake::Filters::KeysBlacklist do
         [proc { 'bongo' }, :bash],
         [
           { bingo: 'bango', bongo: 'bish', bash: 'bosh' },
-          { bingo: 'bango', bongo: '[Filtered]', bash: '[Filtered]' }
-        ]
+          { bingo: 'bango', bongo: '[Filtered]', bash: '[Filtered]' },
+        ],
       )
     end
 
@@ -85,13 +85,13 @@ RSpec.describe Airbrake::Filters::KeysBlacklist do
         [proc { Object.new }],
         [
           { bingo: 'bango', bongo: 'bish' },
-          { bingo: 'bango', bongo: 'bish' }
-        ]
+          { bingo: 'bango', bongo: 'bish' },
+        ],
       )
 
       it "logs an error" do
         expect(Airbrake::Loggable.instance).to receive(:error).with(
-          /KeysBlacklist is invalid.+patterns: \[#<Object:.+>\]/
+          /KeysBlacklist is invalid.+patterns: \[#<Object:.+>\]/,
         )
         keys_blacklist = described_class.new(patterns)
         keys_blacklist.call(notice)
@@ -104,7 +104,7 @@ RSpec.describe Airbrake::Filters::KeysBlacklist do
       context "and when the filter is called once" do
         it "logs an error" do
           expect(Airbrake::Loggable.instance).to receive(:error).with(
-            /KeysBlacklist is invalid.+patterns: \[#<Proc:.+>\]/
+            /KeysBlacklist is invalid.+patterns: \[#<Proc:.+>\]/,
           )
           keys_blacklist = described_class.new(patterns)
           keys_blacklist.call(notice)
@@ -127,13 +127,13 @@ RSpec.describe Airbrake::Filters::KeysBlacklist do
       [Object.new],
       [
         { bingo: 'bango', bongo: 'bish' },
-        { bingo: 'bango', bongo: 'bish' }
-      ]
+        { bingo: 'bango', bongo: 'bish' },
+      ],
     )
 
     it "logs an error" do
       expect(Airbrake::Loggable.instance).to receive(:error).with(
-        /KeysBlacklist is invalid.+patterns: \[#<Object:.+>\]/
+        /KeysBlacklist is invalid.+patterns: \[#<Object:.+>\]/,
       )
       keys_blacklist = described_class.new(patterns)
       keys_blacklist.call(notice)
@@ -147,8 +147,8 @@ RSpec.describe Airbrake::Filters::KeysBlacklist do
         ['bish'],
         [
           { bongo: { bish: 'bash' } },
-          { bongo: { bish: '[Filtered]' } }
-        ]
+          { bongo: { bish: '[Filtered]' } },
+        ],
       )
     end
 
@@ -161,8 +161,8 @@ RSpec.describe Airbrake::Filters::KeysBlacklist do
         ['bango'],
         [
           bongo,
-          { bingo: { bango: '[Filtered]' } }
-        ]
+          { bingo: { bango: '[Filtered]' } },
+        ],
       )
     end
   end
@@ -177,7 +177,7 @@ RSpec.describe Airbrake::Filters::KeysBlacklist do
 
         subject.call(notice)
         expect(notice[:context][:url]).to(
-          eq 'http://localhost:3000/crash?foo=bar&baz=bongo&bish=[Filtered]&color=%23FFAAFF'
+          eq('http://localhost:3000/crash?foo=bar&baz=bongo&bish=[Filtered]&color=%23FFAAFF'),
         )
       end
     end

--- a/spec/filters/keys_whitelist_spec.rb
+++ b/spec/filters/keys_whitelist_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe Airbrake::Filters::KeysWhitelist do
       [/\Abin/],
       [
         { bingo: 'bango', bongo: 'bish', bash: 'bosh' },
-        { bingo: 'bango', bongo: '[Filtered]', bash: '[Filtered]' }
-      ]
+        { bingo: 'bango', bongo: '[Filtered]', bash: '[Filtered]' },
+      ],
     )
   end
 
@@ -30,8 +30,8 @@ RSpec.describe Airbrake::Filters::KeysWhitelist do
       [:bongo],
       [
         { bongo: 'bish', bash: 'bosh', bbashh: 'bboshh' },
-        { bongo: 'bish', bash: '[Filtered]', bbashh: '[Filtered]' }
-      ]
+        { bongo: 'bish', bash: '[Filtered]', bbashh: '[Filtered]' },
+      ],
     )
   end
 
@@ -41,8 +41,8 @@ RSpec.describe Airbrake::Filters::KeysWhitelist do
       ['bash'],
       [
         { bingo: 'bango', bongo: 'bish', bash: 'bosh' },
-        { bingo: '[Filtered]', bongo: '[Filtered]', bash: 'bosh' }
-      ]
+        { bingo: '[Filtered]', bongo: '[Filtered]', bash: 'bosh' },
+      ],
     )
   end
 
@@ -53,8 +53,8 @@ RSpec.describe Airbrake::Filters::KeysWhitelist do
         [proc { 'bongo' }, :bash],
         [
           { bingo: 'bango', bongo: 'bish', bash: 'bosh' },
-          { bingo: '[Filtered]', bongo: 'bish', bash: 'bosh' }
-        ]
+          { bingo: '[Filtered]', bongo: 'bish', bash: 'bosh' },
+        ],
       )
     end
 
@@ -64,13 +64,13 @@ RSpec.describe Airbrake::Filters::KeysWhitelist do
         [proc { Object.new }],
         [
           { bingo: 'bango', bongo: 'bish', bash: 'bosh' },
-          { bingo: '[Filtered]', bongo: '[Filtered]', bash: '[Filtered]' }
-        ]
+          { bingo: '[Filtered]', bongo: '[Filtered]', bash: '[Filtered]' },
+        ],
       )
 
       it "logs an error" do
         expect(Airbrake::Loggable.instance).to receive(:error).with(
-          /KeysWhitelist is invalid.+patterns: \[#<Object:.+>\]/
+          /KeysWhitelist is invalid.+patterns: \[#<Object:.+>\]/,
         )
         keys_whitelist = described_class.new(patterns)
         keys_whitelist.call(notice)
@@ -83,7 +83,7 @@ RSpec.describe Airbrake::Filters::KeysWhitelist do
       context "and when the filter is called once" do
         it "logs an error" do
           expect(Airbrake::Loggable.instance).to receive(:error).with(
-            /KeysWhitelist is invalid.+patterns: \[#<Proc:.+>\]/
+            /KeysWhitelist is invalid.+patterns: \[#<Proc:.+>\]/,
           )
           keys_whitelist = described_class.new(patterns)
           keys_whitelist.call(notice)
@@ -94,8 +94,8 @@ RSpec.describe Airbrake::Filters::KeysWhitelist do
           [proc { proc { ['bingo'] } }],
           [
             { bingo: 'bango', bongo: 'bish', bash: 'bosh' },
-            { bingo: '[Filtered]', bongo: '[Filtered]', bash: '[Filtered]' }
-          ]
+            { bingo: '[Filtered]', bongo: '[Filtered]', bash: '[Filtered]' },
+          ],
         )
       end
     end
@@ -107,13 +107,13 @@ RSpec.describe Airbrake::Filters::KeysWhitelist do
       [Object.new],
       [
         { bingo: 'bango', bongo: 'bish', bash: 'bosh' },
-        { bingo: '[Filtered]', bongo: '[Filtered]', bash: '[Filtered]' }
-      ]
+        { bingo: '[Filtered]', bongo: '[Filtered]', bash: '[Filtered]' },
+      ],
     )
 
     it "logs an error" do
       expect(Airbrake::Loggable.instance).to receive(:error).with(
-        /KeysWhitelist is invalid.+patterns: \[#<Object:.+>\]/
+        /KeysWhitelist is invalid.+patterns: \[#<Object:.+>\]/,
       )
       keys_whitelist = described_class.new(patterns)
       keys_whitelist.call(notice)
@@ -127,8 +127,8 @@ RSpec.describe Airbrake::Filters::KeysWhitelist do
         %w[bongo bish],
         [
           { bingo: 'bango', bongo: { bish: 'bash' } },
-          { bingo: '[Filtered]', bongo: { bish: 'bash' } }
-        ]
+          { bingo: '[Filtered]', bongo: { bish: 'bash' } },
+        ],
       )
     end
 
@@ -166,7 +166,7 @@ RSpec.describe Airbrake::Filters::KeysWhitelist do
           notice[:context][:url] = 'http://localhost:3000/crash?foo=bar&baz=bongo&bish=bash'
           subject.call(notice)
           expect(notice[:context][:url]).to(
-            eq('http://localhost:3000/crash?foo=[Filtered]&baz=[Filtered]&bish=bash')
+            eq('http://localhost:3000/crash?foo=[Filtered]&baz=[Filtered]&bish=bash'),
           )
         end
       end
@@ -177,7 +177,7 @@ RSpec.describe Airbrake::Filters::KeysWhitelist do
             'http://localhost:3000/cra]]]sh?foo=bar&baz=bongo&bish=bash'
           subject.call(notice)
           expect(notice[:context][:url]).to(
-            eq('http://localhost:3000/cra]]]sh?foo=bar&baz=bongo&bish=bash')
+            eq('http://localhost:3000/cra]]]sh?foo=bar&baz=bongo&bish=bash'),
           )
         end
       end

--- a/spec/filters/root_directory_filter_spec.rb
+++ b/spec/filters/root_directory_filter_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Airbrake::Filters::RootDirectoryFilter do
       { file: "/home/kyrylo/code/airbrake/ruby/spec/spec_helper.rb" },
       { file: "#{root_directory}/gems/rspec-core-3.3.2/lib/rspec/core/configuration.rb " },
       { file: "/opt/rubies/ruby-2.2.2/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb" },
-      { file: "#{root_directory}/gems/rspec-core-3.3.2/exe/rspec" }
+      { file: "#{root_directory}/gems/rspec-core-3.3.2/exe/rspec" },
     ]
     # rubocop:enable Metrics/LineLength
 
@@ -23,9 +23,9 @@ RSpec.describe Airbrake::Filters::RootDirectoryFilter do
           { file: "/home/kyrylo/code/airbrake/ruby/spec/spec_helper.rb" },
           { file: "/PROJECT_ROOT/gems/rspec-core-3.3.2/lib/rspec/core/configuration.rb " },
           { file: "/opt/rubies/ruby-2.2.2/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb" },
-          { file: "/PROJECT_ROOT/gems/rspec-core-3.3.2/exe/rspec" }
-        ]
-      )
+          { file: "/PROJECT_ROOT/gems/rspec-core-3.3.2/exe/rspec" },
+        ],
+      ),
     )
     # rubocop:enable Metrics/LineLength
   end
@@ -33,7 +33,7 @@ RSpec.describe Airbrake::Filters::RootDirectoryFilter do
   it "does not filter file when it is nil" do
     expect(notice[:errors].first[:file]).to be_nil
     expect { subject.call(notice) }.not_to(
-      change { notice[:errors].first[:file] }
+      change { notice[:errors].first[:file] },
     )
   end
 end

--- a/spec/filters/sql_filter_spec.rb
+++ b/spec/filters/sql_filter_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Airbrake::Filters::SqlFilter do
     it "ignores '#{query}'" do
       filter = described_class.new('postgres')
       q = Airbrake::Query.new(
-        query: query, method: 'GET', route: '/', start_time: Time.now
+        query: query, method: 'GET', route: '/', start_time: Time.now,
       )
       filter.call(q)
 
@@ -29,204 +29,204 @@ RSpec.describe Airbrake::Filters::SqlFilter do
     {
       input: 'SELECT * FROM things;',
       output: 'SELECT * FROM things;',
-      dialects: ALL_DIALECTS
+      dialects: ALL_DIALECTS,
     }, {
       input: "SELECT `t001`.`c2` FROM `t001` WHERE `t001`.`c2` = 'value' AND c3=\"othervalue\" LIMIT ?",
       output: "SELECT `t001`.`c2` FROM `t001` WHERE `t001`.`c2` = ? AND c3=? LIMIT ?",
-      dialects: %i[mysql]
+      dialects: %i[mysql],
     }, {
       input: "SELECT * FROM t WHERE foo=\"bar/*\" AND baz=\"whatever */qux\"",
       output: "SELECT * FROM t WHERE foo=? AND baz=?",
-      dialects: %i[mysql]
+      dialects: %i[mysql],
     }, {
       input: "SELECT * FROM t WHERE foo='bar/*' AND baz='whatever */qux'",
       output: "SELECT * FROM t WHERE foo=? AND baz=?",
-      dialects: ALL_DIALECTS
+      dialects: ALL_DIALECTS,
     }, {
       input: "SELECT \"t001\".\"c2\" FROM \"t001\" WHERE \"t001\".\"c2\" = 'value' AND c3=1234 LIMIT 1",
       output: "SELECT \"t001\".\"c2\" FROM \"t001\" WHERE \"t001\".\"c2\" = ? AND c3=? LIMIT ?",
-      dialects: %i[postgres oracle]
+      dialects: %i[postgres oracle],
     }, {
       input: "SELECT * FROM t WHERE foo=\"bar--\" AND\n  baz=\"qux--\"",
       output: "SELECT * FROM t WHERE foo=? AND\n  baz=?",
-      dialects: %i[mysql]
+      dialects: %i[mysql],
     }, {
       input: "SELECT * FROM t WHERE foo='bar--' AND\n  baz='qux--'",
       output: "SELECT * FROM t WHERE foo=? AND\n  baz=?",
-      dialects: ALL_DIALECTS
+      dialects: ALL_DIALECTS,
     }, {
       input: "SELECT * FROM foo WHERE bar='baz' /* Hide Me */",
       output: "SELECT * FROM foo WHERE bar=? ?",
-      dialects: ALL_DIALECTS
+      dialects: ALL_DIALECTS,
     }, {
       input: "SELECT * FROM foobar WHERE password='hunter2'\n-- No peeking!",
       output: "SELECT * FROM foobar WHERE password=?\n?",
-      dialects: ALL_DIALECTS
+      dialects: ALL_DIALECTS,
     }, {
       input: "SELECT foo, bar FROM baz WHERE password='hunter2' # Secret",
       output: "SELECT foo, bar FROM baz WHERE password=? ?",
-      dialects: ALL_DIALECTS
+      dialects: ALL_DIALECTS,
     }, {
       input: "SELECT \"col1\", \"col2\" from \"table\" WHERE \"col3\"=E'foo\\'bar\\\\baz' AND country=e'foo\\'bar\\\\baz'",
       output: "SELECT \"col1\", \"col2\" from \"table\" WHERE \"col3\"=E?",
-      dialects: %i[postgres]
+      dialects: %i[postgres],
     }, {
       input: "INSERT INTO `X` values(\"test\",0, 1 , 2, 'test')",
       output: "INSERT INTO `X` values(?)",
-      dialects: %i[mysql]
+      dialects: %i[mysql],
     }, {
       input: "INSERT INTO `X` values(\"test\",0, 1 , 2, 'test')",
       output: "INSERT INTO `X` values(?)",
-      dialects: %i[mysql]
+      dialects: %i[mysql],
     }, {
       input: "SELECT c11.col1, c22.col2 FROM table c11, table c22 WHERE value='nothing'",
       output: "SELECT c11.col1, c22.col2 FROM table c11, table c22 WHERE value=?",
-      dialects: ALL_DIALECTS
+      dialects: ALL_DIALECTS,
     }, {
       input: "INSERT INTO X VALUES(1, 23456, 123.456, 99+100)",
       output: "INSERT INTO X VALUES(?)",
-      dialects: ALL_DIALECTS
+      dialects: ALL_DIALECTS,
     }, {
       input: "SELECT * FROM table WHERE name=\"foo\" AND value=\"don't\"",
       output: "SELECT * FROM table WHERE name=? AND value=?",
-      dialects: %i[mysql]
+      dialects: %i[mysql],
     }, {
       input: "SELECT * FROM table WHERE name='foo' AND value = 'bar'",
       output: "SELECT * FROM table WHERE name=? AND value = ?",
-      dialects: ALL_DIALECTS
+      dialects: ALL_DIALECTS,
     }, {
       input: "SELECT * FROM table WHERE col='foo\\''bar'",
       output: "SELECT * FROM table WHERE col=?",
-      dialects: ALL_DIALECTS
+      dialects: ALL_DIALECTS,
     }, {
       input: "SELECT * FROM table WHERE col1='foo\"bar' AND col2='what\"ever'",
       output: "SELECT * FROM table WHERE col1=? AND col2=?",
-      dialects: ALL_DIALECTS
+      dialects: ALL_DIALECTS,
     }, {
       input: "select * from accounts where accounts.name != 'dude\n newline' order by accounts.name",
       output: "select * from accounts where accounts.name != ? order by accounts.name",
-      dialects: ALL_DIALECTS
+      dialects: ALL_DIALECTS,
     }, {
       input: "SELECT * FROM table WHERE col1=\"don't\" AND col2=\"won't\"",
       output: "SELECT * FROM table WHERE col1=? AND col2=?",
-      dialects: %i[mysql]
+      dialects: %i[mysql],
     }, {
       input: "INSERT INTO X values('', 'jim''s ssn',0, 1 , 'jim''s son''s son', \"\"\"jim''s\"\" hat\", \"\\\"jim''s secret\\\"\")",
       output: "INSERT INTO X values(?, ?,?, ? , ?, ?, ?",
-      dialects: %i[mysql]
+      dialects: %i[mysql],
     }, {
       input: "SELECT * FROM table WHERE name='foo\\' AND color='blue'",
       output: "SELECT * FROM table WHERE name=?",
-      dialects: ALL_DIALECTS
+      dialects: ALL_DIALECTS,
     }, {
       input: "SELECT * FROM table WHERE foo=\"this string ends with a backslash\\\\\"",
       output: "SELECT * FROM table WHERE foo=?",
-      dialects: %i[mysql]
+      dialects: %i[mysql],
     }, {
       input: "SELECT * FROM table WHERE foo='this string ends with a backslash\\\\'",
       output: "SELECT * FROM table WHERE foo=?",
-      dialects: ALL_DIALECTS
+      dialects: ALL_DIALECTS,
     }, {
       # TODO: fix this example.
       input: "SELECT * FROM table WHERE name='foo\'' AND color='blue'",
       output: "Error: Airbrake::Query was not filtered",
-      dialects: ALL_DIALECTS
+      dialects: ALL_DIALECTS,
     }, {
       input: "INSERT INTO X values('', 'a''b c',0, 1 , 'd''e f''s h')",
       output: "INSERT INTO X values(?)",
-      dialects: ALL_DIALECTS
+      dialects: ALL_DIALECTS,
     }, {
       input: "SELECT * FROM t WHERE -- '\n  bar='baz' -- '",
       output: "SELECT * FROM t WHERE ?\n  bar=? ?",
-      dialects: ALL_DIALECTS
+      dialects: ALL_DIALECTS,
     }, {
       input: "SELECT * FROM t WHERE /* ' */\n  bar='baz' -- '",
       output: "SELECT * FROM t WHERE ?\n  bar=? ?",
-      dialects: ALL_DIALECTS
+      dialects: ALL_DIALECTS,
     }, {
       input: "SELECT * FROM t WHERE -- '\n  /* ' */ c2='xxx' /* ' */\n  c='x\n  xx' -- '",
       output: "SELECT * FROM t WHERE ?\n  ? c2=? ?\n  c=? ?",
-      dialects: ALL_DIALECTS
+      dialects: ALL_DIALECTS,
     }, {
       input: "SELECT * FROM t WHERE -- '\n  c='x\n  xx' -- '",
       output: "SELECT * FROM t WHERE ?\n  c=? ?",
-      dialects: ALL_DIALECTS
+      dialects: ALL_DIALECTS,
     }, {
       input: "SELECT * FROM foo WHERE col='value1' AND /* don't */ col2='value1' /* won't */",
       output: "SELECT * FROM foo WHERE col=? AND ? col2=? ?",
-      dialects: ALL_DIALECTS
+      dialects: ALL_DIALECTS,
     }, {
       input: "SELECT * FROM table WHERE foo='bar' AND baz=\"nothing to see here'",
       output: "Error: Airbrake::Query was not filtered",
-      dialects: %i[mysql]
+      dialects: %i[mysql],
     }, {
       input: "SELECT * FROM table WHERE foo='bar' AND baz='nothing to see here",
       output: "Error: Airbrake::Query was not filtered",
-      dialects: ALL_DIALECTS
+      dialects: ALL_DIALECTS,
     }, {
       input: "SELECT * FROM \"foo\" WHERE \"foo\" = $a$dollar quotes can be $b$nested$b$$a$ and bar = 'baz'",
       output: "SELECT * FROM \"foo\" WHERE \"foo\" = ? and bar = ?",
-      dialects: %i[postgres]
+      dialects: %i[postgres],
     }, {
       input: "INSERT INTO \"foo\" (\"bar\", \"baz\", \"qux\") VALUES ($1, $2, $3) RETURNING \"id\"",
       output: "INSERT INTO \"foo\" (?) RETURNING \"id\"",
-      dialects: %i[postgres]
+      dialects: %i[postgres],
     }, {
       input: "select * from foo where bar = 'some\\tthing' and baz = 10",
       output: "select * from foo where bar = ? and baz = ?",
-      dialects: ALL_DIALECTS
+      dialects: ALL_DIALECTS,
     }, {
       input: "select * from users where user = 'user1\\' password = 'hunter 2' -- ->don't count this quote",
       output: "select * from users where user = ?",
-      dialects: ALL_DIALECTS
+      dialects: ALL_DIALECTS,
     }, {
       input: "select * from foo where bar=q'[baz's]' and x=5",
       output: "select * from foo where bar=? and x=?",
-      dialects: %i[oracle]
+      dialects: %i[oracle],
     }, {
       input: "select * from foo where bar=q'{baz's}' and x=5",
       output: "select * from foo where bar=? and x=?",
-      dialects: %i[oracle]
+      dialects: %i[oracle],
     }, {
       input: "select * from foo where bar=q'<baz's>' and x=5",
       output: "select * from foo where bar=? and x=?",
-      dialects: %i[oracle]
+      dialects: %i[oracle],
     }, {
       input: "select * from foo where bar=q'(baz's)' and x=5",
       output: "select * from foo where bar=? and x=?",
-      dialects: %i[oracle]
+      dialects: %i[oracle],
     }, {
       input: "select * from foo where bar=0xabcdef123 and x=5",
       output: "select * from foo where bar=? and x=?",
-      dialects: %i[cassandra sqlite]
+      dialects: %i[cassandra sqlite],
     }, {
       input: "select * from foo where bar=0x2F and x=5",
       output: "select * from foo where bar=? and x=?",
-      dialects: %i[mysql cassandra sqlite]
+      dialects: %i[mysql cassandra sqlite],
     }, {
       input: "select * from foo where bar=1.234e-5 and x=5",
       output: "select * from foo where bar=? and x=?",
-      dialects: ALL_DIALECTS
+      dialects: ALL_DIALECTS,
     }, {
       input: "select * from foo where bar=01234567-89ab-cdef-0123-456789abcdef and x=5",
       output: "select * from foo where bar=? and x=?",
-      dialects: %i[postgres cassandra]
+      dialects: %i[postgres cassandra],
     }, {
       input: "select * from foo where bar={01234567-89ab-cdef-0123-456789abcdef} and x=5",
       output: "select * from foo where bar=? and x=?",
-      dialects: %i[postgres]
+      dialects: %i[postgres],
     }, {
       input: "select * from foo where bar=0123456789abcdef0123456789abcdef and x=5",
       output: "select * from foo where bar=? and x=?",
-      dialects: %i[postgtes]
+      dialects: %i[postgtes],
     }, {
       input: "select * from foo where bar={012-345678-9abc-def012345678-9abcdef} and x=5",
       output: "select * from foo where bar=? and x=?",
-      dialects: %i[postgres]
+      dialects: %i[postgres],
     }, {
       input: "select * from foo where bar=true and x=FALSE",
       output: "select * from foo where bar=? and x=?",
-      dialects: %i[mysql postgres cassandra sqlite]
+      dialects: %i[mysql postgres cassandra sqlite],
     }
   ].each do |test|
     include_examples 'query filtering', test
@@ -263,13 +263,13 @@ RSpec.describe Airbrake::Filters::SqlFilter do
     'oid = rngtypid WHERE t.typname IN (?) OR t.typtype IN (?) OR t.typinput ' \
     '= ?::regprocedure OR t.typelem != ?',
 
-    'SELECT t.oid, t.typname FROM pg_type as t WHERE t.typname IN (?)'
+    'SELECT t.oid, t.typname FROM pg_type as t WHERE t.typname IN (?)',
   ].each do |query|
     include_examples 'query blacklisting', query, should_ignore: true
   end
 
   [
-    'UPDATE "users" SET "last_sign_in_at" = ? WHERE "users"."id" = ?'
+    'UPDATE "users" SET "last_sign_in_at" = ? WHERE "users"."id" = ?',
   ].each do |query|
     include_examples 'query blacklisting', query, should_ignore: false
   end

--- a/spec/filters/system_exit_filter_spec.rb
+++ b/spec/filters/system_exit_filter_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Airbrake::Filters::SystemExitFilter do
   it "marks SystemExit exceptions as ignored" do
     notice = Airbrake::Notice.new(SystemExit.new)
     expect { subject.call(notice) }.to(
-      change { notice.ignored? }.from(false).to(true)
+      change { notice.ignored? }.from(false).to(true),
     )
   end
 

--- a/spec/filters/thread_filter_spec.rb
+++ b/spec/filters/thread_filter_spec.rb
@@ -77,13 +77,13 @@ RSpec.describe Airbrake::Filters::ThreadFilter do
                 {
                   bish: {
                     bash: 'foo',
-                    bosh: Object.new
-                  }
-                }
-              ]
-            }
+                    bosh: Object.new,
+                  },
+                },
+              ],
+            },
           },
-          123
+          123,
         ]
       end
 
@@ -103,15 +103,15 @@ RSpec.describe Airbrake::Filters::ThreadFilter do
                     {
                       bish: {
                         bash: 'foo',
-                        bosh: /\A#<Object:.+>\z/
-                      }
-                    }
-                  ]
-                }
+                        bosh: /\A#<Object:.+>\z/,
+                      },
+                    },
+                  ],
+                },
               },
-              123
-            ]
-          )
+              123,
+            ],
+          ),
         )
       end
     end
@@ -194,13 +194,13 @@ RSpec.describe Airbrake::Filters::ThreadFilter do
                 {
                   bish: {
                     bash: 'foo',
-                    bosh: Object.new
-                  }
-                }
-              ]
-            }
+                    bosh: Object.new,
+                  },
+                },
+              ],
+            },
           },
-          123
+          123,
         ]
       end
 
@@ -220,15 +220,15 @@ RSpec.describe Airbrake::Filters::ThreadFilter do
                     {
                       bish: {
                         bash: 'foo',
-                        bosh: /\A#<Object:.+>\z/
-                      }
-                    }
-                  ]
-                }
+                        bosh: /\A#<Object:.+>\z/,
+                      },
+                    },
+                  ],
+                },
               },
-              123
-            ]
-          )
+              123,
+            ],
+          ),
         )
       end
     end

--- a/spec/fixtures/project_root/code.rb
+++ b/spec/fixtures/project_root/code.rb
@@ -10,7 +10,7 @@ module Airbrake
     NOTIFIER = {
       name: 'airbrake-ruby'.freeze,
       version: Airbrake::AIRBRAKE_RUBY_VERSION,
-      url: 'https://github.com/airbrake/airbrake-ruby'.freeze
+      url: 'https://github.com/airbrake/airbrake-ruby'.freeze,
     }.freeze
 
     ##
@@ -19,7 +19,7 @@ module Airbrake
     CONTEXT = {
       os: RUBY_PLATFORM,
       language: "#{RUBY_ENGINE}/#{RUBY_VERSION}".freeze,
-      notifier: NOTIFIER
+      notifier: NOTIFIER,
     }.freeze
 
     ##
@@ -38,7 +38,7 @@ module Airbrake
       IOError,
       NotImplementedError,
       JSON::GeneratorError,
-      Encoding::UndefinedConversionError
+      Encoding::UndefinedConversionError,
     ].freeze
 
     # @return [Array<Symbol>] the list of keys that can be be overwritten with
@@ -71,10 +71,10 @@ module Airbrake
         errors: NestedException.new(config, exception).as_json,
         context: context,
         environment: {
-          program_name: $PROGRAM_NAME
+          program_name: $PROGRAM_NAME,
         },
         session: {},
-        params: params
+        params: params,
       }
       @stash = { exception: exception }
       @truncator = Airbrake::Truncator.new(PAYLOAD_MAX_SIZE)
@@ -170,7 +170,7 @@ module Airbrake
         # Make sure we always send hostname.
         hostname: HOSTNAME,
 
-        severity: DEFAULT_SEVERITY
+        severity: DEFAULT_SEVERITY,
       }.merge(CONTEXT).delete_if { |_key, val| val.nil? || val.empty? }
     end
 
@@ -187,7 +187,7 @@ module Airbrake
         @config.logger.error(
           "#{LOG_LABEL} truncation failed. File an issue at " \
           "https://github.com/airbrake/airbrake-ruby " \
-          "and attach the following payload: #{@payload}"
+          "and attach the following payload: #{@payload}",
         )
       end
 
@@ -202,7 +202,7 @@ module Airbrake
         attributes = exception.to_airbrake
       rescue StandardError => ex
         @config.logger.error(
-          "#{LOG_LABEL} #{exception.class}#to_airbrake failed: #{ex.class}: #{ex}"
+          "#{LOG_LABEL} #{exception.class}#to_airbrake failed: #{ex.class}: #{ex}",
         )
       end
 
@@ -213,7 +213,7 @@ module Airbrake
       rescue TypeError
         @config.logger.error(
           "#{LOG_LABEL} #{exception.class}#to_airbrake failed:" \
-          " #{attributes} must be a Hash"
+          " #{attributes} must be a Hash",
         )
       end
     end

--- a/spec/notice_notifier/options_spec.rb
+++ b/spec/notice_notifier/options_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Airbrake::NoticeNotifier do
 
     Airbrake::Config.instance = Airbrake::Config.new(
       project_id: project_id,
-      project_key: project_key
+      project_key: project_key,
     )
   end
 
@@ -64,7 +64,7 @@ RSpec.describe Airbrake::NoticeNotifier do
     describe ":root_directory" do
       before do
         subject.add_filter(
-          Airbrake::Filters::RootDirectoryFilter.new('/home/kyrylo/code')
+          Airbrake::Filters::RootDirectoryFilter.new('/home/kyrylo/code'),
         )
       end
 
@@ -73,7 +73,7 @@ RSpec.describe Airbrake::NoticeNotifier do
 
         expect(
           a_request(:post, endpoint)
-          .with(body: %r|{"file":"/PROJECT_ROOT/airbrake/ruby/spec/airbrake_spec.+|)
+          .with(body: %r|{"file":"/PROJECT_ROOT/airbrake/ruby/spec/airbrake_spec.+|),
         ).to have_been_made.once
       end
 
@@ -85,7 +85,7 @@ RSpec.describe Airbrake::NoticeNotifier do
             subject.notify_sync(ex)
             expect(
               a_request(:post, endpoint)
-              .with(body: %r{"rootDirectory":"/bingo/bango"})
+              .with(body: %r{"rootDirectory":"/bingo/bango"}),
             ).to have_been_made.once
           end
         end
@@ -105,7 +105,7 @@ RSpec.describe Airbrake::NoticeNotifier do
         WEBrick::HTTPServer.new(
           Port: 0,
           Logger: WEBrick::Log.new('/dev/null'),
-          AccessLog: []
+          AccessLog: [],
         )
       end
 
@@ -121,7 +121,7 @@ RSpec.describe Airbrake::NoticeNotifier do
       before do
         Airbrake::Config.instance.merge(
           proxy: proxy_params,
-          host: "http://localhost:#{proxy.config[:Port]}"
+          host: "http://localhost:#{proxy.config[:Port]}",
         )
 
         proxy.mount_proc '/' do |req, res|
@@ -139,7 +139,7 @@ RSpec.describe Airbrake::NoticeNotifier do
         if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.6.0")
           skip(
             "We use Webmock 2, which doesn't support Ruby 2.6+. It's " \
-            "safe to run this test on 2.6+ once we upgrade to Webmock 3.5+"
+            "safe to run this test on 2.6+ once we upgrade to Webmock 3.5+",
           )
         end
         subject.notify_sync(ex)
@@ -164,7 +164,7 @@ RSpec.describe Airbrake::NoticeNotifier do
           subject.notify_sync(ex)
           expect(
             a_request(:post, endpoint)
-            .with(body: /"context":{.*"environment":"production".*}/)
+            .with(body: /"context":{.*"environment":"production".*}/),
           ).to have_been_made.once
         end
       end
@@ -192,7 +192,7 @@ RSpec.describe Airbrake::NoticeNotifier do
       context "when env is set and ignore_environments doesn't mention it" do
         params = {
           environment: :development,
-          ignore_environments: [:production]
+          ignore_environments: [:production],
         }
 
         include_examples 'sent notice', params
@@ -201,7 +201,7 @@ RSpec.describe Airbrake::NoticeNotifier do
       context "when the current env and notify envs are the same" do
         params = {
           environment: :development,
-          ignore_environments: %i[production development]
+          ignore_environments: %i[production development],
         }
 
         include_examples 'ignored notice', params
@@ -227,7 +227,7 @@ RSpec.describe Airbrake::NoticeNotifier do
       context "when ignore_environments specifies a Regexp pattern" do
         params = {
           environment: :testing,
-          ignore_environments: ['staging', /test.+/]
+          ignore_environments: ['staging', /test.+/],
         }
 
         include_examples 'ignored notice', params
@@ -241,7 +241,7 @@ RSpec.describe Airbrake::NoticeNotifier do
           before do
             Airbrake::Config.instance.merge(
               blacklist_keys: %i[password password_confirmation],
-              whitelist_keys: [:email, /user/i, 'account_id']
+              whitelist_keys: [:email, /user/i, 'account_id'],
             )
           end
 

--- a/spec/notice_notifier_spec.rb
+++ b/spec/notice_notifier_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Airbrake::NoticeNotifier do
       project_id: 1,
       project_key: 'abc',
       logger: Logger.new('/dev/null'),
-      performance_stats: true
+      performance_stats: true,
     )
   end
 
@@ -32,7 +32,7 @@ RSpec.describe Airbrake::NoticeNotifier do
     let(:body) do
       {
         'id' => '00054414-b147-6ffa-85d6-1524d83362a6',
-        'url' => 'http://localhost/locate/00054414-b147-6ffa-85d6-1524d83362a6'
+        'url' => 'http://localhost/locate/00054414-b147-6ffa-85d6-1524d83362a6',
       }.to_json
     end
 
@@ -110,7 +110,7 @@ RSpec.describe Airbrake::NoticeNotifier do
       before do
         Airbrake::Config.instance.merge(
           environment: 'test',
-          ignore_environments: %w[test]
+          ignore_environments: %w[test],
         )
       end
 
@@ -132,7 +132,7 @@ RSpec.describe Airbrake::NoticeNotifier do
     let(:body) do
       {
         'id' => '00054414-b147-6ffa-85d6-1524d83362a6',
-        'url' => 'http://localhost/locate/00054414-b147-6ffa-85d6-1524d83362a6'
+        'url' => 'http://localhost/locate/00054414-b147-6ffa-85d6-1524d83362a6',
       }
     end
 
@@ -153,8 +153,8 @@ RSpec.describe Airbrake::NoticeNotifier do
       subject.notify_sync('foo', bingo: 'bango')
       expect(
         a_request(:post, endpoint).with(
-          body: /"params":{.*"bingo":"bango".*}/
-        )
+          body: /"params":{.*"bingo":"bango".*}/,
+        ),
       ).to have_been_made.once
     end
 
@@ -190,7 +190,7 @@ RSpec.describe Airbrake::NoticeNotifier do
     context "when the provided environment is ignored" do
       before do
         Airbrake::Config.instance.merge(
-          environment: 'test', ignore_environments: %w[test]
+          environment: 'test', ignore_environments: %w[test],
         )
       end
 
@@ -256,7 +256,7 @@ RSpec.describe Airbrake::NoticeNotifier do
           it "returns the full generated backtrace" do
             backtrace = [
               "/lib/airbrake-ruby/a.rb:84:in `build_notice'",
-              "/lib/airbrake-ruby/b.rb:124:in `send_notice'"
+              "/lib/airbrake-ruby/b.rb:124:in `send_notice'",
             ]
             allow(Kernel).to receive(:caller).and_return(backtrace)
 
@@ -265,8 +265,8 @@ RSpec.describe Airbrake::NoticeNotifier do
             expect(notice[:errors].first[:backtrace]).to eq(
               [
                 { file: '/lib/airbrake-ruby/a.rb', line: 84, function: 'build_notice' },
-                { file: '/lib/airbrake-ruby/b.rb', line: 124, function: 'send_notice' }
-              ]
+                { file: '/lib/airbrake-ruby/b.rb', line: 124, function: 'send_notice' },
+              ],
             )
           end
         end
@@ -276,7 +276,7 @@ RSpec.describe Airbrake::NoticeNotifier do
             backtrace = [
               "/airbrake-ruby/lib/airbrake-ruby/a.rb:84:in `b'",
               "/airbrake-ruby/lib/foo/b.rb:84:in `build'",
-              "/airbrake-ruby/lib/bar/c.rb:124:in `send'"
+              "/airbrake-ruby/lib/bar/c.rb:124:in `send'",
             ]
             allow(Kernel).to receive(:caller).and_return(backtrace)
 
@@ -285,8 +285,8 @@ RSpec.describe Airbrake::NoticeNotifier do
             expect(notice[:errors].first[:backtrace]).to eq(
               [
                 { file: '/airbrake-ruby/lib/foo/b.rb', line: 84, function: 'build' },
-                { file: '/airbrake-ruby/lib/bar/c.rb', line: 124, function: 'send' }
-              ]
+                { file: '/airbrake-ruby/lib/bar/c.rb', line: 124, function: 'send' },
+              ],
             )
           end
         end
@@ -303,7 +303,7 @@ RSpec.describe Airbrake::NoticeNotifier do
         backtrace = [
           "org/jruby/RubyKernel.java:998:in `eval'",
           "/ruby/stdlib/irb/workspace.rb:87:in `evaluate'",
-          "/ruby/stdlib/irb.rb:489:in `block in eval_input'"
+          "/ruby/stdlib/irb.rb:489:in `block in eval_input'",
         ]
         allow(Kernel).to receive(:caller).and_return(backtrace)
 
@@ -314,8 +314,8 @@ RSpec.describe Airbrake::NoticeNotifier do
           [
             { file: 'org/jruby/RubyKernel.java', line: 998, function: 'eval' },
             { file: '/ruby/stdlib/irb/workspace.rb', line: 87, function: 'evaluate' },
-            { file: '/ruby/stdlib/irb.rb:489', line: 489, function: 'block in eval_input' }
-          ]
+            { file: '/ruby/stdlib/irb.rb:489', line: 489, function: 'block in eval_input' },
+          ],
         )
         # rubocop:enable Metrics/LineLength
       end
@@ -330,7 +330,7 @@ RSpec.describe Airbrake::NoticeNotifier do
       it "raises error" do
         expect { subject.build_notice(Exception.new) }.to raise_error(
           Airbrake::Error,
-          'attempted to build Exception with closed Airbrake instance'
+          'attempted to build Exception with closed Airbrake instance',
         )
       end
     end

--- a/spec/notice_spec.rb
+++ b/spec/notice_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Airbrake::Notice do
         before do
           Airbrake::Config.instance.merge(
             app_version: "1.2.3",
-            root_directory: "/one/two"
+            root_directory: "/one/two",
           )
         end
 
@@ -34,7 +34,7 @@ RSpec.describe Airbrake::Notice do
     context "when versions is empty" do
       it "doesn't set the 'versions' payload" do
         expect(notice.to_json).not_to match(
-          /"context":{"versions":{"dep":"1.2.3"}}/
+          /"context":{"versions":{"dep":"1.2.3"}}/,
         )
       end
     end
@@ -43,7 +43,7 @@ RSpec.describe Airbrake::Notice do
       it "sets the 'versions' payload" do
         notice[:context][:versions] = { 'dep' => '1.2.3' }
         expect(notice.to_json).to match(
-          /"context":{.*"versions":{"dep":"1.2.3"}.*}/
+          /"context":{.*"versions":{"dep":"1.2.3"}.*}/,
         )
       end
     end
@@ -192,7 +192,7 @@ RSpec.describe Airbrake::Notice do
             it "doesn't fail" do
               notice[:params] = { a: { b: { c: ObjectWithIoIvars.new } } }
               expect(notice.to_json).to match(
-                /"params":{"a":{"b":{"c":".+ObjectWithIoIvars.+"}}.*}/
+                /"params":{"a":{"b":{"c":".+ObjectWithIoIvars.+"}}.*}/,
               )
             end
           end
@@ -201,7 +201,7 @@ RSpec.describe Airbrake::Notice do
             it "doesn't fail" do
               notice[:params] = { a: [[ObjectWithIoIvars.new]] }
               expect(notice.to_json).to match(
-                /"params":{"a":\[\[".+ObjectWithIoIvars.+"\]\].*}/
+                /"params":{"a":\[\[".+ObjectWithIoIvars.+"\]\].*}/,
               )
             end
           end

--- a/spec/performance_notifier_spec.rb
+++ b/spec/performance_notifier_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Airbrake::PerformanceNotifier do
       project_key: 'banana',
       performance_stats: true,
       performance_stats_flush_period: 0,
-      query_stats: true
+      query_stats: true,
     )
   end
 
@@ -30,8 +30,8 @@ RSpec.describe Airbrake::PerformanceNotifier do
           file: 'foo.rb',
           line: 123,
           start_time: Time.new(2018, 1, 1, 0, 49, 0, 0),
-          end_time: Time.new(2018, 1, 1, 0, 50, 0, 0)
-        )
+          end_time: Time.new(2018, 1, 1, 0, 50, 0, 0),
+        ),
       )
       subject.close
 
@@ -49,7 +49,7 @@ RSpec.describe Airbrake::PerformanceNotifier do
             "sum":60000.0,
             "sumsq":3600000000.0,
             "tdigest":"AAAAAkA0AAAAAAAAAAAAAUdqYAAB"
-          }\]}\z|x)
+          }\]}\z|x),
       ).to have_been_made
     end
 
@@ -60,8 +60,8 @@ RSpec.describe Airbrake::PerformanceNotifier do
           route: '/foo',
           status_code: 200,
           start_time: Time.new(2018, 1, 1, 0, 49, 0, 0),
-          end_time: Time.new(2018, 1, 1, 0, 50, 0, 0)
-        )
+          end_time: Time.new(2018, 1, 1, 0, 50, 0, 0),
+        ),
       )
       subject.close
 
@@ -76,7 +76,7 @@ RSpec.describe Airbrake::PerformanceNotifier do
             "sum":60000.0,
             "sumsq":3600000000.0,
             "tdigest":"AAAAAkA0AAAAAAAAAAAAAUdqYAAB"
-          }\]}\z|x)
+          }\]}\z|x),
       ).to have_been_made
     end
 
@@ -88,8 +88,8 @@ RSpec.describe Airbrake::PerformanceNotifier do
           response_type: 'json',
           start_time: Time.new(2018, 1, 1, 0, 49, 0, 0),
           end_time: Time.new(2018, 1, 1, 0, 50, 0, 0),
-          groups: { db: 131, view: 421 }
-        )
+          groups: { db: 131, view: 421 },
+        ),
       )
       subject.close
 
@@ -118,7 +118,7 @@ RSpec.describe Airbrake::PerformanceNotifier do
                 "tdigest":"AAAAAkA0AAAAAAAAAAAAAUPSgAAB"
               }
             }
-        }\]}\z|x)
+        }\]}\z|x),
       ).to have_been_made
     end
 
@@ -129,8 +129,8 @@ RSpec.describe Airbrake::PerformanceNotifier do
           error_count: 2,
           groups: { redis: 131, sql: 421 },
           start_time: Time.new(2018, 1, 1, 0, 49, 0, 0),
-          end_time: Time.new(2018, 1, 1, 0, 50, 0, 0)
-        )
+          end_time: Time.new(2018, 1, 1, 0, 50, 0, 0),
+        ),
       )
       subject.close
 
@@ -158,7 +158,7 @@ RSpec.describe Airbrake::PerformanceNotifier do
                 "tdigest":"AAAAAkA0AAAAAAAAAAAAAUPSgAAB"
               }
             }
-        }\]}\z/x)
+        }\]}\z/x),
       ).to have_been_made
     end
 
@@ -168,13 +168,13 @@ RSpec.describe Airbrake::PerformanceNotifier do
           method: 'GET',
           route: '/foo',
           status_code: 200,
-          start_time: Time.new(2018, 1, 1, 0, 0, 20, 0)
-        )
+          start_time: Time.new(2018, 1, 1, 0, 0, 20, 0),
+        ),
       )
       subject.close
 
       expect(
-        a_request(:put, routes).with(body: /"time":"2018-01-01T00:00:00\+00:00"/)
+        a_request(:put, routes).with(body: /"time":"2018-01-01T00:00:00\+00:00"/),
       ).to have_been_made
     end
 
@@ -184,21 +184,21 @@ RSpec.describe Airbrake::PerformanceNotifier do
           method: 'GET',
           route: '/foo',
           status_code: 200,
-          start_time: Time.new(2018, 1, 1, 0, 0, 20, 0)
-        )
+          start_time: Time.new(2018, 1, 1, 0, 0, 20, 0),
+        ),
       )
       subject.notify(
         Airbrake::Request.new(
           method: 'GET',
           route: '/foo',
           status_code: 200,
-          start_time: Time.new(2018, 1, 1, 0, 0, 50, 0)
-        )
+          start_time: Time.new(2018, 1, 1, 0, 0, 50, 0),
+        ),
       )
       subject.close
 
       expect(
-        a_request(:put, routes).with(body: /"count":2/)
+        a_request(:put, routes).with(body: /"count":2/),
       ).to have_been_made
     end
 
@@ -209,8 +209,8 @@ RSpec.describe Airbrake::PerformanceNotifier do
           route: '/foo',
           status_code: 200,
           start_time: Time.new(2018, 1, 1, 0, 0, 49, 0),
-          end_time: Time.new(2018, 1, 1, 0, 0, 50, 0)
-        )
+          end_time: Time.new(2018, 1, 1, 0, 0, 50, 0),
+        ),
       )
       subject.notify(
         Airbrake::Request.new(
@@ -218,8 +218,8 @@ RSpec.describe Airbrake::PerformanceNotifier do
           route: '/foo',
           status_code: 200,
           start_time: Time.new(2018, 1, 1, 0, 1, 49, 0),
-          end_time: Time.new(2018, 1, 1, 0, 1, 55, 0)
-        )
+          end_time: Time.new(2018, 1, 1, 0, 1, 55, 0),
+        ),
       )
       subject.close
 
@@ -233,8 +233,8 @@ RSpec.describe Airbrake::PerformanceNotifier do
               {"method":"GET","route":"/foo","statusCode":200,
                "time":"2018-01-01T00:01:00\+00:00","count":1,"sum":6000.0,
                "sumsq":36000000.0,"tdigest":"AAAAAkA0AAAAAAAAAAAAAUW7gAAB"}\]}
-          \z|x
-        )
+          \z|x,
+        ),
       ).to have_been_made
     end
 
@@ -245,8 +245,8 @@ RSpec.describe Airbrake::PerformanceNotifier do
           route: '/foo',
           status_code: 200,
           start_time: Time.new(2018, 1, 1, 0, 49, 0, 0),
-          end_time: Time.new(2018, 1, 1, 0, 50, 0, 0)
-        )
+          end_time: Time.new(2018, 1, 1, 0, 50, 0, 0),
+        ),
       )
       subject.notify(
         Airbrake::Request.new(
@@ -254,8 +254,8 @@ RSpec.describe Airbrake::PerformanceNotifier do
           route: '/foo',
           status_code: 200,
           start_time: Time.new(2018, 1, 1, 0, 49, 0, 0),
-          end_time: Time.new(2018, 1, 1, 0, 50, 0, 0)
-        )
+          end_time: Time.new(2018, 1, 1, 0, 50, 0, 0),
+        ),
       )
       subject.close
 
@@ -269,8 +269,8 @@ RSpec.describe Airbrake::PerformanceNotifier do
               {"method":"POST","route":"/foo","statusCode":200,
                "time":"2018-01-01T00:49:00\+00:00","count":1,"sum":60000.0,
                "sumsq":3600000000.0,"tdigest":"AAAAAkA0AAAAAAAAAAAAAUdqYAAB"}\]}
-          \z|x
-        )
+          \z|x,
+        ),
       ).to have_been_made
     end
 
@@ -282,8 +282,8 @@ RSpec.describe Airbrake::PerformanceNotifier do
           response_type: 'json',
           start_time: Time.new(2018, 1, 1, 0, 0, 20, 0),
           end_time: Time.new(2018, 1, 1, 0, 0, 22, 0),
-          groups: { db: 131, view: 421 }
-        )
+          groups: { db: 131, view: 421 },
+        ),
       )
       subject.notify(
         Airbrake::PerformanceBreakdown.new(
@@ -292,8 +292,8 @@ RSpec.describe Airbrake::PerformanceNotifier do
           response_type: 'json',
           start_time: Time.new(2018, 1, 1, 0, 0, 30, 0),
           end_time: Time.new(2018, 1, 1, 0, 0, 32, 0),
-          groups: { db: 55, view: 11 }
-        )
+          groups: { db: 55, view: 11 },
+        ),
       )
       subject.close
 
@@ -322,7 +322,7 @@ RSpec.describe Airbrake::PerformanceNotifier do
                 "tdigest":"AAAAAkA0AAAAAAAAAAAAAkEwAABDzQAAAQE="
               }
             }
-        }\]}\z|x)
+        }\]}\z|x),
       ).to have_been_made
     end
 
@@ -333,8 +333,8 @@ RSpec.describe Airbrake::PerformanceNotifier do
           error_count: 2,
           groups: { redis: 131, sql: 421 },
           start_time: Time.new(2018, 1, 1, 0, 49, 0, 0),
-          end_time: Time.new(2018, 1, 1, 0, 50, 0, 0)
-        )
+          end_time: Time.new(2018, 1, 1, 0, 50, 0, 0),
+        ),
       )
       subject.notify(
         Airbrake::Queue.new(
@@ -342,8 +342,8 @@ RSpec.describe Airbrake::PerformanceNotifier do
           error_count: 3,
           groups: { redis: 131, sql: 421 },
           start_time: Time.new(2018, 1, 1, 0, 49, 0, 0),
-          end_time: Time.new(2018, 1, 1, 0, 50, 0, 0)
-        )
+          end_time: Time.new(2018, 1, 1, 0, 50, 0, 0),
+        ),
       )
       subject.close
 
@@ -371,7 +371,7 @@ RSpec.describe Airbrake::PerformanceNotifier do
                 "tdigest":"AAAAAkA0AAAAAAAAAAAAAUPSgAAC"
               }
             }
-        }\]}\z/x)
+        }\]}\z/x),
       ).to have_been_made
     end
 
@@ -381,8 +381,8 @@ RSpec.describe Airbrake::PerformanceNotifier do
           method: 'GET',
           route: '/foo',
           status_code: 200,
-          start_time: Time.new(2018, 1, 1, 0, 49, 0, 0)
-        )
+          start_time: Time.new(2018, 1, 1, 0, 49, 0, 0),
+        ),
       )
       subject.close
 
@@ -392,7 +392,7 @@ RSpec.describe Airbrake::PerformanceNotifier do
 
     it "checks performance stat configuration" do
       request = Airbrake::Request.new(
-        method: 'GET', route: '/foo', status_code: 200, start_time: Time.new
+        method: 'GET', route: '/foo', status_code: 200, start_time: Time.new,
       )
       expect(Airbrake::Config.instance).to receive(:check_performance_options)
         .with(request).and_return(Airbrake::Promise.new)
@@ -408,15 +408,15 @@ RSpec.describe Airbrake::PerformanceNotifier do
           method: 'POST',
           route: '/foo',
           status_code: 200,
-          start_time: Time.new
-        )
+          start_time: Time.new,
+        ),
       )
       subject.close
 
       expect(
         a_request(:put, routes).with(
-          body: /\A{"routes":\[.+\],"environment":"test"}\z/x
-        )
+          body: /\A{"routes":\[.+\],"environment":"test"}\z/x,
+        ),
       ).to have_been_made
     end
 
@@ -437,7 +437,7 @@ RSpec.describe Airbrake::PerformanceNotifier do
           project_id: 1,
           project_key: 'banana',
           performance_stats: true,
-          performance_stats_flush_period: flush_period
+          performance_stats_flush_period: flush_period,
         )
 
         subject.notify(
@@ -445,8 +445,8 @@ RSpec.describe Airbrake::PerformanceNotifier do
             method: 'GET',
             route: '/foo',
             status_code: 200,
-            start_time: Time.new(2018, 1, 1, 0, 49, 0, 0)
-          )
+            start_time: Time.new(2018, 1, 1, 0, 49, 0, 0),
+          ),
         )
 
         subject.notify(
@@ -454,8 +454,8 @@ RSpec.describe Airbrake::PerformanceNotifier do
             method: 'POST',
             route: '/foo',
             query: 'SELECT * FROM things',
-            start_time: Time.new(2018, 1, 1, 0, 49, 0, 0)
-          )
+            start_time: Time.new(2018, 1, 1, 0, 49, 0, 0),
+          ),
         )
 
         sleep(flush_period + 0.5)
@@ -474,8 +474,8 @@ RSpec.describe Airbrake::PerformanceNotifier do
             method: 'GET',
             route: '/foo',
             status_code: 200,
-            start_time: Time.new(2018, 1, 1, 0, 49, 0, 0)
-          )
+            start_time: Time.new(2018, 1, 1, 0, 49, 0, 0),
+          ),
         )
         subject.close
 
@@ -488,8 +488,8 @@ RSpec.describe Airbrake::PerformanceNotifier do
             method: 'POST',
             route: '/foo',
             query: 'SELECT * FROM things',
-            start_time: Time.new(2018, 1, 1, 0, 49, 0, 0)
-          )
+            start_time: Time.new(2018, 1, 1, 0, 49, 0, 0),
+          ),
         )
         subject.close
 
@@ -510,15 +510,15 @@ RSpec.describe Airbrake::PerformanceNotifier do
             method: 'POST',
             route: '/foo',
             query: 'SELECT * FROM things',
-            start_time: Time.new(2018, 1, 1, 0, 49, 0, 0)
-          )
+            start_time: Time.new(2018, 1, 1, 0, 49, 0, 0),
+          ),
         )
         subject.close
 
         expect(
           a_request(:put, queries).with(
-            body: /\A{"queries":\[{"method":"POST","route":"\[Filtered\]"/
-          )
+            body: /\A{"queries":\[{"method":"POST","route":"\[Filtered\]"/,
+          ),
         ).to have_been_made
       end
     end
@@ -540,8 +540,8 @@ RSpec.describe Airbrake::PerformanceNotifier do
           method: 'POST',
           route: '/foo',
           query: 'SELECT * FROM things',
-          start_time: Time.new(2018, 1, 1, 0, 49, 0, 0)
-        )
+          start_time: Time.new(2018, 1, 1, 0, 49, 0, 0),
+        ),
       )
       subject.close
     end
@@ -549,7 +549,7 @@ RSpec.describe Airbrake::PerformanceNotifier do
     it "logs the exit message" do
       allow(Airbrake::Loggable.instance).to receive(:debug)
       expect(Airbrake::Loggable.instance).to receive(:debug).with(
-        /performance notifier closed/
+        /performance notifier closed/,
       )
       subject.close
     end
@@ -571,8 +571,8 @@ RSpec.describe Airbrake::PerformanceNotifier do
           method: 'POST',
           route: '/foo',
           status_code: 200,
-          start_time: Time.new(2018, 1, 1, 0, 49, 0, 0)
-        )
+          start_time: Time.new(2018, 1, 1, 0, 49, 0, 0),
+        ),
       )
       subject.close
 

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Airbrake::Query do
   describe "#stash" do
     subject do
       described_class.new(
-        method: 'GET', route: '/', query: '', start_time: Time.now
+        method: 'GET', route: '/', query: '', start_time: Time.now,
       )
     end
 

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Airbrake::Request do
   describe "#stash" do
     subject do
       described_class.new(
-        method: 'GET', route: '/', status_code: 200, start_time: Time.now
+        method: 'GET', route: '/', status_code: 200, start_time: Time.now,
       )
     end
 

--- a/spec/response_spec.rb
+++ b/spec/response_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Airbrake::Response do
       context "when response code is #{code}" do
         it "logs response body" do
           expect(Airbrake::Loggable.instance).to receive(:debug).with(
-            /Airbrake::Response \(#{code}\): {}/
+            /Airbrake::Response \(#{code}\): {}/,
           )
           described_class.parse(OpenStruct.new(code: code, body: '{}'))
         end
@@ -15,10 +15,10 @@ RSpec.describe Airbrake::Response do
       context "when response code is #{code}" do
         it "logs response message" do
           expect(Airbrake::Loggable.instance).to receive(:error).with(
-            /Airbrake: foo/
+            /Airbrake: foo/,
           )
           described_class.parse(
-            OpenStruct.new(code: code, body: '{"message":"foo"}')
+            OpenStruct.new(code: code, body: '{"message":"foo"}'),
           )
         end
       end
@@ -29,7 +29,7 @@ RSpec.describe Airbrake::Response do
 
       it "logs response message" do
         expect(Airbrake::Loggable.instance).to receive(:error).with(
-          /Airbrake: rate limited/
+          /Airbrake: rate limited/,
         )
         described_class.parse(response)
       end
@@ -41,7 +41,7 @@ RSpec.describe Airbrake::Response do
         resp = described_class.parse(response)
         expect(resp).to include(
           'error' => '**Airbrake: rate limited',
-          'rate_limit_reset' => time
+          'rate_limit_reset' => time,
         )
       end
     end
@@ -51,7 +51,7 @@ RSpec.describe Airbrake::Response do
 
       it "logs response body" do
         expect(Airbrake::Loggable.instance).to receive(:error).with(
-          /Airbrake: unexpected code \(500\)\. Body: foo/
+          /Airbrake: unexpected code \(500\)\. Body: foo/,
         )
         described_class.parse(response)
       end
@@ -73,14 +73,14 @@ RSpec.describe Airbrake::Response do
 
       it "logs response body" do
         expect(Airbrake::Loggable.instance).to receive(:error).with(
-          /Airbrake: error while parsing body \(.*unexpected token.*\)\. Body: foo/
+          /Airbrake: error while parsing body \(.*unexpected token.*\)\. Body: foo/,
         )
         described_class.parse(response)
       end
 
       it "returns an error message" do
         expect(described_class.parse(response)['error']).to match(
-          /\A#<JSON::ParserError.+>/
+          /\A#<JSON::ParserError.+>/,
         )
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,7 +47,7 @@ class AirbrakeTestError < RuntimeError
       "/home/kyrylo/.gem/ruby/2.2.2/gems/rspec-core-3.3.2/lib/rspec/core/runner.rb:88:in `run'",
       "/home/kyrylo/.gem/ruby/2.2.2/gems/rspec-core-3.3.2/lib/rspec/core/runner.rb:73:in `run'",
       "/home/kyrylo/.gem/ruby/2.2.2/gems/rspec-core-3.3.2/lib/rspec/core/runner.rb:41:in `invoke'",
-      "/home/kyrylo/.gem/ruby/2.2.2/gems/rspec-core-3.3.2/exe/rspec:4:in `<main>'"
+      "/home/kyrylo/.gem/ruby/2.2.2/gems/rspec-core-3.3.2/exe/rspec:4:in `<main>'",
     ]
     # rubocop:enable Metrics/LineLength
   end
@@ -78,7 +78,7 @@ class JavaAirbrakeTestError < AirbrakeTestError
       "opt.rubies.jruby_minus_9_dot_0_dot_0_dot_0.bin.irb.RUBY$script(/opt/rubies/jruby-9.0.0.0/bin/irb:13)",
       "org.jruby.ir.Compiler$1.load(Compiler.java:111)",
       "org.jruby.Main.run(Main.java:225)",
-      "org.jruby.Main.main(Main.java:197)"
+      "org.jruby.Main.main(Main.java:197)",
     ]
     # rubocop:enable Metrics/LineLength
   end

--- a/spec/stat_spec.rb
+++ b/spec/stat_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Airbrake::Stat do
         'count' => 0,
         'sum' => 0.0,
         'sumsq' => 0.0,
-        'tdigest' => 'AAAAAkA0AAAAAAAAAAAAAA=='
+        'tdigest' => 'AAAAAkA0AAAAAAAAAAAAAA==',
       )
     end
   end
@@ -34,7 +34,7 @@ RSpec.describe Airbrake::Stat do
   describe "#inspect" do
     it "provides custom inspect output" do
       expect(subject.inspect).to eq(
-        '#<struct Airbrake::Stat count=0, sum=0.0, sumsq=0.0>'
+        '#<struct Airbrake::Stat count=0, sum=0.0, sumsq=0.0>',
       )
     end
   end

--- a/spec/sync_sender_spec.rb
+++ b/spec/sync_sender_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Airbrake::SyncSender do
   before do
     Airbrake::Config.instance = Airbrake::Config.new(
-      project_id: 1, project_key: 'banana'
+      project_id: 1, project_key: 'banana',
     )
   end
 
@@ -17,8 +17,8 @@ RSpec.describe Airbrake::SyncSender do
       subject.send({}, promise)
       expect(
         a_request(:post, endpoint).with(
-          headers: { 'Content-Type' => 'application/json' }
-        )
+          headers: { 'Content-Type' => 'application/json' },
+        ),
       ).to have_been_made.once
     end
 
@@ -27,9 +27,9 @@ RSpec.describe Airbrake::SyncSender do
       expect(
         a_request(:post, endpoint).with(
           headers: {
-            'User-Agent' => %r{airbrake-ruby/\d+\.\d+\.\d+ Ruby/\d+\.\d+\.\d+}
-          }
-        )
+            'User-Agent' => %r{airbrake-ruby/\d+\.\d+\.\d+ Ruby/\d+\.\d+\.\d+},
+          },
+        ),
       ).to have_been_made.once
     end
 
@@ -37,8 +37,8 @@ RSpec.describe Airbrake::SyncSender do
       subject.send({}, promise)
       expect(
         a_request(:post, endpoint).with(
-          headers: { 'Authorization' => 'Bearer banana' }
-        )
+          headers: { 'Authorization' => 'Bearer banana' },
+        ),
       ).to have_been_made.once
     end
 
@@ -47,7 +47,7 @@ RSpec.describe Airbrake::SyncSender do
       allow(subject).to receive(:build_https).and_return(https)
       allow(https).to receive(:request).and_raise(StandardError.new('foo'))
       expect(Airbrake::Loggable.instance).to receive(:error).with(
-        /HTTP error: foo/
+        /HTTP error: foo/,
       )
       expect(subject.send({}, promise)).to be_an(Airbrake::Promise)
       expect(promise.value).to eq('error' => '**Airbrake: HTTP error: foo')
@@ -69,10 +69,10 @@ RSpec.describe Airbrake::SyncSender do
         notice = Airbrake::Notice.new(ex)
 
         expect(Airbrake::Loggable.instance).to receive(:error).with(
-          /data was not sent/
+          /data was not sent/,
         )
         expect(Airbrake::Loggable.instance).to receive(:error).with(
-          /truncation failed/
+          /truncation failed/,
         )
         expect(subject.send(notice, promise)).to be_an(Airbrake::Promise)
         expect(promise.value)
@@ -87,7 +87,7 @@ RSpec.describe Airbrake::SyncSender do
         stub_request(:post, endpoint).to_return(
           status: 429,
           body: '{"message":"IP is rate limited"}',
-          headers: { 'X-RateLimit-Delay' => '1' }
+          headers: { 'X-RateLimit-Delay' => '1' },
         )
       end
 

--- a/spec/tdigest_spec.rb
+++ b/spec/tdigest_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Airbrake::TDigest do
       new_tdigest = described_class.from_bytes(bytes)
       # Expect some rounding error due to compression
       expect(new_tdigest.percentile(0.9).round(5)).to eq(
-        subject.percentile(0.9).round(5)
+        subject.percentile(0.9).round(5),
       )
       expect(new_tdigest.as_small_bytes).to eq(bytes)
     end
@@ -126,8 +126,8 @@ RSpec.describe Airbrake::TDigest do
           113270270.27027026,
           154459459.45945945,
           123829787.23404256,
-          103191489.36170213
-        ]
+          103191489.36170213,
+        ],
       )
     end
 
@@ -166,13 +166,13 @@ RSpec.describe Airbrake::TDigest do
       it "has the parameters of the left argument (the calling tdigest)" do
         new_tdigest = subject + @other
         expect(new_tdigest.instance_variable_get(:@delta)).to eq(
-          subject.instance_variable_get(:@delta)
+          subject.instance_variable_get(:@delta),
         )
         expect(new_tdigest.instance_variable_get(:@k)).to eq(
-          subject.instance_variable_get(:@k)
+          subject.instance_variable_get(:@k),
         )
         expect(new_tdigest.instance_variable_get(:@cx)).to eq(
-          subject.instance_variable_get(:@cx)
+          subject.instance_variable_get(:@cx),
         )
       end
 

--- a/spec/thread_pool_spec.rb
+++ b/spec/thread_pool_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Airbrake::ThreadPool do
     described_class.new(
       worker_size: worker_size,
       queue_size: queue_size,
-      block: proc { |message| tasks << message }
+      block: proc { |message| tasks << message },
     )
   end
 
@@ -35,7 +35,7 @@ RSpec.describe Airbrake::ThreadPool do
         described_class.new(
           worker_size: 1,
           queue_size: 1,
-          block: proc { |message| tasks << message }
+          block: proc { |message| tasks << message },
         )
       end
 
@@ -98,11 +98,11 @@ RSpec.describe Airbrake::ThreadPool do
     context "when there's some work to do" do
       it "logs how many tasks are left to process" do
         thread_pool = described_class.new(
-          worker_size: 0, queue_size: 2, block: proc {}
+          worker_size: 0, queue_size: 2, block: proc {},
         )
 
         expect(Airbrake::Loggable.instance).to receive(:debug).with(
-          /waiting to process \d+ task\(s\)/
+          /waiting to process \d+ task\(s\)/,
         )
         expect(Airbrake::Loggable.instance).to receive(:debug).with(/closed/)
 
@@ -112,7 +112,7 @@ RSpec.describe Airbrake::ThreadPool do
 
       it "waits until the queue gets empty" do
         thread_pool = described_class.new(
-          worker_size: 1, queue_size: 2, block: proc {}
+          worker_size: 1, queue_size: 2, block: proc {},
         )
 
         10.times { subject << 1 }

--- a/spec/timed_trace_spec.rb
+++ b/spec/timed_trace_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe Airbrake::TimedTrace do
       it "returns a Hash with all spans" do
         expect(subject.spans).to match(
           'operation' => be > 0,
-          'another operation' => be > 0
+          'another operation' => be > 0,
         )
       end
     end

--- a/spec/truncator_spec.rb
+++ b/spec/truncator_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Airbrake::Truncator do
           banana: multiply_by_2_max_len('a'),
           kiwi: multiply_by_2_max_len('b'),
           strawberry: 'c',
-          shrimp: 'd'
+          shrimp: 'd',
         }.freeze
       end
 
@@ -34,7 +34,7 @@ RSpec.describe Airbrake::Truncator do
         expect(subject).to be_frozen
 
         expect(subject).to eq(
-          banana: 'aaa[Truncated]', kiwi: 'bbb[Truncated]', strawberry: 'c'
+          banana: 'aaa[Truncated]', kiwi: 'bbb[Truncated]', strawberry: 'c',
         )
         expect(subject[:banana]).to be_frozen
         expect(subject[:kiwi]).to be_frozen
@@ -48,7 +48,7 @@ RSpec.describe Airbrake::Truncator do
           multiply_by_2_max_len('a'),
           'b',
           multiply_by_2_max_len('c'),
-          'd'
+          'd',
         ].freeze
       end
 
@@ -69,7 +69,7 @@ RSpec.describe Airbrake::Truncator do
           multiply_by_2_max_len('a'),
           'b',
           multiply_by_2_max_len('c'),
-          'd'
+          'd',
         ]).freeze
       end
 
@@ -78,7 +78,7 @@ RSpec.describe Airbrake::Truncator do
         expect(subject).to be_frozen
 
         expect(subject).to eq(
-          Set.new(['aaa[Truncated]', 'b', 'ccc[Truncated]'])
+          Set.new(['aaa[Truncated]', 'b', 'ccc[Truncated]']),
         )
         expect(subject).to be_frozen
       end
@@ -166,7 +166,7 @@ RSpec.describe Airbrake::Truncator do
 
       it "prevents recursion" do
         expect(subject).to eq(
-          Set.new(['[Circular]', { k: '[Circular]' }, 'aaa[Truncated]'])
+          Set.new(['[Circular]', { k: '[Circular]' }, 'aaa[Truncated]']),
         )
         expect(subject).to be_frozen
       end
@@ -177,13 +177,13 @@ RSpec.describe Airbrake::Truncator do
         {
           a: multiply_by_2_max_len('a'),
           b: multiply_by_2_max_len('b'),
-          c: { d: multiply_by_2_max_len('d'), e: 'e' }
+          c: { d: multiply_by_2_max_len('d'), e: 'e' },
         }
       end
 
       it "truncates the long strings" do
         expect(subject).to eq(
-          a: 'aaa[Truncated]', b: 'bbb[Truncated]', c: { d: 'ddd[Truncated]', e: 'e' }
+          a: 'aaa[Truncated]', b: 'bbb[Truncated]', c: { d: 'ddd[Truncated]', e: 'e' },
         )
         expect(subject).to be_frozen
       end
@@ -218,8 +218,8 @@ RSpec.describe Airbrake::Truncator do
           errors: [
             { file: 'a' },
             { file: 'a' },
-            hashie.new.merge(file: 'bcde')
-          ]
+            hashie.new.merge(file: 'bcde'),
+          ],
         }
       end
 
@@ -228,8 +228,8 @@ RSpec.describe Airbrake::Truncator do
           errors: [
             { file: 'a' },
             { file: 'a' },
-            hashie.new.merge(file: 'bcd[Truncated]')
-          ]
+            hashie.new.merge(file: 'bcd[Truncated]'),
+          ],
         )
         expect(subject).to be_frozen
       end


### PR DESCRIPTION
When you edit Go, Rust, JS and Ruby at the same time, it's a headache to keep
remembering various style guides. I found that trailing commas generate better
diffs and also allow inserting new elements faster.