### PR TITLE
notice_notifier: fix confusing error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Airbrake Ruby Changelog
 
 ### master
 
+* `NoticeNotifier` fixed confusing error message when trying to build a notice
+  when Airbrake was closed
+  ([#525](https://github.com/airbrake/airbrake-ruby/pull/525))
+
 ### [v4.10.1][v4.10.1] (December 12, 2019)
 
 * Fixed bug in `PerformanceNotifier` where resource's `start_time` and

--- a/lib/airbrake-ruby/notice_notifier.rb
+++ b/lib/airbrake-ruby/notice_notifier.rb
@@ -55,7 +55,8 @@ module Airbrake
     def build_notice(exception, params = {})
       if @async_sender.closed?
         raise Airbrake::Error,
-              "attempted to build #{exception} with closed Airbrake instance"
+              "Airbrake is closed; can't build exception: " \
+              "#{exception.class}: #{exception}"
       end
 
       if exception.is_a?(Airbrake::Notice)

--- a/spec/notice_notifier_spec.rb
+++ b/spec/notice_notifier_spec.rb
@@ -328,9 +328,9 @@ RSpec.describe Airbrake::NoticeNotifier do
       end
 
       it "raises error" do
-        expect { subject.build_notice(Exception.new) }.to raise_error(
+        expect { subject.build_notice(Exception.new('oops')) }.to raise_error(
           Airbrake::Error,
-          'attempted to build Exception with closed Airbrake instance',
+          "Airbrake is closed; can't build exception: Exception: oops",
         )
       end
     end


### PR DESCRIPTION
Addresses #524 (Error Airbrake: performance notifier closed causes deadlock)

A user reported that he saw the following message in the logs:

> Airbrake::Error (attempted to build deadlock; recursive locking with closed
  Airbrake instance)

Because exceptions are stringified, the error message can get very confusing. In
issue #524 the user thought that there's a deadlock in airbrake-ruby (me too,
to be honest), but when I took a closer look, it turned out that we print the
exception we're building as a string.

I changed the message, so it's more obvious what's going on.