### PR TITLE
Fix all Ruby 2.7 warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 gemspec
 
+gem 'rake', '~> 10' if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.2')
 gem 'rubocop', '= 0.55', require: false
 gem 'simplecov', '~> 0.16', require: false

--- a/airbrake-ruby.gemspec
+++ b/airbrake-ruby.gemspec
@@ -34,7 +34,7 @@ DESC
 
   s.add_development_dependency 'rspec', '~> 3'
   s.add_development_dependency 'rspec-its', '~> 1.2'
-  s.add_development_dependency 'rake', '~> 10'
+  s.add_development_dependency 'rake', '>= 10', '< 14'
   s.add_development_dependency 'pry', '~> 0'
   s.add_development_dependency 'webmock', '~> 2.3'
   s.add_development_dependency 'benchmark-ips', '~> 2'

--- a/lib/airbrake-ruby.rb
+++ b/lib/airbrake-ruby.rb
@@ -84,6 +84,13 @@ module Airbrake
   #  special cases where we need to work around older implementations
   JRUBY = (RUBY_ENGINE == 'jruby')
 
+  # @return [Boolean] true if this Ruby supports safe levels and tainting,
+  #  to guard against using deprecated or unsupported features.
+  HAS_SAFE_LEVEL = (
+    RUBY_ENGINE == 'ruby' &&
+    Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.7')
+  )
+
   class << self
     # @since v4.2.3
     # @api private

--- a/lib/airbrake-ruby.rb
+++ b/lib/airbrake-ruby.rb
@@ -371,7 +371,7 @@ module Airbrake
     # @since v3.0.0
     # @see Airbrake::PerformanceNotifier#notify
     def notify_request(request_info, stash = {})
-      request = Request.new(request_info)
+      request = Request.new(**request_info)
       request.stash.merge!(stash)
       performance_notifier.notify(request)
     end
@@ -381,7 +381,7 @@ module Airbrake
     # @since v4.10.0
     # @see .notify_request
     def notify_request_sync(request_info, stash = {})
-      request = Request.new(request_info)
+      request = Request.new(**request_info)
       request.stash.merge!(stash)
       performance_notifier.notify_sync(request)
     end
@@ -414,7 +414,7 @@ module Airbrake
     # @since v3.2.0
     # @see Airbrake::PerformanceNotifier#notify
     def notify_query(query_info, stash = {})
-      query = Query.new(query_info)
+      query = Query.new(**query_info)
       query.stash.merge!(stash)
       performance_notifier.notify(query)
     end
@@ -425,7 +425,7 @@ module Airbrake
     # @since v4.10.0
     # @see .notify_query
     def notify_query_sync(query_info, stash = {})
-      query = Query.new(query_info)
+      query = Query.new(**query_info)
       query.stash.merge!(stash)
       performance_notifier.notify_sync(query)
     end
@@ -453,7 +453,7 @@ module Airbrake
     # @return [void]
     # @since v4.2.0
     def notify_performance_breakdown(breakdown_info, stash = {})
-      performance_breakdown = PerformanceBreakdown.new(breakdown_info)
+      performance_breakdown = PerformanceBreakdown.new(**breakdown_info)
       performance_breakdown.stash.merge!(stash)
       performance_notifier.notify(performance_breakdown)
     end
@@ -463,7 +463,7 @@ module Airbrake
     # @since v4.10.0
     # @see .notify_performance_breakdown
     def notify_performance_breakdown_sync(breakdown_info, stash = {})
-      performance_breakdown = PerformanceBreakdown.new(breakdown_info)
+      performance_breakdown = PerformanceBreakdown.new(**breakdown_info)
       performance_breakdown.stash.merge!(stash)
       performance_notifier.notify_sync(performance_breakdown)
     end
@@ -491,7 +491,7 @@ module Airbrake
     # @since v4.9.0
     # @see .notify_queue_sync
     def notify_queue(queue_info, stash = {})
-      queue = Queue.new(queue_info)
+      queue = Queue.new(**queue_info)
       queue.stash.merge!(stash)
       performance_notifier.notify(queue)
     end
@@ -500,7 +500,7 @@ module Airbrake
     # @since v4.10.0
     # @see .notify_queue
     def notify_queue_sync(queue_info, stash = {})
-      queue = Queue.new(queue_info)
+      queue = Queue.new(**queue_info)
       queue.stash.merge!(stash)
       performance_notifier.notify_sync(queue)
     end

--- a/lib/airbrake-ruby/filters/thread_filter.rb
+++ b/lib/airbrake-ruby/filters/thread_filter.rb
@@ -72,7 +72,7 @@ module Airbrake
         thread_info[:group] = th.group.list.map(&:inspect)
         thread_info[:priority] = th.priority
 
-        thread_info[:safe_level] = th.safe_level unless Airbrake::JRUBY
+        thread_info[:safe_level] = th.safe_level if Airbrake::HAS_SAFE_LEVEL
       end
 
       def sanitize_value(value)

--- a/lib/airbrake-ruby/performance_breakdown.rb
+++ b/lib/airbrake-ruby/performance_breakdown.rb
@@ -5,15 +5,15 @@ module Airbrake
   # @see Airbrake.notify_breakdown
   # @api public
   # @since v4.2.0
-  # rubocop:disable Metrics/BlockLength, Metrics/ParameterLists
-  PerformanceBreakdown = Struct.new(
-    :method, :route, :response_type, :groups, :start_time, :end_time, :timing,
-    :time
-  ) do
+  # rubocop:disable Metrics/ParameterLists
+  class PerformanceBreakdown
     include HashKeyable
     include Ignorable
     include Stashable
     include Mergeable
+
+    attr_accessor :method, :route, :response_type, :groups, :start_time,
+                  :end_time, :timing, :time
 
     def initialize(
       method:,
@@ -26,9 +26,14 @@ module Airbrake
       time: Time.now
     )
       @time_utc = TimeTruncate.utc_truncate_minutes(time)
-      super(
-        method, route, response_type, groups, start_time, end_time, timing, time
-      )
+      @method = method
+      @route = route
+      @response_type = response_type
+      @groups = groups
+      @start_time = start_time
+      @end_time = end_time
+      @timing = timing
+      @time = time
     end
 
     def destination
@@ -48,5 +53,5 @@ module Airbrake
       }.delete_if { |_key, val| val.nil? }
     end
   end
-  # rubocop:enable Metrics/BlockLength, Metrics/ParameterLists
+  # rubocop:enable Metrics/ParameterLists
 end

--- a/lib/airbrake-ruby/query.rb
+++ b/lib/airbrake-ruby/query.rb
@@ -4,16 +4,16 @@ module Airbrake
   # @see Airbrake.notify_query
   # @api public
   # @since v3.2.0
-  # rubocop:disable Metrics/ParameterLists, Metrics/BlockLength
-  Query = Struct.new(
-    :method, :route, :query, :func, :file, :line, :start_time, :end_time,
-    :timing, :time
-  ) do
+  # rubocop:disable Metrics/ParameterLists
+  class Query
     include HashKeyable
     include Ignorable
     include Stashable
     include Mergeable
     include Grouppable
+
+    attr_accessor :method, :route, :query, :func, :file, :line, :start_time,
+                  :end_time, :timing, :time
 
     def initialize(
       method:,
@@ -28,10 +28,16 @@ module Airbrake
       time: Time.now
     )
       @time_utc = TimeTruncate.utc_truncate_minutes(time)
-      super(
-        method, route, query, func, file, line, start_time, end_time, timing,
-        time
-      )
+      @method = method
+      @route = route
+      @query = query
+      @func = func
+      @file = file
+      @line = line
+      @start_time = start_time
+      @end_time = end_time
+      @timing = timing
+      @time = time
     end
 
     def destination
@@ -53,6 +59,6 @@ module Airbrake
         'line' => line,
       }.delete_if { |_key, val| val.nil? }
     end
-    # rubocop:enable Metrics/ParameterLists, Metrics/BlockLength
+    # rubocop:enable Metrics/ParameterLists
   end
 end

--- a/lib/airbrake-ruby/queue.rb
+++ b/lib/airbrake-ruby/queue.rb
@@ -4,13 +4,14 @@ module Airbrake
   # @see Airbrake.notify_queue
   # @api public
   # @since v4.9.0
-  # rubocop:disable Metrics/BlockLength, Metrics/ParameterLists
-  Queue = Struct.new(
-    :queue, :error_count, :groups, :start_time, :end_time, :timing, :time
-  ) do
+  # rubocop:disable Metrics/ParameterLists
+  class Queue
     include HashKeyable
     include Ignorable
     include Stashable
+
+    attr_accessor :queue, :error_count, :groups, :start_time, :end_time,
+                  :timing, :time
 
     def initialize(
       queue:,
@@ -22,7 +23,13 @@ module Airbrake
       time: Time.now
     )
       @time_utc = TimeTruncate.utc_truncate_minutes(time)
-      super(queue, error_count, groups, start_time, end_time, timing, time)
+      @queue = queue
+      @error_count = error_count
+      @groups = groups
+      @start_time = start_time
+      @end_time = end_time
+      @timing = timing
+      @time = time
     end
 
     def destination
@@ -61,5 +68,5 @@ module Airbrake
       ''
     end
   end
-  # rubocop:enable Metrics/BlockLength, Metrics/ParameterLists
+  # rubocop:enable Metrics/ParameterLists
 end

--- a/lib/airbrake-ruby/request.rb
+++ b/lib/airbrake-ruby/request.rb
@@ -4,15 +4,16 @@ module Airbrake
   # @see Airbrake.notify_request
   # @api public
   # @since v3.2.0
-  # rubocop:disable Metrics/BlockLength, Metrics/ParameterLists
-  Request = Struct.new(
-    :method, :route, :status_code, :start_time, :end_time, :timing, :time
-  ) do
+  # rubocop:disable Metrics/ParameterLists
+  class Request
     include HashKeyable
     include Ignorable
     include Stashable
     include Mergeable
     include Grouppable
+
+    attr_accessor :method, :route, :status_code, :start_time, :end_time,
+                  :timing, :time
 
     def initialize(
       method:,
@@ -24,7 +25,13 @@ module Airbrake
       time: Time.now
     )
       @time_utc = TimeTruncate.utc_truncate_minutes(time)
-      super(method, route, status_code, start_time, end_time, timing, time)
+      @method = method
+      @route = route
+      @status_code = status_code
+      @start_time = start_time
+      @end_time = end_time
+      @timing = timing
+      @time = time
     end
 
     def destination
@@ -44,5 +51,5 @@ module Airbrake
       }.delete_if { |_key, val| val.nil? }
     end
   end
-  # rubocop:enable Metrics/BlockLength, Metrics/ParameterLists
+  # rubocop:enable Metrics/ParameterLists
 end

--- a/lib/airbrake-ruby/stat.rb
+++ b/lib/airbrake-ruby/stat.rb
@@ -1,6 +1,5 @@
 require 'base64'
 
-# rubocop:disable Metrics/BlockLength
 module Airbrake
   # Stat is a data structure that allows accumulating performance data (route
   # performance, SQL query performance and such). It's powered by TDigests.
@@ -14,14 +13,19 @@ module Airbrake
   #   stat.to_h # Pack and serialize data so it can be transmitted.
   #
   # @since v3.2.0
-  Stat = Struct.new(:count, :sum, :sumsq, :tdigest) do
+  class Stat
+    attr_accessor :count, :sum, :sumsq, :tdigest
+
     # @param [Integer] count How many times this stat was incremented
     # @param [Float] sum The sum of duration in milliseconds
     # @param [Float] sumsq The squared sum of duration in milliseconds
     # @param [TDigest::TDigest] tdigest Packed durations. By default,
     #   compression is 20
     def initialize(count: 0, sum: 0.0, sumsq: 0.0, tdigest: TDigest.new(0.05))
-      super(count, sum, sumsq, tdigest)
+      @count = count
+      @sum = sum
+      @sumsq = sumsq
+      @tdigest = tdigest
     end
 
     # @return [Hash{String=>Object}] stats as a hash with compressed TDigest
@@ -67,7 +71,6 @@ module Airbrake
     def inspect
       "#<struct Airbrake::Stat count=#{count}, sum=#{sum}, sumsq=#{sumsq}>"
     end
-    alias_method :pretty_print, :inspect
+    alias pretty_print inspect
   end
 end
-# rubocop:enable Metrics/BlockLength

--- a/lib/airbrake-ruby/truncator.rb
+++ b/lib/airbrake-ruby/truncator.rb
@@ -108,8 +108,8 @@ module Airbrake
       return str if utf8_string && str.valid_encoding?
 
       temp_str = str.dup
-      temp_str.encode!(TEMP_ENCODING, ENCODING_OPTIONS) if utf8_string
-      temp_str.encode!('utf-8', ENCODING_OPTIONS)
+      temp_str.encode!(TEMP_ENCODING, **ENCODING_OPTIONS) if utf8_string
+      temp_str.encode!('utf-8', **ENCODING_OPTIONS)
     end
   end
 end

--- a/spec/filters/thread_filter_spec.rb
+++ b/spec/filters/thread_filter_spec.rb
@@ -258,7 +258,9 @@ RSpec.describe Airbrake::Filters::ThreadFilter do
     expect(notice[:params][:thread][:priority]).to eq(0)
   end
 
-  it "appends safe_level", skip: Airbrake::JRUBY do
+  it "appends safe_level", skip: (
+    "Not supported on this version of Ruby." unless Airbrake::HAS_SAFE_LEVEL
+  ) do
     subject.call(notice)
     expect(notice[:params][:thread][:safe_level]).to eq(0)
   end


### PR DESCRIPTION
- Allow rake 13.x on Ruby 2.2+.
- The whole safe_level feature is a deprecated noop in 2.7+.
- Fixed all keyword parameter warnings.
- KeywordStruct wrapper to allow Struct with keyword parameters on
  Ruby 2.7, or faking the behavior on other Ruby versions/platforms.