### PR TITLE
Bump webmock to `~> 3.8`

### DIFF
--- a/airbrake-ruby.gemspec
+++ b/airbrake-ruby.gemspec
@@ -36,7 +36,7 @@ DESC
   s.add_development_dependency 'rspec-its', '~> 1.2'
   s.add_development_dependency 'rake', '>= 10', '< 14'
   s.add_development_dependency 'pry', '~> 0'
-  s.add_development_dependency 'webmock', '~> 2.3'
+  s.add_development_dependency 'webmock', '~> 3.8'
   s.add_development_dependency 'benchmark-ips', '~> 2'
   s.add_development_dependency 'yard', '~> 0.9'
 

--- a/spec/performance_notifier_spec.rb
+++ b/spec/performance_notifier_spec.rb
@@ -389,7 +389,7 @@ RSpec.describe Airbrake::PerformanceNotifier do
       subject.close
 
       expect(promise).to be_an(Airbrake::Promise)
-      expect(promise.value).to eq('' => nil)
+      expect(promise.value).to eq('' => '')
     end
 
     it "checks performance stat configuration" do
@@ -601,7 +601,7 @@ RSpec.describe Airbrake::PerformanceNotifier do
           body: %r|\A{"queries":\[{"method":"POST","route":"/foo"|,
         ),
       ).to have_been_made
-      expect(retval).to eq('' => nil)
+      expect(retval).to eq('' => '')
     end
   end
 


### PR DESCRIPTION
This update fixes the following warning, which can be seen when we run the test
suite:

```
webmock-2.3.2/lib/webmock/util/json.rb:27:
warning: assigned but unused variable - pos
```