### PR TITLE
thread_pool: create a new thread group per process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Airbrake Ruby Changelog
 
 ### master
 
+* Fixed `ThreadError: can't move to the enclosed thread group` when using
+  `notify` inside a `fork`
+  ([#577](https://github.com/airbrake/airbrake-ruby/pull/577))
+
 ### [v4.14.0][v4.14.0] (April 10, 2020)
 
 * Fixed a bug where some default filters are not appended

--- a/lib/airbrake-ruby/thread_pool.rb
+++ b/lib/airbrake-ruby/thread_pool.rb
@@ -83,6 +83,7 @@ module Airbrake
 
         if @pid != Process.pid && @workers.list.empty?
           @pid = Process.pid
+          @workers = ThreadGroup.new
           spawn_workers
         end
 


### PR DESCRIPTION
Fixes #576 (ThreadError: can't move to the enclosed thread group)

When we `Airbrake.notify` inside a `fork` block, `ThreadPool` tries to respawn
workers (which were killed by the `fork`) to the same `ThreadGroup`, which was
created in the parent thread. The problem is that that `ThreadGroup` is already
finalised in that parent thread and no new threads can be added anymore.  The
fix is to create a new `ThreadGroup` on `fork`. This way every process will have
its own `ThreadGroup`.