### PR TITLE
Add `job_stats` to the config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Airbrake Ruby Changelog
 
 ### master
 
+* Added a new option called `job_stats`, which controls whether the library
+  should send jobs (aka tasks/workers/queues)
+  ([#534](https://github.com/airbrake/airbrake-ruby/pull/534))
+
 ### [v4.11.1][v4.11.1] (December 20, 2019)
 
 * `PerformanceNotifier`: started rejecting resources with zero timing

--- a/README.md
+++ b/README.md
@@ -388,6 +388,24 @@ Airbrake.configure do |c|
 end
 ```
 
+#### job_stats
+
+Configures Airbrake Performance Monitoring job (aka queue/task/worker)
+statistics collection. It is displayed on the Performance tab of your
+project. If `performance_stats` is `false`, setting this to `true` won't have
+effect because `performance_stats` has higher precedence. By default, it's
+enabled.
+
+The statistics is sent via:
+
+* [`Airbrake.notify_queue`](#airbrakenotify_queue)
+
+```
+Airbrake.configure do |c|
+  c.job_stats = false
+end
+```
+
 ### Asynchronous Airbrake options
 
 The options listed below apply to [`Airbrake.notify`](#airbrakenotify), they do
@@ -895,7 +913,8 @@ Sends queue (worker) statistics to Airbrake. Supports groups (similar to
 Airbrake.notify_queue(
   queue: "emails",
   error_count: 1,
-  groups: { redis: 24.0, sql: 0.4 } # ms
+  groups: { redis: 24.0, sql: 0.4 }, # ms
+  timing: 0.05221 # ms
 )
 ```
 

--- a/lib/airbrake-ruby/config.rb
+++ b/lib/airbrake-ruby/config.rb
@@ -101,6 +101,12 @@ module Airbrake
     # @since v4.6.0
     attr_accessor :query_stats
 
+    # @return [Boolean] true if the library should send job/queue/worker stats
+    #   to Airbrake, false otherwise
+    # @api public
+    # @since v4.12.0
+    attr_accessor :job_stats
+
     class << self
       # @return [Config]
       attr_writer :instance
@@ -139,6 +145,7 @@ module Airbrake
       self.performance_stats = true
       self.performance_stats_flush_period = 15
       self.query_stats = true
+      self.job_stats = true
 
       merge(user_config)
     end
@@ -213,6 +220,8 @@ module Airbrake
         promise.reject("The Performance Stats feature is disabled")
       elsif resource.is_a?(Airbrake::Query) && !query_stats
         promise.reject("The Query Stats feature is disabled")
+      elsif resource.is_a?(Airbrake::Queue) && !job_stats
+        promise.reject("The Job Stats feature is disabled")
       else
         promise
       end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Airbrake::Config do
   its(:performance_stats) { is_expected.to eq(true) }
   its(:performance_stats_flush_period) { is_expected.to eq(15) }
   its(:query_stats) { is_expected.to eq(true) }
+  its(:job_stats) { is_expected.to eq(true) }
 
   describe "#new" do
     context "when user config is passed" do
@@ -143,6 +144,21 @@ RSpec.describe Airbrake::Config do
         promise = subject.check_performance_options(resource)
         expect(promise.value).to eq(
           'error' => "The Query Stats feature is disabled",
+        )
+      end
+    end
+
+    context "when job stats are disabled" do
+      before { subject.job_stats = false }
+
+      let(:resource) do
+        Airbrake::Queue.new(queue: 'foo_queue', error_count: 0, timing: 1)
+      end
+
+      it "returns a rejected promise" do
+        promise = subject.check_performance_options(resource)
+        expect(promise.value).to eq(
+          'error' => "The Job Stats feature is disabled",
         )
       end
     end

--- a/spec/performance_notifier_spec.rb
+++ b/spec/performance_notifier_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Airbrake::PerformanceNotifier do
       performance_stats: true,
       performance_stats_flush_period: 0,
       query_stats: true,
+      job_stats: true,
     )
   end
 


### PR DESCRIPTION
It works exactly the same as `query_stats`. Users who don't need the feature can
disable it.