### PR TITLE
performance_notifier: refactor timer algorithm to use condition vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Airbrake Ruby Changelog
   ```
   ERROR -- : **Airbrake: tdigest.count=94, but count=100
   ```
+* `PerformanceNotifier`: fixed `ThreadError: deadlock; recursive locking`
+  ([#554](https://github.com/airbrake/airbrake-ruby/pull/554))
 * Fixed `Airbrake::Loggable` and `Airbrake::Config.instance.logger` not being
   set to `Logger::WARN` by default (as promised by the README)
   ([#551](https://github.com/airbrake/airbrake-ruby/pull/551))

--- a/lib/airbrake-ruby/monotonic_time.rb
+++ b/lib/airbrake-ruby/monotonic_time.rb
@@ -16,6 +16,11 @@ module Airbrake
         time_in_nanoseconds / (10.0**6)
       end
 
+      # @return [Integer] current monotonic time in seconds
+      def time_in_s
+        time_in_nanoseconds / (10.0**9)
+      end
+
       private
 
       if defined?(Process::CLOCK_MONOTONIC)

--- a/lib/airbrake-ruby/performance_notifier.rb
+++ b/lib/airbrake-ruby/performance_notifier.rb
@@ -55,34 +55,6 @@ module Airbrake
 
     private
 
-    def update_payload(resource)
-      if (total_stat = @payload[resource])
-        @payload.key(total_stat).merge(resource)
-      else
-        @payload[resource] = { total: Airbrake::Stat.new }
-      end
-
-      update_total(resource, @payload[resource][:total])
-
-      resource.groups.each do |name, ms|
-        @payload[resource][name] ||= Airbrake::Stat.new
-        @payload[resource][name].increment_ms(ms)
-      end
-    end
-
-    def update_total(resource, total)
-      if resource.timing
-        total.increment_ms(resource.timing)
-      else
-        loc = caller_locations(6..6).first
-        Kernel.warn(
-          "#{loc.path}:#{loc.lineno}: warning: :start_time and :end_time are " \
-          "deprecated. Use :timing & :time instead",
-        )
-        total.increment(resource.start_time, resource.end_time)
-      end
-    end
-
     def schedule_flush
       return if @payload.empty?
 
@@ -135,6 +107,34 @@ module Airbrake
         else
           schedule_flush
         end
+      end
+    end
+
+    def update_payload(resource)
+      if (total_stat = @payload[resource])
+        @payload.key(total_stat).merge(resource)
+      else
+        @payload[resource] = { total: Airbrake::Stat.new }
+      end
+
+      update_total(resource, @payload[resource][:total])
+
+      resource.groups.each do |name, ms|
+        @payload[resource][name] ||= Airbrake::Stat.new
+        @payload[resource][name].increment_ms(ms)
+      end
+    end
+
+    def update_total(resource, total)
+      if resource.timing
+        total.increment_ms(resource.timing)
+      else
+        loc = caller_locations(6..6).first
+        Kernel.warn(
+          "#{loc.path}:#{loc.lineno}: warning: :start_time and :end_time are " \
+          "deprecated. Use :timing & :time instead",
+        )
+        total.increment(resource.start_time, resource.end_time)
       end
     end
 

--- a/spec/monotonic_time_spec.rb
+++ b/spec/monotonic_time_spec.rb
@@ -9,4 +9,15 @@ RSpec.describe Airbrake::MonotonicTime do
       expect(subject.time_in_ms).to be > old_time
     end
   end
+
+  describe ".time_in_s" do
+    it "returns monotonic time in seconds" do
+      expect(subject.time_in_s).to be_a(Float)
+    end
+
+    it "always returns time in the future" do
+      old_time = subject.time_in_s
+      expect(subject.time_in_s).to be > old_time
+    end
+  end
 end


### PR DESCRIPTION
Fixes (hopefully) #553 (ThreadError: deadlock; recursive locking in
Airbrake::PerformanceNotifier)

While I've never been able to reproduce the mentioned bug personally, I believe
the problem is the faulty timer mechanism. We mess with background threads and
shared state, which is always prone to bugs.

In this new version of the code we use monitors and condition variables. It
allows us a better synchronisation for `@payload` access. We got rid of the
unwanted `@waiting` variable and stopped calling hacky `Thread.pass`. Basically,
we let Ruby do its threading thing and we don't interrupt manually.

The new implementation became simpler and more stable and I do hope I got this
right.