### PR TITLE
airbrake-ruby: do not reappend same filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Airbrake Ruby Changelog
   `context/referer`, `context/httpMethod`, `context/userAddr`,
   `context/userAgent`
   ([#562](https://github.com/airbrake/airbrake-ruby/pull/562))
+* Fixed addition of duplicate filters on multiple `Airbrake.configure` calls
+  ([#563](https://github.com/airbrake/airbrake-ruby/pull/563))
 
 ### [v4.13.2][v4.13.2] (February 21, 2020)
 

--- a/lib/airbrake-ruby.rb
+++ b/lib/airbrake-ruby.rb
@@ -581,6 +581,7 @@ module Airbrake
         notice_notifier.add_filter(whitelist)
       end
 
+      return if configured?
       return unless config.root_directory
 
       [

--- a/spec/airbrake_spec.rb
+++ b/spec/airbrake_spec.rb
@@ -75,6 +75,16 @@ RSpec.describe Airbrake do
         described_class.configure {}
         expect(described_class.deploy_notifier).to eql(deploy_notifier)
       end
+
+      it "doesn't append the same notice notifier filters over and over" do
+        described_class.configure do |c|
+          c.project_id = 1
+          c.project_key = '2'
+        end
+
+        expect(described_class.notice_notifier).not_to receive(:add_filter)
+        10.times { described_class.configure {} }
+      end
     end
 
     context "when blacklist_keys gets configured" do


### PR DESCRIPTION
Fixes #561 (Multiple `Airbrake.configure` calls append the same filters to the
filter chain)

This solution makes sure we don't reappend the same "static" filters over and
over when we call `Airbrake.configure`. Static here means that the filters
implement exactly the same algorithm, so they are duplicative and thus not
necessary.

There are non-static filters. For example, if users configure blacklist keys
twice, the same filter will be added. The filter chain will have two instances
of `KeysBlacklistFilter`. However this is okay because both of them will filter
different keys (therefore the algorithm is different).