### PR TITLE
Fix some default filters not being appended

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@ Airbrake Ruby Changelog
 
 ### master
 
+* Fixed a bug where some default filters are not appended
+  ([#573](https://github.com/airbrake/airbrake-ruby/pull/573)):
+    - `Airbrake::Filters::RootDirectoryFilter`
+    - `Airbrake::Filters::GitRevisionFilter`
+    - `Airbrake::Filters::GitRepositoryFilter`
+    - `Airbrake::Filters::GitLastCheckoutFilter`
+* Added `Airbrake::NoticeNotifier#has_filter?`, which checks whether the filter
+  chain of the notifier includes an instance of the given class
+  ([#573](https://github.com/airbrake/airbrake-ruby/pull/573))
+
 ### [v4.13.4][v4.13.4] (April 9, 2020)
 
 * Added support for `AIRBRAKE_DEPLOY_USERNAME`, which overrides deployer

--- a/lib/airbrake-ruby.rb
+++ b/lib/airbrake-ruby.rb
@@ -570,6 +570,7 @@ module Airbrake
 
     private
 
+    # rubocop:disable Metrics/AbcSize
     def process_config_options(config)
       if config.blacklist_keys.any?
         blacklist = Airbrake::Filters::KeysBlacklist.new(config.blacklist_keys)
@@ -581,7 +582,6 @@ module Airbrake
         notice_notifier.add_filter(whitelist)
       end
 
-      return if configured?
       return unless config.root_directory
 
       [
@@ -590,9 +590,12 @@ module Airbrake
         Airbrake::Filters::GitRepositoryFilter,
         Airbrake::Filters::GitLastCheckoutFilter,
       ].each do |filter|
+        next if notice_notifier.has_filter?(filter)
+
         notice_notifier.add_filter(filter.new(config.root_directory))
       end
     end
+    # rubocop:enable Metrics/AbcSize
   end
 end
 # rubocop:enable Metrics/ModuleLength

--- a/lib/airbrake-ruby/filter_chain.rb
+++ b/lib/airbrake-ruby/filter_chain.rb
@@ -76,7 +76,7 @@ module Airbrake
 
     # @return [String] customized inspect to lessen the amount of clutter
     def inspect
-      @filters.map(&:class).to_s
+      filter_classes.to_s
     end
 
     # @return [String] {#inspect} for PrettyPrint
@@ -90,6 +90,20 @@ module Airbrake
         q.seplist(@filters) { |f| q.pp(f.class) }
       end
       q.text(']')
+    end
+
+    # @param [Class] filter_class
+    # @return [Boolean] true if the current chain has an instance of the given
+    #   class, false otherwise
+    # @since v4.14.0
+    def includes?(filter_class)
+      filter_classes.include?(filter_class)
+    end
+
+    private
+
+    def filter_classes
+      @filters.map(&:class)
     end
   end
 end

--- a/lib/airbrake-ruby/notice_notifier.rb
+++ b/lib/airbrake-ruby/notice_notifier.rb
@@ -82,6 +82,12 @@ module Airbrake
       @context.merge!(context)
     end
 
+    # @return [Boolean]
+    # @since v4.14.0
+    def has_filter?(filter_class) # rubocop:disable Naming/PredicateName
+      @filter_chain.includes?(filter_class)
+    end
+
     private
 
     def convert_to_exception(ex)

--- a/spec/airbrake_spec.rb
+++ b/spec/airbrake_spec.rb
@@ -85,6 +85,18 @@ RSpec.describe Airbrake do
         expect(described_class.notice_notifier).not_to receive(:add_filter)
         10.times { described_class.configure {} }
       end
+
+      it "appends some default filters" do
+        allow(described_class.notice_notifier).to receive(:add_filter)
+        expect(described_class.notice_notifier).to receive(:add_filter).with(
+          an_instance_of(Airbrake::Filters::RootDirectoryFilter),
+        )
+
+        described_class.configure do |c|
+          c.project_id = 1
+          c.project_key = '2'
+        end
+      end
     end
 
     context "when blacklist_keys gets configured" do

--- a/spec/filter_chain_spec.rb
+++ b/spec/filter_chain_spec.rb
@@ -89,4 +89,31 @@ RSpec.describe Airbrake::FilterChain do
       expect(subject.inspect).to eq('[Proc]')
     end
   end
+
+  describe "#includes?" do
+    context "when a custom filter class is included in the filter chain" do
+      it "returns true" do
+        klass = Class.new {}
+
+        subject.add_filter(klass.new)
+        expect(subject.includes?(klass)).to eq(true)
+      end
+    end
+
+    context "when Proc filter class is included in the filter chain" do
+      it "returns true" do
+        subject.add_filter(proc {})
+        expect(subject.includes?(Proc)).to eq(true)
+      end
+    end
+
+    context "when filter class is NOT included in the filter chain" do
+      it "returns false" do
+        klass = Class.new {}
+
+        subject.add_filter(proc {})
+        expect(subject.includes?(klass)).to eq(false)
+      end
+    end
+  end
 end


### PR DESCRIPTION
In e4db77de1ea6203dbcec6c68234d6ce7ffd7139a, in attempt to fix appending same
filters over and over I actually introduced a bug. Some filters wouldn't be
appended at all.

In order to solve that, I have to add special API that allows me to append
filters conditionally. Now the code that calls `add_filter` can decide whether
it wants to append a filter or skip. We achieve it with
`NoticeNotifier#has_filter?`.