### PR TITLE
Resolve future Rubocop offences

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ AllCops:
   Exclude:
     - 'pkg/**/*'
     - 'vendor/**/*'
+    - 'spec/fixtures/**/*'
 
 Metrics/MethodLength:
   Max: 25

--- a/lib/airbrake-ruby.rb
+++ b/lib/airbrake-ruby.rb
@@ -1,7 +1,6 @@
 require 'net/https'
 require 'logger'
 require 'json'
-require 'thread'
 require 'set'
 require 'socket'
 require 'time'

--- a/lib/airbrake-ruby/notice.rb
+++ b/lib/airbrake-ruby/notice.rb
@@ -76,7 +76,7 @@ module Airbrake
     #
     # @return [Hash{String=>String}, nil]
     # @api private
-    def to_json
+    def to_json(*_args)
       loop do
         begin
           json = @payload.to_json

--- a/lib/airbrake-ruby/notice_notifier.rb
+++ b/lib/airbrake-ruby/notice_notifier.rb
@@ -9,7 +9,7 @@ module Airbrake
     # @return [Array<Class>] filters to be executed first
     DEFAULT_FILTERS = [
       Airbrake::Filters::SystemExitFilter,
-      Airbrake::Filters::GemRootFilter
+      Airbrake::Filters::GemRootFilter,
 
       # Optional filters (must be included by users):
       # Airbrake::Filters::ThreadFilter


### PR DESCRIPTION
I bumped Rubocop in https://github.com/airbrake/airbrake-ruby/pull/556 and saw a bunch of new offences. However, https://github.com/airbrake/airbrake-ruby/pull/556 will not be merged due to old Ruby support.

So what I am doing is cherry-picking a few useful changes from https://github.com/airbrake/airbrake-ruby/pull/556 and merging them with `master`.