### PR TITLE
queue: add #route for API compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Airbrake Ruby Changelog
 
 ### master
 
+* Added `Airbrake::Queue#route` for filter API compatibility. It always returns
+  an empty string ([#539](https://github.com/airbrake/airbrake-ruby/pull/539))
+
 ### [v4.12.0][v4.12.0] (January 7, 2020)
 
 * Added a new option called `job_stats`, which controls whether the library

--- a/lib/airbrake-ruby/queue.rb
+++ b/lib/airbrake-ruby/queue.rb
@@ -51,6 +51,15 @@ module Airbrake
     def merge(other)
       self.error_count += other.error_count
     end
+
+    # Queues don't have routes, but we want to define this to make sure our
+    # filter API is consistent (other models define this property)
+    #
+    # @return [String] empty route
+    # @see https://github.com/airbrake/airbrake-ruby/pull/537
+    def route
+      ''
+    end
   end
   # rubocop:enable Metrics/BlockLength, Metrics/ParameterLists
 end

--- a/spec/queue_spec.rb
+++ b/spec/queue_spec.rb
@@ -18,4 +18,13 @@ RSpec.describe Airbrake::Queue do
       expect(queue.end_time).to eq(time + 1)
     end
   end
+
+  describe "#route" do
+    it "always returns an empty route" do
+      queue = described_class.new(
+        queue: 'a', error_count: 0, start_time: Time.now,
+      )
+      expect(queue.route).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
Alternative solution to the problem described in:
https://github.com/airbrake/airbrake-ruby/pull/537

We've added `Airbrake::Queue` but forgot to define `#route`. Hence, some filters
that call `resource.route` will raise `NoMethodError`