### PR TITLE
Fix default `end_time` sometimes being equal to `start_time`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Airbrake Ruby Changelog
 
 ### master
 
+* Fixed bug in `PerformanceNotifier` where resource's `start_time` and
+  `end_time` could be the same. This was resulting into sending `sum` statistics
+  for `:total` payload to equal to `0.0`. Zero `sum` is rejected by the backend,
+  and as result, the whole resource is rejected as well
+  ([#522](https://github.com/airbrake/airbrake-ruby/pull/522))
+
 ### [v4.10.0][v4.10.0] (December 12, 2019)
 
 * Added `Airbrake.notfy_queue_sync`

--- a/lib/airbrake-ruby/performance_breakdown.rb
+++ b/lib/airbrake-ruby/performance_breakdown.rb
@@ -20,7 +20,7 @@ module Airbrake
       response_type:,
       groups:,
       start_time:,
-      end_time: Time.now
+      end_time: start_time + 1
     )
       @start_time_utc = TimeTruncate.utc_truncate_minutes(start_time)
       super(method, route, response_type, groups, start_time, end_time)

--- a/lib/airbrake-ruby/query.rb
+++ b/lib/airbrake-ruby/query.rb
@@ -22,7 +22,7 @@ module Airbrake
       file: nil,
       line: nil,
       start_time:,
-      end_time: Time.now
+      end_time: start_time + 1
     )
       @start_time_utc = TimeTruncate.utc_truncate_minutes(start_time)
       super(method, route, query, func, file, line, start_time, end_time)

--- a/lib/airbrake-ruby/queue.rb
+++ b/lib/airbrake-ruby/queue.rb
@@ -15,7 +15,7 @@ module Airbrake
       error_count:,
       groups: {},
       start_time: Time.now,
-      end_time: Time.now
+      end_time: start_time + 1
     )
       @start_time_utc = TimeTruncate.utc_truncate_minutes(start_time)
       super(queue, error_count, groups, start_time, end_time)

--- a/lib/airbrake-ruby/request.rb
+++ b/lib/airbrake-ruby/request.rb
@@ -17,7 +17,7 @@ module Airbrake
       route:,
       status_code:,
       start_time:,
-      end_time: Time.now
+      end_time: start_time + 1
     )
       @start_time_utc = TimeTruncate.utc_truncate_minutes(start_time)
       super(method, route, status_code, start_time, end_time)

--- a/spec/performance_breakdown_spec.rb
+++ b/spec/performance_breakdown_spec.rb
@@ -9,4 +9,15 @@ RSpec.describe Airbrake::PerformanceBreakdown do
 
     it { is_expected.to respond_to(:stash) }
   end
+
+  describe "#end_time" do
+    it "is always equal to start_time + 1 second by default" do
+      time = Time.now
+      performance_breakdown = described_class.new(
+        method: 'GET', route: '/', response_type: '', groups: {},
+        start_time: time
+      )
+      expect(performance_breakdown.end_time).to eq(time + 1)
+    end
+  end
 end

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -8,4 +8,14 @@ RSpec.describe Airbrake::Query do
 
     it { is_expected.to respond_to(:stash) }
   end
+
+  describe "#end_time" do
+    it "is always equal to start_time + 1 second by default" do
+      time = Time.now
+      query = described_class.new(
+        method: 'GET', route: '/', query: '', start_time: time,
+      )
+      expect(query.end_time).to eq(time + 1)
+    end
+  end
 end

--- a/spec/queue_spec.rb
+++ b/spec/queue_spec.rb
@@ -8,4 +8,14 @@ RSpec.describe Airbrake::Queue do
   describe "#stash" do
     it { is_expected.to respond_to(:stash) }
   end
+
+  describe "#end_time" do
+    it "is always equal to start_time + 1 second by default" do
+      time = Time.now
+      queue = described_class.new(
+        queue: 'bananas', error_count: 0, start_time: time,
+      )
+      expect(queue.end_time).to eq(time + 1)
+    end
+  end
 end

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -8,4 +8,14 @@ RSpec.describe Airbrake::Request do
 
     it { is_expected.to respond_to(:stash) }
   end
+
+  describe "#end_time" do
+    it "is always equal to start_time + 1 second by default" do
+      time = Time.now
+      request = described_class.new(
+        method: 'GET', route: '/', status_code: 200, start_time: time,
+      )
+      expect(request.end_time).to eq(time + 1)
+    end
+  end
 end


### PR DESCRIPTION
In `PerformanceNotifier` there's a possible situtation when `start_time` and
`end_time` are the same. If that's the case, the backend will reject the
resource because `Airbrake::Stat` would report zero `sum`. As result, the
backend will reject what we send:

```
**Airbrake: sum <= 0
```