### PR TITLE
filters/keys: add referer, httpMethod, userAddr & userAgent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ Airbrake Ruby Changelog
 
 ### master
 
+* Added the ability to filter via `blacklist_keys` the following keys:
+  `context/referer`, `context/httpMethod`, `context/userAddr`,
+  `context/userAgent`
+  ([#562](https://github.com/airbrake/airbrake-ruby/pull/562))
+
 ### [v4.13.2][v4.13.2] (February 21, 2020)
 
 * `AsyncSender`: fixed ``undefined method `first' for nil:NilClass

--- a/lib/airbrake-ruby/filters/keys_filter.rb
+++ b/lib/airbrake-ruby/filters/keys_filter.rb
@@ -24,7 +24,18 @@ module Airbrake
 
       # @return [Array<Symbol>] parts of a Notice's *context* payload that can
       #   be modified by blacklist/whitelist filters
-      FILTERABLE_CONTEXT_KEYS = %i[user headers].freeze
+      FILTERABLE_CONTEXT_KEYS = %i[
+        user
+
+        # Provided by Airbrake::Rack::HttpHeadersFilter
+        headers
+        referer
+        httpMethod
+
+        # Provided by Airbrake::Rack::ContextFilter
+        userAddr
+        userAgent
+      ].freeze
 
       include Loggable
 


### PR DESCRIPTION
In the Airbrake gem we have filters that add the following keys to the context
payload:

* referer
* httpMethod
* userAddr
* userAgent

This information is not critical for our services to work and sometimes users
need to filter that due to various reasons. Specifically, someone requested to
be able to filter `userAddr` due to GDPR reasons.