### PR TITLE
{config,loggable}: set default Logger level to Logger::WARN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Airbrake Ruby Changelog
   ```
   ERROR -- : **Airbrake: tdigest.count=94, but count=100
   ```
+* Fixed `Airbrake::Loggable` and `Airbrake::Config.instance.logger` not being
+  set to `Logger::WARN` by default (as promised by the README)
+  ([#551](https://github.com/airbrake/airbrake-ruby/pull/551))
 
 ### [v4.13.0][v4.13.0] (January 27, 2020)
 

--- a/lib/airbrake-ruby/config.rb
+++ b/lib/airbrake-ruby/config.rb
@@ -119,12 +119,13 @@ module Airbrake
 
     # @param [Hash{Symbol=>Object}] user_config the hash to be used to build the
     #   config
+    # rubocop:disable Metrics/AbcSize
     def initialize(user_config = {})
       self.proxy = {}
       self.queue_size = 100
       self.workers = 1
       self.code_hunks = true
-      self.logger = ::Logger.new(File::NULL)
+      self.logger = ::Logger.new(File::NULL).tap { |l| l.level = Logger::WARN }
       self.project_id = user_config[:project_id]
       self.project_key = user_config[:project_key]
       self.host = 'https://api.airbrake.io'
@@ -149,6 +150,7 @@ module Airbrake
 
       merge(user_config)
     end
+    # rubocop:enable Metrics/AbcSize
 
     # The full URL to the Airbrake Notice API. Based on the +:host+ option.
     # @return [URI] the endpoint address

--- a/lib/airbrake-ruby/loggable.rb
+++ b/lib/airbrake-ruby/loggable.rb
@@ -22,7 +22,7 @@ module Airbrake
 
       # @return [Logger]
       def instance
-        @instance ||= ::Logger.new(File::NULL)
+        @instance ||= ::Logger.new(File::NULL).tap { |l| l.level = ::Logger::WARN }
       end
     end
 

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -163,4 +163,10 @@ RSpec.describe Airbrake::Config do
       end
     end
   end
+
+  describe "#logger" do
+    it "sets logger level to Logger::WARN" do
+      expect(subject.logger.level).to eq(Logger::WARN)
+    end
+  end
 end

--- a/spec/loggable_spec.rb
+++ b/spec/loggable_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe Airbrake::Loggable do
+  describe ".instance" do
+    it "returns a logger" do
+      expect(described_class.instance).to be_a(Logger)
+    end
+  end
+
+  describe "#logger" do
+    let(:subject) do
+      Class.new { include Airbrake::Loggable }.new
+    end
+
+    it "returns a logger that has Logger::WARN severity" do
+      expect(subject.logger.level).to eq(Logger::WARN)
+    end
+  end
+end


### PR DESCRIPTION
Issue #550 mentions that README states that our default logger is `Logger::WARN`,
however the code never sets that level. The default value is `Logger::DEBUG`,
which is unwanted, since it generates a lot of clutter.