### PR TITLE
Fix crashing `add_performance_filter` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -957,14 +957,14 @@ Always returns a Hash with response from the server.
 Adds a performance filter that filters performance data. Works exactly like
 [`Airbrake.add_filter`](#airbrakeadd_filter). The only difference is that
 instead of `Airbrake::Notice` it yields performance data (such as
-`Airbrake::Query` or `Airbrake::Request`). It's invoked after
+`Airbrake::Query`, `Airbrake::Request`, or `Airbrake::Queue`). It's invoked after
 [`notify_request`](#airbrakenotify_request) or
 [`notify_query`](#airbrakenotify_query) (but [`notify`](#airbrakenotify) calls
 don't trigger it!).
 
 ```ruby
 Airbrake.add_performance_filter do |resource|
-  resource.ignore! if resource.route =~ %r{/health_check}
+  resource.ignore! if !resource.respond_to?(:route) || resource.route =~ %r{/health_check}
 end
 ```
 


### PR DESCRIPTION
Since v10, `airbrake` is able to send performance info for `ActiveJob` jobs: https://github.com/airbrake/airbrake/commit/8bff73b59f7c715d13a0108119c662cce65f005c

The payload is an object of type `Request::Queue`, which doesn't respond to `route`. Therefore, this PR fixes the sample code to ensure you check if the `route` method exists before calling it.