### PR TITLE
Ignore .ruby-version and .ruby-gemset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ doc
 .yardoc
 pkg
 coverage
+.ruby-version
+.ruby-gemset


### PR DESCRIPTION
Make local development easier for rvm and rbenv users.