### PR TITLE
performance_notifier: log JSON instead of Ruby objects

### DIFF
--- a/lib/airbrake-ruby/performance_notifier.rb
+++ b/lib/airbrake-ruby/performance_notifier.rb
@@ -156,13 +156,12 @@ module Airbrake
       signature = "#{self.class.name}##{__method__}"
       raise "#{signature}: payload (#{payload}) cannot be empty. Race?" if payload.none?
 
-      logger.debug { "#{LOG_LABEL} #{signature}: #{payload}" }
-
       with_grouped_payload(payload) do |resource_hash, destination|
         url = URI.join(
           @config.host,
           "api/v5/projects/#{@config.project_id}/#{destination}",
         )
+        logger.debug { "#{LOG_LABEL} #{signature}: #{resource_hash}" }
         sender.send(resource_hash, promise, url)
       end
 


### PR DESCRIPTION
Since we are sending JSON, it makes sense to log JSON, instead of Ruby objects.

Before:

```
DEBUG -- : **Airbrake: Airbrake::PerformanceNotifier#send:
{#<Airbrake::Queue:0x00007fedb7e748f0 @time_utc="2020-02-07T05:27:00+00:00",
@queue="BadWorker", @error_count=0, @groups={},
@start_time=2020-02-07 13:27:40 +0800, @end_time=2020-02-07 13:27:41 +0800,
@timing=8, @time=2020-02-07 13:27:40 +0800, @stash={}
>=>{:total=>#<struct Airbrake::Stat count=100, sum=5390.0, sumsq=378058.0>}}
```

After:

```
DEBUG -- : **Airbrake: Airbrake::PerformanceNotifier#send:
{"queues"=>[{"queue"=>"BadWorker", "errorCount"=>0,
"time"=>"2020-02-07T05:28:00+00:00",
"count"=>100, "sum"=>5318.0, "sumsq"=>359568.0,
"tdigest"=>"AAAAA......."}]}
```