### PR TITLE
Configuration fixes for airbrake/airbrake#1062

### DIFF
--- a/lib/airbrake-ruby.rb
+++ b/lib/airbrake-ruby.rb
@@ -91,6 +91,12 @@ module Airbrake
     Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.7')
   )
 
+  # @return [Boolean] true if this Ruby supports ... argument forwarding.
+  HAS_ARGUMENT_FORWARDING = (
+    RUBY_ENGINE == 'ruby' &&
+    Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7')
+  )
+
   class << self
     # @since v4.2.3
     # @api private

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -163,4 +163,43 @@ RSpec.describe Airbrake::Config do
       end
     end
   end
+
+  describe "#default_wrapping_style" do
+    let(:message) { "default_wrapping_style must be :chain or :prepend" }
+    it "is :chain by default" do
+      expect(subject.default_wrapping_style).to eq :chain
+    end
+
+    %i[chain prepend].each do |value|
+      it "allows :#{value}" do
+        subject.default_wrapping_style = value
+        expect(subject.default_wrapping_style).to eq value
+      end
+
+      it "allows '#{value}'" do
+        subject.default_wrapping_style = value.to_s
+        expect(subject.default_wrapping_style).to eq value
+      end
+    end
+
+    it "doesn't allow other symbols" do
+      expect { subject.default_wrapping_style = :foo }
+        .to raise_error(ArgumentError, message)
+    end
+
+    it "doesn't allow other strings" do
+      expect { subject.default_wrapping_style = 'bar' }
+        .to raise_error(ArgumentError, message)
+    end
+
+    it "doesn't allow other values" do
+      expect { subject.default_wrapping_style = 1 }
+        .to raise_error(ArgumentError, message)
+    end
+
+    it "doesn't allow nil" do
+      expect { subject.default_wrapping_style = nil }
+        .to raise_error(ArgumentError, message)
+    end
+  end
 end


### PR DESCRIPTION
Airbrake::Rack::Instrumentable#airbrake_capture_timing does method
wrapping similar to alias_method_chain, but this style of wrapping
will cause stack overflows on methods that have been overriden
with Module#prepend. However, using prepend style wrapping will
stack overflow on methods built with alias_method_chain or the
equivalent alias_method calls.

Some people have chained codebases, like those based on Rails < 5.
Rails 5+ codebases are based on prepend. For either case, there
will be random methods that are implemted in the other style, so
even if we set a default we need to have the option of using the
other style. We need to support both wrapping methods, and we
need a way for the user to declare which wrapping method is used
as the default for their project. It can't be autodetected.

Method wrapping also needs to do argument forwarding, and the
syntax and semantics for that changed in Ruby 2.7, effectively.
The real change is coming in Ruby 3 but 2.7 adds many warning
messages for the transition.

Here, we just add the config setting for the default method
wrapping style, and a flag constant to indicate whether the
new argument forwarding style and syntax is supported. As new
Ruby platforms support the new syntax, the flag constant can
be adjusted to match.

The rest will be done in the airbrake gem.