### PR TITLE
filters/git_last_checkout: add support for AIRBRAKE_DEPLOY_USERNAME

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Airbrake Ruby Changelog
 
 ### master
 
+* Added support for `AIRBRAKE_DEPLOY_USERNAME`, which overrides deployer
+  username in the automatic deploy tracking feature
+  ([#566](https://github.com/airbrake/airbrake-ruby/pull/566))
+
 ### [v4.13.3][v4.13.3] (March 2, 2020)
 
 * Added the ability to filter via `blacklist_keys` the following keys:

--- a/lib/airbrake-ruby/filters/git_last_checkout_filter.rb
+++ b/lib/airbrake-ruby/filters/git_last_checkout_filter.rb
@@ -27,6 +27,7 @@ module Airbrake
         @git_path = File.join(root_directory, '.git')
         @weight = 116
         @last_checkout = nil
+        @deploy_username = ENV['AIRBRAKE_DEPLOY_USERNAME']
       end
 
       # @macro call_filter
@@ -59,7 +60,7 @@ module Airbrake
 
         author = parts[2..-4]
         @last_checkout = {
-          username: author[0..1].join(' '),
+          username: @deploy_username || author[0..1].join(' '),
           email: parts[-3][1..-2],
           revision: parts[1],
           time: timestamp(parts[-2].to_i),

--- a/spec/filters/git_last_checkout_filter_spec.rb
+++ b/spec/filters/git_last_checkout_filter_spec.rb
@@ -21,24 +21,41 @@ RSpec.describe Airbrake::Filters::GitLastCheckoutFilter do
   end
 
   context "when .git directory exists" do
-    before { subject.call(notice) }
+    context "when AIRBRAKE_DEPLOY_USERNAME env variable is set" do
+      before { ENV['AIRBRAKE_DEPLOY_USERNAME'] = 'deployer' }
 
-    it "attaches last checkouted username" do
-      expect(notice[:context][:lastCheckout][:username]).not_to be_empty
+      it "attaches username from the environment" do
+        subject.call(notice)
+        expect(notice[:context][:lastCheckout][:username]).to eq('deployer')
+      end
+    end
+
+    context "when AIRBRAKE_DEPLOY_USERNAME env variable is NOT set" do
+      before { ENV['AIRBRAKE_DEPLOY_USERNAME'] = nil }
+
+      it "attaches last checkouted username" do
+        subject.call(notice)
+        username = notice[:context][:lastCheckout][:username]
+        expect(username).not_to be_empty
+        expect(username).not_to be_nil
+      end
     end
 
     it "attaches last checkouted email" do
+      subject.call(notice)
       expect(notice[:context][:lastCheckout][:email]).to(
         match(/\A\w+[\w.-]*@\w+\.?\w+?\z/),
       )
     end
 
     it "attaches last checkouted revision" do
+      subject.call(notice)
       expect(notice[:context][:lastCheckout][:revision]).not_to be_empty
       expect(notice[:context][:lastCheckout][:revision].size).to eq(40)
     end
 
     it "attaches last checkouted time" do
+      subject.call(notice)
       expect(notice[:context][:lastCheckout][:time]).not_to be_empty
       expect(notice[:context][:lastCheckout][:time].size).to eq(25)
     end


### PR DESCRIPTION
In certain environments, when a deploy starts, end deploy user might not be the
one who started the deploy. For example, if you deploy via Ansible, the script
could create a fake user who would pull the web app repo and deploy it for
you. Even though you started the script, the filter will pick up the fake user
name, since `.git` was created by that user.

To work around that, we introduce the `AIRBRAKE_DEPLOY_USERNAME` env
variable. With help of it we can forward the username from Ansible to Ruby.