### PR TITLE
Bump Rubocop & resolve new offences

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -92,3 +92,6 @@ Style/TrailingCommaInArrayLiteral:
 
 Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: comma
+
+Naming/RescuedExceptionsVariableName:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ AllCops:
   Exclude:
     - 'pkg/**/*'
     - 'vendor/**/*'
+    - 'spec/fixtures/**/*'
 
 Metrics/MethodLength:
   Max: 25

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,7 +10,7 @@ AllCops:
 Metrics/MethodLength:
   Max: 25
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 90
 
 # Details:
@@ -48,7 +48,7 @@ Metrics/ClassLength:
 Style/FrozenStringLiteralComment:
   Enabled: false
 
-Layout/IndentArray:
+Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
 
 Style/NumericPredicate:
@@ -69,10 +69,7 @@ Metrics/BlockLength:
     - 'spec/**/*.rb'
     - 'airbrake-ruby.gemspec'
 
-Performance/RegexpMatch:
-  Enabled: false
-
-Layout/IndentHeredoc:
+Layout/HeredocIndentation:
   Enabled: false
 
 Gemspec/OrderedDependencies:
@@ -81,7 +78,7 @@ Gemspec/OrderedDependencies:
 Style/FormatStringToken:
   Enabled: false
 
-Naming/UncommunicativeMethodParamName:
+Naming/MethodParameterName:
   Enabled: false
 
 Gemspec/RequiredRubyVersion:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -95,3 +95,6 @@ Style/TrailingCommaInHashLiteral:
 
 Naming/RescuedExceptionsVariableName:
   Enabled: false
+
+Layout/EmptyLineAfterGuardClause:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,5 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'rake', '~> 10' if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.2')
-gem 'rubocop', '= 0.55', require: false
+gem 'rubocop', '= 0.79', require: false
 gem 'simplecov', '~> 0.16', require: false

--- a/benchmarks/benchmark_helpers.rb
+++ b/benchmarks/benchmark_helpers.rb
@@ -6,7 +6,7 @@ require 'webmock'
 require 'airbrake-ruby'
 
 BIG_EXCEPTION = RuntimeError.new('App crashed!')
-# rubocop:disable Metrics/LineLength
+# rubocop:disable Layout/LineLength
 BIG_EXCEPTION.set_backtrace(
   ["lib/arel/visitors/to_sql.rb:729:in `unsupported'",
    "lib/arel/visitors/reduce.rb:13:in `visit'",
@@ -147,7 +147,7 @@ SMALL_EXCEPTION.set_backtrace(
    "/home/kyrylo/.gem/ruby/2.2.2/gems/rspec-core-3.3.2/lib/rspec/core/runner.rb:41:in `invoke'",
    "/home/kyrylo/.gem/ruby/2.2.2/gems/rspec-core-3.3.2/exe/rspec:4:in `<main>'"],
 )
-# rubocop:enable Metrics/LineLength
+# rubocop:enable Layout/LineLength
 
 # Make sure we don't send any remote requests.
 WebMock.disable_net_connect!(allow_localhost: true)

--- a/lib/airbrake-ruby.rb
+++ b/lib/airbrake-ruby.rb
@@ -1,7 +1,6 @@
 require 'net/https'
 require 'logger'
 require 'json'
-require 'thread'
 require 'set'
 require 'socket'
 require 'time'

--- a/lib/airbrake-ruby/backtrace.rb
+++ b/lib/airbrake-ruby/backtrace.rb
@@ -22,7 +22,7 @@ module Airbrake
         (?<line>\d+)      # Matches '43'
         :in\s
         `(?<function>.*)' # Matches "`block (3 levels) in <top (required)>'"
-      \z}x
+      \z}x.freeze
 
       # @return [Regexp] the pattern that matches JRuby Java stack frames, such
       #  as org.jruby.ast.NewlineNode.interpret(NewlineNode.java:105)
@@ -39,7 +39,7 @@ module Airbrake
           :?
           (?<line>\d+)?  # Matches '105'
         \)
-      \z}x
+      \z}x.freeze
 
       # @return [Regexp] the pattern that tries to assume what a generic stack
       #   frame might look like, when exception's backtrace is set manually.
@@ -53,7 +53,7 @@ module Airbrake
         |
           :in\s(?<function>.+)   # Matches ":in func"
         )?                       # ... or nothing
-      \z}x
+      \z}x.freeze
 
       # @return [Regexp] the pattern that matches exceptions from PL/SQL such as
       #   ORA-06512: at "STORE.LI_LICENSES_PACK", line 1945
@@ -67,7 +67,7 @@ module Airbrake
         |
           #{GENERIC}
         )
-      \z/x
+      \z/x.freeze
 
       # @return [Regexp] the pattern that matches CoffeeScript backtraces
       #   usually coming from Rails & ExecJS
@@ -82,7 +82,7 @@ module Airbrake
           # Matches the Ruby part of the backtrace
           #{RUBY}
         )
-      \z/x
+      \z/x.freeze
     end
 
     # @return [Integer] how many first frames should include code hunks

--- a/lib/airbrake-ruby/filters/git_last_checkout_filter.rb
+++ b/lib/airbrake-ruby/filters/git_last_checkout_filter.rb
@@ -45,7 +45,6 @@ module Airbrake
 
       private
 
-      # rubocop:disable Metrics/AbcSize
       def last_checkout
         return unless (line = last_checkout_line)
 
@@ -65,7 +64,6 @@ module Airbrake
           time: timestamp(parts[-2].to_i),
         }
       end
-      # rubocop:enable Metrics/AbcSize
 
       def last_checkout_line
         head_path = File.join(@git_path, 'logs', 'HEAD')

--- a/lib/airbrake-ruby/filters/sql_filter.rb
+++ b/lib/airbrake-ruby/filters/sql_filter.rb
@@ -23,7 +23,7 @@ module Airbrake
 
       # @return [Hash{Symbol=>Regexp}] matchers for certain features of SQL
       ALL_FEATURES = {
-        # rubocop:disable Metrics/LineLength
+        # rubocop:disable Layout/LineLength
         single_quotes: /'(?:[^']|'')*?(?:\\'.*|'(?!'))/,
         double_quotes: /"(?:[^"]|"")*?(?:\\".*|"(?!"))/,
         dollar_quotes: /(\$(?!\d)[^$]*?\$).*?(?:\1|$)/,
@@ -33,13 +33,13 @@ module Airbrake
         hexadecimal_literals: /0x[0-9a-fA-F]+/,
         comments: /(?:#|--).*?(?=\r|\n|$)/i,
         multi_line_comments: %r{/\*(?:[^/]|/[^*])*?(?:\*/|/\*.*)},
-        oracle_quoted_strings: /q'\[.*?(?:\]'|$)|q'\{.*?(?:\}'|$)|q'\<.*?(?:\>'|$)|q'\(.*?(?:\)'|$)/
-        # rubocop:enable Metrics/LineLength
+        oracle_quoted_strings: /q'\[.*?(?:\]'|$)|q'\{.*?(?:\}'|$)|q'\<.*?(?:\>'|$)|q'\(.*?(?:\)'|$)/,
+        # rubocop:enable Layout/LineLength
       }.freeze
 
       # @return [Regexp] the regexp that is applied after the feature regexps
       #   were used
-      POST_FILTER = /(?<=[values|in ]\().+(?=\))/i
+      POST_FILTER = /(?<=[values|in ]\().+(?=\))/i.freeze
 
       # @return [Hash{Symbol=>Array<Symbol>}] a set of features that corresponds
       #   to a certain dialect

--- a/lib/airbrake-ruby/notice.rb
+++ b/lib/airbrake-ruby/notice.rb
@@ -76,7 +76,7 @@ module Airbrake
     #
     # @return [Hash{String=>String}, nil]
     # @api private
-    def to_json
+    def to_json(*_args)
       loop do
         begin
           json = @payload.to_json

--- a/lib/airbrake-ruby/notice_notifier.rb
+++ b/lib/airbrake-ruby/notice_notifier.rb
@@ -9,7 +9,7 @@ module Airbrake
     # @return [Array<Class>] filters to be executed first
     DEFAULT_FILTERS = [
       Airbrake::Filters::SystemExitFilter,
-      Airbrake::Filters::GemRootFilter
+      Airbrake::Filters::GemRootFilter,
 
       # Optional filters (must be included by users):
       # Airbrake::Filters::ThreadFilter

--- a/lib/airbrake-ruby/truncator.rb
+++ b/lib/airbrake-ruby/truncator.rb
@@ -104,7 +104,9 @@ module Airbrake
     # @see https://github.com/flori/json/commit/3e158410e81f94dbbc3da6b7b35f4f64983aa4e3
     def replace_invalid_characters(str)
       encoding = str.encoding
+      # rubocop:disable Style/MultipleComparison
       utf8_string = (encoding == Encoding::UTF_8 || encoding == Encoding::ASCII)
+      # rubocop:enable Style/MultipleComparison
       return str if utf8_string && str.valid_encoding?
 
       temp_str = str.dup

--- a/spec/backtrace_spec.rb
+++ b/spec/backtrace_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Airbrake::Backtrace do
   describe ".parse" do
     context "UNIX backtrace" do
       let(:parsed_backtrace) do
-        # rubocop:disable Metrics/LineLength, Style/HashSyntax, Layout/SpaceAroundOperators, Layout/SpaceInsideHashLiteralBraces
+        # rubocop:disable Layout/LineLength, Style/HashSyntax, Layout/SpaceAroundOperators, Layout/SpaceInsideHashLiteralBraces
         [{:file=>"/home/kyrylo/code/airbrake/ruby/spec/spec_helper.rb", :line=>23, :function=>"<top (required)>"},
          {:file=>"/opt/rubies/ruby-2.2.2/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb", :line=>54, :function=>"require"},
          {:file=>"/opt/rubies/ruby-2.2.2/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb", :line=>54, :function=>"require"},
@@ -16,7 +16,7 @@ RSpec.describe Airbrake::Backtrace do
          {:file=>"/home/kyrylo/.gem/ruby/2.2.2/gems/rspec-core-3.3.2/lib/rspec/core/runner.rb", :line=>73, :function=>"run"},
          {:file=>"/home/kyrylo/.gem/ruby/2.2.2/gems/rspec-core-3.3.2/lib/rspec/core/runner.rb", :line=>41, :function=>"invoke"},
          {:file=>"/home/kyrylo/.gem/ruby/2.2.2/gems/rspec-core-3.3.2/exe/rspec", :line=>4, :function=>"<main>"}]
-        # rubocop:enable Metrics/LineLength, Style/HashSyntax, Layout/SpaceAroundOperators, Layout/SpaceInsideHashLiteralBraces
+        # rubocop:enable Layout/LineLength, Style/HashSyntax, Layout/SpaceAroundOperators, Layout/SpaceInsideHashLiteralBraces
       end
 
       it "returns a properly formatted array of hashes" do
@@ -34,10 +34,10 @@ RSpec.describe Airbrake::Backtrace do
       let(:ex) { AirbrakeTestError.new.tap { |e| e.set_backtrace(windows_bt) } }
 
       let(:parsed_backtrace) do
-        # rubocop:disable Metrics/LineLength, Style/HashSyntax, Layout/SpaceInsideHashLiteralBraces, Layout/SpaceAroundOperators
+        # rubocop:disable Layout/LineLength, Style/HashSyntax, Layout/SpaceInsideHashLiteralBraces, Layout/SpaceAroundOperators
         [{:file=>"C:/Program Files/Server/app/models/user.rb", :line=>13, :function=>"magic"},
          {:file=>"C:/Program Files/Server/app/controllers/users_controller.rb", :line=>8, :function=>"index"}]
-        # rubocop:enable Metrics/LineLength, Style/HashSyntax, Layout/SpaceInsideHashLiteralBraces, Layout/SpaceAroundOperators
+        # rubocop:enable Layout/LineLength, Style/HashSyntax, Layout/SpaceInsideHashLiteralBraces, Layout/SpaceAroundOperators
       end
 
       it "returns a properly formatted array of hashes" do
@@ -47,7 +47,7 @@ RSpec.describe Airbrake::Backtrace do
 
     context "JRuby Java exceptions" do
       let(:backtrace_array) do
-        # rubocop:disable Metrics/LineLength, Style/HashSyntax, Layout/SpaceInsideHashLiteralBraces, Layout/SpaceAroundOperators
+        # rubocop:disable Layout/LineLength, Style/HashSyntax, Layout/SpaceInsideHashLiteralBraces, Layout/SpaceAroundOperators
         [{:file=>"InstanceMethodInvoker.java", :line=>26, :function=>"org.jruby.java.invokers.InstanceMethodInvoker.call"},
          {:file=>"Interpreter.java", :line=>126, :function=>"org.jruby.ir.interpreter.Interpreter.INTERPRET_EVAL"},
          {:file=>"RubyKernel$INVOKER$s$0$3$eval19.gen", :line=>nil, :function=>"org.jruby.RubyKernel$INVOKER$s$0$3$eval19.call"},
@@ -59,7 +59,7 @@ RSpec.describe Airbrake::Backtrace do
          {:file=>"Compiler.java", :line=>111, :function=>"org.jruby.ir.Compiler$1.load"},
          {:file=>"Main.java", :line=>225, :function=>"org.jruby.Main.run"},
          {:file=>"Main.java", :line=>197, :function=>"org.jruby.Main.main"}]
-        # rubocop:enable Metrics/LineLength, Style/HashSyntax, Layout/SpaceInsideHashLiteralBraces, Layout/SpaceAroundOperators
+        # rubocop:enable Layout/LineLength, Style/HashSyntax, Layout/SpaceInsideHashLiteralBraces, Layout/SpaceAroundOperators
       end
 
       it "returns a properly formatted array of hashes" do
@@ -72,21 +72,21 @@ RSpec.describe Airbrake::Backtrace do
 
     context "JRuby classloader exceptions" do
       let(:backtrace) do
-        # rubocop:disable Metrics/LineLength
+        # rubocop:disable Layout/LineLength
         ['uri_3a_classloader_3a_.META_minus_INF.jruby_dot_home.lib.ruby.stdlib.net.protocol.rbuf_fill(uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/net/protocol.rb:158)',
          'bin.processors.image_uploader.block in make_streams(bin/processors/image_uploader.rb:21)',
          'uri_3a_classloader_3a_.gems.faye_minus_websocket_minus_0_dot_10_dot_5.lib.faye.websocket.api.invokeOther13:dispatch_event(uri_3a_classloader_3a_/gems/faye_minus_websocket_minus_0_dot_10_dot_5/lib/faye/websocket/uri:classloader:/gems/faye-websocket-0.10.5/lib/faye/websocket/api.rb:109)',
          'tmp.jruby9022301782566983632extract.$dot.META_minus_INF.rails.file(/tmp/jruby9022301782566983632extract/./META-INF/rails.rb:13)']
-        # rubocop:enable Metrics/LineLength
+        # rubocop:enable Layout/LineLength
       end
 
       let(:parsed_backtrace) do
-        # rubocop:disable Metrics/LineLength
+        # rubocop:disable Layout/LineLength
         [{ file: 'uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/net/protocol.rb', line: 158, function: 'uri_3a_classloader_3a_.META_minus_INF.jruby_dot_home.lib.ruby.stdlib.net.protocol.rbuf_fill' },
          { file: 'bin/processors/image_uploader.rb', line: 21, function: 'bin.processors.image_uploader.block in make_streams' },
          { file: 'uri_3a_classloader_3a_/gems/faye_minus_websocket_minus_0_dot_10_dot_5/lib/faye/websocket/uri:classloader:/gems/faye-websocket-0.10.5/lib/faye/websocket/api.rb', line: 109, function: 'uri_3a_classloader_3a_.gems.faye_minus_websocket_minus_0_dot_10_dot_5.lib.faye.websocket.api.invokeOther13:dispatch_event' },
          { file: '/tmp/jruby9022301782566983632extract/./META-INF/rails.rb', line: 13, function: 'tmp.jruby9022301782566983632extract.$dot.META_minus_INF.rails.file' }]
-        # rubocop:enable Metrics/LineLength
+        # rubocop:enable Layout/LineLength
       end
 
       let(:ex) { JavaAirbrakeTestError.new.tap { |e| e.set_backtrace(backtrace) } }
@@ -99,19 +99,19 @@ RSpec.describe Airbrake::Backtrace do
 
     context "JRuby non-throwable exceptions" do
       let(:backtrace) do
-        # rubocop:disable Metrics/LineLength
+        # rubocop:disable Layout/LineLength
         ['org.postgresql.core.v3.ConnectionFactoryImpl.openConnectionImpl(org/postgresql/core/v3/ConnectionFactoryImpl.java:257)',
          'org.postgresql.core.ConnectionFactory.openConnection(org/postgresql/core/ConnectionFactory.java:65)',
          'org.postgresql.jdbc2.AbstractJdbc2Connection.<init>(org/postgresql/jdbc2/AbstractJdbc2Connection.java:149)']
-        # rubocop:enable Metrics/LineLength
+        # rubocop:enable Layout/LineLength
       end
 
       let(:parsed_backtrace) do
-        # rubocop:disable Metrics/LineLength
+        # rubocop:disable Layout/LineLength
         [{ file: 'org/postgresql/core/v3/ConnectionFactoryImpl.java', line: 257, function: 'org.postgresql.core.v3.ConnectionFactoryImpl.openConnectionImpl' },
          { file: 'org/postgresql/core/ConnectionFactory.java', line: 65, function: 'org.postgresql.core.ConnectionFactory.openConnection' },
          { file: 'org/postgresql/jdbc2/AbstractJdbc2Connection.java', line: 149, function: 'org.postgresql.jdbc2.AbstractJdbc2Connection.<init>' }]
-        # rubocop:enable Metrics/LineLength
+        # rubocop:enable Layout/LineLength
       end
 
       let(:ex) { AirbrakeTestError.new.tap { |e| e.set_backtrace(backtrace) } }
@@ -123,22 +123,22 @@ RSpec.describe Airbrake::Backtrace do
 
     context "generic backtrace" do
       context "when function is absent" do
-        # rubocop:disable Metrics/LineLength
+        # rubocop:disable Layout/LineLength
         let(:generic_bt) do
           ["/home/bingo/bango/assets/stylesheets/error_pages.scss:139:in `animation'",
            "/home/bingo/bango/assets/stylesheets/error_pages.scss:139",
            "/home/bingo/.gem/ruby/2.2.2/gems/sass-3.4.20/lib/sass/tree/visitors/perform.rb:349:in `block in visit_mixin'"]
         end
-        # rubocop:enable Metrics/LineLength
+        # rubocop:enable Layout/LineLength
 
         let(:ex) { AirbrakeTestError.new.tap { |e| e.set_backtrace(generic_bt) } }
 
         let(:parsed_backtrace) do
-          # rubocop:disable Metrics/LineLength, Style/HashSyntax, Layout/SpaceInsideHashLiteralBraces, Layout/SpaceAroundOperators
+          # rubocop:disable Layout/LineLength, Style/HashSyntax, Layout/SpaceInsideHashLiteralBraces, Layout/SpaceAroundOperators
           [{:file=>"/home/bingo/bango/assets/stylesheets/error_pages.scss", :line=>139, :function=>"animation"},
            {:file=>"/home/bingo/bango/assets/stylesheets/error_pages.scss", :line=>139, :function=>nil},
            {:file=>"/home/bingo/.gem/ruby/2.2.2/gems/sass-3.4.20/lib/sass/tree/visitors/perform.rb", :line=>349, :function=>"block in visit_mixin"}]
-          # rubocop:enable Metrics/LineLength, Style/HashSyntax, Layout/SpaceInsideHashLiteralBraces, Layout/SpaceAroundOperators
+          # rubocop:enable Layout/LineLength, Style/HashSyntax, Layout/SpaceInsideHashLiteralBraces, Layout/SpaceAroundOperators
         end
 
         it "returns a properly formatted array of hashes" do
@@ -277,9 +277,9 @@ RSpec.describe Airbrake::Backtrace do
                 93 => '        begin',
                 94 => '          json = @payload.to_json',
                 95 => '        rescue *JSON_EXCEPTIONS => ex',
-                # rubocop:disable Metrics/LineLength,Lint/InterpolationCheck
+                # rubocop:disable Layout/LineLength,Lint/InterpolationCheck
                 96 => '          @config.logger.debug("#{LOG_LABEL} `notice.to_json` failed: #{ex.class}: #{ex}")',
-                # rubocop:enable Metrics/LineLength,Lint/InterpolationCheck
+                # rubocop:enable Layout/LineLength,Lint/InterpolationCheck
               },
             },
             {
@@ -325,9 +325,9 @@ RSpec.describe Airbrake::Backtrace do
                 93 => '        begin',
                 94 => '          json = @payload.to_json',
                 95 => '        rescue *JSON_EXCEPTIONS => ex',
-                # rubocop:disable Metrics/LineLength,Lint/InterpolationCheck
+                # rubocop:disable Layout/LineLength,Lint/InterpolationCheck
                 96 => '          @config.logger.debug("#{LOG_LABEL} `notice.to_json` failed: #{ex.class}: #{ex}")',
-                # rubocop:enable Metrics/LineLength,Lint/InterpolationCheck
+                # rubocop:enable Layout/LineLength,Lint/InterpolationCheck
               },
             },
           ]
@@ -357,9 +357,9 @@ RSpec.describe Airbrake::Backtrace do
                 93 => '        begin',
                 94 => '          json = @payload.to_json',
                 95 => '        rescue *JSON_EXCEPTIONS => ex',
-                # rubocop:disable Metrics/LineLength,Lint/InterpolationCheck
+                # rubocop:disable Layout/LineLength,Lint/InterpolationCheck
                 96 => '          @config.logger.debug("#{LOG_LABEL} `notice.to_json` failed: #{ex.class}: #{ex}")',
-                # rubocop:enable Metrics/LineLength,Lint/InterpolationCheck
+                # rubocop:enable Layout/LineLength,Lint/InterpolationCheck
               },
             },
             {
@@ -370,9 +370,9 @@ RSpec.describe Airbrake::Backtrace do
                 93 => '        begin',
                 94 => '          json = @payload.to_json',
                 95 => '        rescue *JSON_EXCEPTIONS => ex',
-                # rubocop:disable Metrics/LineLength,Lint/InterpolationCheck
+                # rubocop:disable Layout/LineLength,Lint/InterpolationCheck
                 96 => '          @config.logger.debug("#{LOG_LABEL} `notice.to_json` failed: #{ex.class}: #{ex}")',
-                # rubocop:enable Metrics/LineLength,Lint/InterpolationCheck
+                # rubocop:enable Layout/LineLength,Lint/InterpolationCheck
                 97 => '        else',
               },
             },

--- a/spec/code_hunk_spec.rb
+++ b/spec/code_hunk_spec.rb
@@ -34,9 +34,9 @@ RSpec.describe Airbrake::CodeHunk do
           eq(
             1 => 'module Airbrake',
             2 => '  ##',
-            # rubocop:disable Metrics/LineLength
+            # rubocop:disable Layout/LineLength
             3 => '  # Represents a chunk of information that is meant to be either sent to',
-            # rubocop:enable Metrics/LineLength
+            # rubocop:enable Layout/LineLength
           ),
         )
       end

--- a/spec/filters/gem_root_filter_spec.rb
+++ b/spec/filters/gem_root_filter_spec.rb
@@ -7,18 +7,18 @@ RSpec.describe Airbrake::Filters::GemRootFilter do
   after { 2.times { Gem.path.pop } }
 
   it "replaces gem root in the backtrace with a label" do
-    # rubocop:disable Metrics/LineLength
+    # rubocop:disable Layout/LineLength
     notice[:errors].first[:backtrace] = [
       { file: "/home/kyrylo/code/airbrake/ruby/spec/spec_helper.rb" },
       { file: "#{root1}/gems/rspec-core-3.3.2/lib/rspec/core/configuration.rb" },
       { file: "/opt/rubies/ruby-2.2.2/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb" },
       { file: "#{root2}/gems/rspec-core-3.3.2/exe/rspec" },
     ]
-    # rubocop:enable Metrics/LineLength
+    # rubocop:enable Layout/LineLength
 
     subject.call(notice)
 
-    # rubocop:disable Metrics/LineLength
+    # rubocop:disable Layout/LineLength
     expect(notice[:errors].first[:backtrace]).to(
       eq(
         [
@@ -29,7 +29,7 @@ RSpec.describe Airbrake::Filters::GemRootFilter do
         ],
       ),
     )
-    # rubocop:enable Metrics/LineLength
+    # rubocop:enable Layout/LineLength
   end
 
   it "does not filter file when it is nil" do

--- a/spec/filters/root_directory_filter_spec.rb
+++ b/spec/filters/root_directory_filter_spec.rb
@@ -5,18 +5,18 @@ RSpec.describe Airbrake::Filters::RootDirectoryFilter do
   let(:notice) { Airbrake::Notice.new(AirbrakeTestError.new) }
 
   it "replaces root directory in the backtrace with a label" do
-    # rubocop:disable Metrics/LineLength
+    # rubocop:disable Layout/LineLength
     notice[:errors].first[:backtrace] = [
       { file: "/home/kyrylo/code/airbrake/ruby/spec/spec_helper.rb" },
       { file: "#{root_directory}/gems/rspec-core-3.3.2/lib/rspec/core/configuration.rb " },
       { file: "/opt/rubies/ruby-2.2.2/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb" },
       { file: "#{root_directory}/gems/rspec-core-3.3.2/exe/rspec" },
     ]
-    # rubocop:enable Metrics/LineLength
+    # rubocop:enable Layout/LineLength
 
     subject.call(notice)
 
-    # rubocop:disable Metrics/LineLength
+    # rubocop:disable Layout/LineLength
     expect(notice[:errors].first[:backtrace]).to(
       eq(
         [
@@ -27,7 +27,7 @@ RSpec.describe Airbrake::Filters::RootDirectoryFilter do
         ],
       ),
     )
-    # rubocop:enable Metrics/LineLength
+    # rubocop:enable Layout/LineLength
   end
 
   it "does not filter file when it is nil" do

--- a/spec/filters/sql_filter_spec.rb
+++ b/spec/filters/sql_filter_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Airbrake::Filters::SqlFilter do
 
   ALL_DIALECTS = %i[mysql postgres sqlite cassandra oracle].freeze
 
-  # rubocop:disable Metrics/LineLength
+  # rubocop:disable Layout/LineLength
   [
     {
       input: 'SELECT * FROM things;',
@@ -229,7 +229,7 @@ RSpec.describe Airbrake::Filters::SqlFilter do
   ].each do |test|
     include_examples 'query filtering', test
   end
-  # rubocop:enable Metrics/LineLength
+  # rubocop:enable Layout/LineLength
 
   [
     'COMMIT',

--- a/spec/notice_notifier/options_spec.rb
+++ b/spec/notice_notifier/options_spec.rb
@@ -149,10 +149,10 @@ RSpec.describe Airbrake::NoticeNotifier do
         expect(proxied_request.header['proxy-authorization'].first)
           .to eq('Basic dXNlcjpwYXNzd29yZA==')
 
-        # rubocop:disable Metrics/LineLength
+        # rubocop:disable Layout/LineLength
         expect(proxied_request.request_line)
           .to eq("POST http://localhost:#{proxy.config[:Port]}/api/v3/projects/105138/notices HTTP/1.1\r\n")
-        # rubocop:enable Metrics/LineLength
+        # rubocop:enable Layout/LineLength
       end
     end
 

--- a/spec/notice_notifier_spec.rb
+++ b/spec/notice_notifier_spec.rb
@@ -309,7 +309,7 @@ RSpec.describe Airbrake::NoticeNotifier do
 
         notice = subject.build_notice(Exception.new)
 
-        # rubocop:disable Metrics/LineLength
+        # rubocop:disable Layout/LineLength
         expect(notice[:errors].first[:backtrace]).to eq(
           [
             { file: 'org/jruby/RubyKernel.java', line: 998, function: 'eval' },
@@ -317,7 +317,7 @@ RSpec.describe Airbrake::NoticeNotifier do
             { file: '/ruby/stdlib/irb.rb:489', line: 489, function: 'block in eval_input' },
           ],
         )
-        # rubocop:enable Metrics/LineLength
+        # rubocop:enable Layout/LineLength
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,7 +33,7 @@ class AirbrakeTestError < RuntimeError
 
   def initialize(*)
     super
-    # rubocop:disable Metrics/LineLength
+    # rubocop:disable Layout/LineLength
     @backtrace = [
       "/home/kyrylo/code/airbrake/ruby/spec/spec_helper.rb:23:in `<top (required)>'",
       "/opt/rubies/ruby-2.2.2/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'",
@@ -49,7 +49,7 @@ class AirbrakeTestError < RuntimeError
       "/home/kyrylo/.gem/ruby/2.2.2/gems/rspec-core-3.3.2/lib/rspec/core/runner.rb:41:in `invoke'",
       "/home/kyrylo/.gem/ruby/2.2.2/gems/rspec-core-3.3.2/exe/rspec:4:in `<main>'",
     ]
-    # rubocop:enable Metrics/LineLength
+    # rubocop:enable Layout/LineLength
   end
 
   # rubocop:disable Naming/AccessorMethodName
@@ -66,7 +66,7 @@ end
 class JavaAirbrakeTestError < AirbrakeTestError
   def initialize(*)
     super
-    # rubocop:disable Metrics/LineLength
+    # rubocop:disable Layout/LineLength
     @backtrace = [
       "org.jruby.java.invokers.InstanceMethodInvoker.call(InstanceMethodInvoker.java:26)",
       "org.jruby.ir.interpreter.Interpreter.INTERPRET_EVAL(Interpreter.java:126)",
@@ -80,7 +80,7 @@ class JavaAirbrakeTestError < AirbrakeTestError
       "org.jruby.Main.run(Main.java:225)",
       "org.jruby.Main.main(Main.java:197)",
     ]
-    # rubocop:enable Metrics/LineLength
+    # rubocop:enable Layout/LineLength
   end
 
   def is_a?(*)


### PR DESCRIPTION
I am not going to merge this because Rubocop dropped Ruby 2.1 & Ruby 2.2 support a long time ago and we have plans doing so. Instead, I will cherry-pick some commits from this PR (mostly lint-related ones) and make a new PR, so that we can merge them with `master` and get the best of both worlds.