### PR TITLE
stat: delete 'count' method and use tdigest.size as 'count'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ Airbrake Ruby Changelog
 
 ### master
 
+* `PerformanceNotifier`: fixed bug when the backend would reject valid payload
+  due to TDigest count mismatch
+  ([#549](https://github.com/airbrake/airbrake-ruby/pull/549)). For example:
+
+  ```
+  ERROR -- : **Airbrake: tdigest.count=94, but count=100
+  ```
+
 ### [v4.13.0][v4.13.0] (January 27, 2020)
 
 * Added `Airbrake::Queue#route` for filter API compatibility. It always returns

--- a/spec/stat_spec.rb
+++ b/spec/stat_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe Airbrake::Stat do
   describe "#increment_ms" do
     before { subject.increment_ms(1000) }
 
-    its(:count) { is_expected.to eq(1) }
     its(:sum) { is_expected.to eq(1000) }
     its(:sumsq) { is_expected.to eq(1000000) }
 


### PR DESCRIPTION
Once in a while our backend would reject a perfectly valid payload with the
following message (the actual numbers can vary):

```
ERROR -- : **Airbrake: tdigest.count=98, but count=100
```

In `Airbrake::Stat` we dump 2 counts: one comes from the Stat class itself, the
other one is provided by the TDigest implementation. The Stat count would always
be stable (100 calls means the count is 100). The TDigest count sometimes would
be less (98 in this particular example).

Java implementation of TDigest defines `size()` as:

> the number of points that have been added to this TDigest

I don't have a good grasp with the tdigest algorithm but during hours of
experimentation I established that the TDigest count is dependent on the values
we feed to the tdigest. This could mean two things:

1. The Ruby implementation of TDigest is bugged
2. This works as intended because this *is* the algorithm

If you know which of these is true, please ping me.

But could this be a race condition? Well, that was my first thought because we
use our own timer implementation. However a simple change in specs disproves
this quickly:

```
diff --git a/spec/tdigest_spec.rb b/spec/tdigest_spec.rb
index 897ac35..ace60b3 100644
--- a/spec/tdigest_spec.rb
+++ b/spec/tdigest_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe Airbrake::TDigest do
   describe "#size" do
     it "reports the number of observations" do
       n = 10_000
-      n.times { subject.push(rand) }
+      n.times { subject.push(rand(1..100)) }
       subject.compress!
       expect(subject.size).to eq(n)
     end
```

Once in a while that test would fail and `subject.size` would be slightly less
than `n`.

However, if we feed the same value all the time, the TDigest count is always
stable: 100 push calls means tdigest.count=100.

So, the fix is to remove our own count since it serves no real purpose and rely
on the TDigest count.