### PR TITLE
performance_notifier: add #notify_sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Airbrake Ruby Changelog
 
 ### master
 
+* Added `Airbrake.notfy_queue_sync`
+  ([#518](https://github.com/airbrake/airbrake-ruby/pull/518))
+
 ### [v4.9.0][v4.9.0] (December 9, 2019)
 
 * Added `Airbrake.notify_queue`, which sends queue (worker) info to Airbrake

--- a/README.md
+++ b/README.md
@@ -886,6 +886,26 @@ a rejected promise.
 When [`config.performance_stats = true`](#performance_stats), then it aggregates
 statistics and sends as a batch every 15 seconds.
 
+#### Airbrake.notify_queue_sync
+
+Sends queue (worker) statistics to Airbrake synchronously. Supports groups (similar to
+[performance breakdowns](#airbrakenotify_performance_breakdown)).
+
+```ruby
+Airbrake.notify_queue(
+  queue: "emails",
+  error_count: 1,
+  groups: { redis: 24.0, sql: 0.4 } # ms
+)
+#=> { "NoContent" => nil }
+```
+
+Accepts the same parameters as [`Airbrake.notify_queue`](#airbrakenotify_queue).
+
+##### Return value
+
+Always returns a Hash with response from the server.
+
 #### Airbrake.add_performance_filter
 
 Adds a performance filter that filters performance data. Works exactly like

--- a/lib/airbrake-ruby.rb
+++ b/lib/airbrake-ruby.rb
@@ -442,14 +442,42 @@ module Airbrake
     #   failed
     # @option queue_info [Array<Hash{Symbol=>Float}>] :groups Where the job
     #   spent its time
-    # @param [Hash] stash What needs to be appeneded to the stash, so it's
+    # @param [Hash] stash What needs to be appended to the stash, so it's
     #   available in filters
     # @return [void]
     # @since v4.9.0
+    # @see .notify_queue_sync
     def notify_queue(queue_info, stash = {})
       queue = Queue.new(queue_info)
       queue.stash.merge!(stash)
       performance_notifier.notify(queue)
+    end
+
+    # Increments statistics of a certain queue (worker) synchronously.
+    #
+    # @example
+    #   response = Airbrake.notify_queue_sync(
+    #     queue: 'emails',
+    #     error_count: 1,
+    #     groups: { redis: 24.0, sql: 0.4 } # ms
+    #   )
+    #   puts response #=> { 'NoContent' => nil }
+    #
+    # @param [Hash{Symbol=>Object}] queue_info
+    # @option queue_info [String] :queue The name of the queue/worker
+    # @option queue_info [Integer] :error_count How many times this worker
+    #   failed
+    # @option queue_info [Array<Hash{Symbol=>Float}>] :groups Where the job
+    #   spent its time
+    # @param [Hash] stash What needs to be appended to the stash, so it's
+    #   available in filters
+    # @return [void]
+    # @since v4.10.0
+    # @see .notify_queue
+    def notify_queue_sync(queue_info, stash = {})
+      queue = Queue.new(queue_info)
+      queue.stash.merge!(stash)
+      performance_notifier.notify_sync(queue)
     end
 
     # Runs a callback before {.notify_request} or {.notify_query} kicks in. This

--- a/spec/airbrake_spec.rb
+++ b/spec/airbrake_spec.rb
@@ -334,6 +334,20 @@ RSpec.describe Airbrake do
     end
   end
 
+  describe "#notify_queue_sync" do
+    it "notifies queue synchronously" do
+      expect(described_class.performance_notifier).to receive(:notify_sync)
+
+      described_class.notify_queue_sync(
+        {
+          queue: 'bananas',
+          error_count: 10,
+        },
+        request_id: 1,
+      )
+    end
+  end
+
   describe ".performance_notifier" do
     it "returns a performance notifier" do
       expect(described_class.performance_notifier)

--- a/spec/performance_notifier_spec.rb
+++ b/spec/performance_notifier_spec.rb
@@ -524,6 +524,26 @@ RSpec.describe Airbrake::PerformanceNotifier do
     end
   end
 
+  describe "#notify_sync" do
+    it "notifies synchronously" do
+      retval = subject.notify_sync(
+        Airbrake::Query.new(
+          method: 'POST',
+          route: '/foo',
+          query: 'SELECT * FROM things',
+          start_time: Time.new(2018, 1, 1, 0, 49, 0, 0),
+        ),
+      )
+
+      expect(
+        a_request(:put, queries).with(
+          body: %r|\A{"queries":\[{"method":"POST","route":"/foo"|,
+        ),
+      ).to have_been_made
+      expect(retval).to eq('' => nil)
+    end
+  end
+
   describe "#close" do
     before do
       Airbrake::Config.instance.merge(performance_stats_flush_period: 0.1)


### PR DESCRIPTION
`PerformanceNotifier#notify_sync` exists for the same reasons as
`NoticeNotifier#notify_sync`.

In certain scenarios, such as Resque jobs, `AsyncSender` dies before it can send
something. Because `PerformanceNotifier` waits 15 seconds before sending
payload, it's guaranteed that once a Resque job finishes, it also kills
`PerformanceNotifier` before it can send. This is the unfortunate effect of
forking.

To cope with this, we must send synchronously.