### PR TITLE
Rename "blacklist" to "blocklist" and "whitelist" to "allowlist"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ Airbrake Ruby Changelog
 
 ### master
 
+* Deprecated `blacklist_keys` in favor of `blocklist_keys`
+  ([#580](https://github.com/airbrake/airbrake-ruby/pull/580))
+* Deprecated `whitelist_keys` in favor of `allowlist_keys`
+  ([#580](https://github.com/airbrake/airbrake-ruby/pull/580))
+
 ### [v4.14.1][v4.14.1] (April 22, 2020)
 
 * Fixed `ThreadError: can't move to the enclosed thread group` when using

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ Airbrake.configure do |c|
 end
 ```
 
-#### blacklist_keys
+#### blocklist_keys
 
 Specifies which keys in the payload (parameters, session data, environment data,
 etc) should be filtered. Before sending an error, filtered keys will be
@@ -262,7 +262,7 @@ filtered.
 
 ```ruby
 Airbrake.configure do |c|
-  c.blacklist_keys = [:email, /credit/i, 'password']
+  c.blocklist_keys = [:email, /credit/i, 'password']
 end
 
 Airbrake.notify('App crashed!', {
@@ -301,14 +301,14 @@ gets executed on first notify, only once):
 ```ruby
 Airbrake.configure do |c|
   # You can mix inline keys and Procs.
-  c.blacklist_keys = [:email, proc { Keyloader.load_keys }, 'password']
+  c.blocklist_keys = [:email, proc { Keyloader.load_keys }, 'password']
 end
 ```
 
 The Proc *must* return an Array consisting only of the elements, which are
 considered to be valid for this option.
 
-#### whitelist_keys
+#### allowlist_keys
 
 Specifies which keys in the payload (parameters, session data, environment data,
 etc) should _not_ be filtered. All other keys will be substituted with the
@@ -319,7 +319,7 @@ shouldn't be filtered.
 
 ```ruby
 Airbrake.configure do |c|
-  c.whitelist_keys = [:email, /user/i, 'account_id']
+  c.allowlist_keys = [:email, /user/i, 'account_id']
 end
 
 Airbrake.notify(StandardError.new('App crashed!'), {
@@ -340,7 +340,7 @@ Airbrake.notify(StandardError.new('App crashed!'), {
 ##### Using Procs to delay filters configuration
 
 See documentation about
-[blacklisting using Proc objects](#using-procs-to-delay-filters-configuration).
+[blocklisting using Proc objects](#using-procs-to-delay-filters-configuration).
 It's identical.
 
 #### code_hunks
@@ -627,7 +627,7 @@ Airbrake.add_filter(MyFilter.new)
 ```
 
 The library provides two default filters that you can use to filter notices:
-[KeysBlacklist][keysblacklist] & [KeysWhitelist][keyswhitelist].
+[KeysBlocklist][keysblocklist] & [KeysAllowlist][keysallowlist].
 
 #### Airbrake.build_notice
 
@@ -1199,8 +1199,8 @@ The project uses the MIT License. See LICENSE.md for details.
 [project-idkey]: https://s3.amazonaws.com/airbrake-github-assets/airbrake-ruby/project-id-key.png
 [issues]: https://github.com/airbrake/airbrake-ruby/issues
 [twitter]: https://twitter.com/airbrake
-[keysblacklist]: https://github.com/airbrake/airbrake-ruby/blob/master/lib/airbrake-ruby/filters/keys_blacklist.rb
-[keyswhitelist]: https://github.com/airbrake/airbrake-ruby/blob/master/lib/airbrake-ruby/filters/keys_whitelist.rb
+[keysblocklist]: https://github.com/airbrake/airbrake-ruby/blob/master/lib/airbrake-ruby/filters/keys_blocklist.rb
+[keysallowlist]: https://github.com/airbrake/airbrake-ruby/blob/master/lib/airbrake-ruby/filters/keys_allowlist.rb
 [golang]: https://golang.org/
 [yard-api]: http://www.rubydoc.info/gems/airbrake-ruby
 [arthur-ruby]: https://s3.amazonaws.com/airbrake-github-assets/airbrake-ruby/arthur-ruby.jpg

--- a/lib/airbrake-ruby.rb
+++ b/lib/airbrake-ruby.rb
@@ -24,8 +24,8 @@ require 'airbrake-ruby/notice'
 require 'airbrake-ruby/backtrace'
 require 'airbrake-ruby/truncator'
 require 'airbrake-ruby/filters/keys_filter'
-require 'airbrake-ruby/filters/keys_whitelist'
-require 'airbrake-ruby/filters/keys_blacklist'
+require 'airbrake-ruby/filters/keys_allowlist'
+require 'airbrake-ruby/filters/keys_blocklist'
 require 'airbrake-ruby/filters/gem_root_filter'
 require 'airbrake-ruby/filters/system_exit_filter'
 require 'airbrake-ruby/filters/root_directory_filter'
@@ -572,14 +572,14 @@ module Airbrake
 
     # rubocop:disable Metrics/AbcSize
     def process_config_options(config)
-      if config.blacklist_keys.any?
-        blacklist = Airbrake::Filters::KeysBlacklist.new(config.blacklist_keys)
-        notice_notifier.add_filter(blacklist)
+      if config.blocklist_keys.any?
+        blocklist = Airbrake::Filters::KeysBlocklist.new(config.blocklist_keys)
+        notice_notifier.add_filter(blocklist)
       end
 
-      if config.whitelist_keys.any?
-        whitelist = Airbrake::Filters::KeysWhitelist.new(config.whitelist_keys)
-        notice_notifier.add_filter(whitelist)
+      if config.allowlist_keys.any?
+        allowlist = Airbrake::Filters::KeysAllowlist.new(config.allowlist_keys)
+        notice_notifier.add_filter(allowlist)
       end
 
       return unless config.root_directory

--- a/lib/airbrake-ruby/config.rb
+++ b/lib/airbrake-ruby/config.rb
@@ -68,14 +68,20 @@ module Airbrake
     # @return [Array<String, Symbol, Regexp>] the keys, which should be
     #   filtered
     # @api public
-    # @since v1.2.0
-    attr_accessor :blacklist_keys
+    # @since v4.15.0
+    attr_accessor :allowlist_keys
 
-    # @return [Array<String, Symbol, Regexp>] the keys, which shouldn't be
+    # @deprecated Use allowlist_keys instead
+    alias whitelist_keys allowlist_keys
+
+    # @return [Array<String, Symbol, Regexp>] the keys, which should be
     #   filtered
     # @api public
-    # @since v1.2.0
-    attr_accessor :whitelist_keys
+    # @since v4.15.0
+    attr_accessor :blocklist_keys
+
+    # @deprecated Use blocklist_keys instead
+    alias blacklist_keys blocklist_keys
 
     # @return [Boolean] true if the library should attach code hunks to each
     #   frame in a backtrace, false otherwise
@@ -134,8 +140,8 @@ module Airbrake
 
       self.timeout = user_config[:timeout]
 
-      self.blacklist_keys = []
-      self.whitelist_keys = []
+      self.blocklist_keys = []
+      self.allowlist_keys = []
 
       self.root_directory = File.realpath(
         (defined?(Bundler) && Bundler.root) ||
@@ -151,6 +157,24 @@ module Airbrake
       merge(user_config)
     end
     # rubocop:enable Metrics/AbcSize
+
+    def blacklist_keys=(keys)
+      loc = caller_locations(1..1).first
+      Kernel.warn(
+        "#{loc.path}:#{loc.lineno}: warning: blacklist_keys= is deprecated " \
+        "use blocklist_keys= instead",
+      )
+      self.blocklist_keys = keys
+    end
+
+    def whitelist_keys=(keys)
+      loc = caller_locations(1..1).first
+      Kernel.warn(
+        "#{loc.path}:#{loc.lineno}: warning: whitelist_keys= is deprecated " \
+        "use allowlist_keys= instead",
+      )
+      self.allowlist_keys = keys
+    end
 
     # The full URL to the Airbrake Notice API. Based on the +:host+ option.
     # @return [URI] the endpoint address

--- a/lib/airbrake-ruby/filters/keys_allowlist.rb
+++ b/lib/airbrake-ruby/filters/keys_allowlist.rb
@@ -4,7 +4,7 @@ module Airbrake
     # notice, but specified keys.
     #
     # @example
-    #   filter = Airbrake::Filters::KeysBlacklist.new(
+    #   filter = Airbrake::Filters::KeysAllowlist.new(
     #     [:email, /credit/i, 'password']
     #   )
     #   airbrake.add_filter(filter)
@@ -22,9 +22,9 @@ module Airbrake
     #   #     email: 'john@example.com',
     #   #     account_id: 42 }
     #
-    # @see KeysBlacklist
+    # @see KeysBlocklist
     # @see KeysFilter
-    class KeysWhitelist
+    class KeysAllowlist
       include KeysFilter
 
       def initialize(*)

--- a/lib/airbrake-ruby/filters/keys_blocklist.rb
+++ b/lib/airbrake-ruby/filters/keys_blocklist.rb
@@ -4,7 +4,7 @@ module Airbrake
     # list of parameters in the payload of a notice.
     #
     # @example
-    #   filter = Airbrake::Filters::KeysBlacklist.new(
+    #   filter = Airbrake::Filters::KeysBlocklist.new(
     #     [:email, /credit/i, 'password']
     #   )
     #   airbrake.add_filter(filter)
@@ -22,10 +22,10 @@ module Airbrake
     #   #     email: '[Filtered]',
     #   #     credit_card: '[Filtered]' }
     #
-    # @see KeysWhitelist
+    # @see KeysAllowlist
     # @see KeysFilter
     # @api private
-    class KeysBlacklist
+    class KeysBlocklist
       include KeysFilter
 
       def initialize(*)

--- a/lib/airbrake-ruby/filters/keys_filter.rb
+++ b/lib/airbrake-ruby/filters/keys_filter.rb
@@ -7,8 +7,8 @@ module Airbrake
     # class that includes this module must implement.
     #
     # @see Notice
-    # @see KeysWhitelist
-    # @see KeysBlacklist
+    # @see KeysAllowlist
+    # @see KeysBlocklist
     # @api private
     module KeysFilter
       # @return [String] The label to replace real values of filtered payload
@@ -19,11 +19,11 @@ module Airbrake
       VALID_PATTERN_CLASSES = [String, Symbol, Regexp].freeze
 
       # @return [Array<Symbol>] parts of a Notice's payload that can be modified
-      #   by blacklist/whitelist filters
+      #   by blocklist/allowlist filters
       FILTERABLE_KEYS = %i[environment session params].freeze
 
       # @return [Array<Symbol>] parts of a Notice's *context* payload that can
-      #   be modified by blacklist/whitelist filters
+      #   be modified by blocklist/allowlist filters
       FILTERABLE_CONTEXT_KEYS = %i[
         user
 
@@ -42,7 +42,7 @@ module Airbrake
       # @return [Integer]
       attr_reader :weight
 
-      # Creates a new KeysBlacklist or KeysWhitelist filter that uses the given
+      # Creates a new KeysBlocklist or KeysAllowlist filter that uses the given
       # +patterns+ for filtering a notice's payload.
       #
       # @param [Array<String,Regexp,Symbol>] patterns

--- a/spec/airbrake_spec.rb
+++ b/spec/airbrake_spec.rb
@@ -99,33 +99,33 @@ RSpec.describe Airbrake do
       end
     end
 
-    context "when blacklist_keys gets configured" do
+    context "when blocklist_keys gets configured" do
       before { allow(Airbrake.notice_notifier).to receive(:add_filter) }
 
-      it "adds blacklist filter" do
+      it "adds blocklist filter" do
         expect(Airbrake.notice_notifier).to receive(:add_filter)
-          .with(an_instance_of(Airbrake::Filters::KeysBlacklist))
-        described_class.configure { |c| c.blacklist_keys = %w[password] }
+          .with(an_instance_of(Airbrake::Filters::KeysBlocklist))
+        described_class.configure { |c| c.blocklist_keys = %w[password] }
       end
 
-      it "initializes blacklist with specified parameters" do
-        expect(Airbrake::Filters::KeysBlacklist).to receive(:new).with(%w[password])
-        described_class.configure { |c| c.blacklist_keys = %w[password] }
+      it "initializes blocklist with specified parameters" do
+        expect(Airbrake::Filters::KeysBlocklist).to receive(:new).with(%w[password])
+        described_class.configure { |c| c.blocklist_keys = %w[password] }
       end
     end
 
-    context "when whitelist_keys gets configured" do
+    context "when allowlist_keys gets configured" do
       before { allow(Airbrake.notice_notifier).to receive(:add_filter) }
 
-      it "adds whitelist filter" do
+      it "adds allowlist filter" do
         expect(Airbrake.notice_notifier).to receive(:add_filter)
-          .with(an_instance_of(Airbrake::Filters::KeysWhitelist))
-        described_class.configure { |c| c.whitelist_keys = %w[banana] }
+          .with(an_instance_of(Airbrake::Filters::KeysAllowlist))
+        described_class.configure { |c| c.allowlist_keys = %w[banana] }
       end
 
-      it "initializes whitelist with specified parameters" do
-        expect(Airbrake::Filters::KeysWhitelist).to receive(:new).with(%w[banana])
-        described_class.configure { |c| c.whitelist_keys = %w[banana] }
+      it "initializes allowlist with specified parameters" do
+        expect(Airbrake::Filters::KeysAllowlist).to receive(:new).with(%w[banana])
+        described_class.configure { |c| c.allowlist_keys = %w[banana] }
       end
     end
 

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe Airbrake::Config do
   its(:environment) { is_expected.to be_nil }
   its(:ignore_environments) { is_expected.to be_empty }
   its(:timeout) { is_expected.to be_nil }
-  its(:blacklist_keys) { is_expected.to be_empty }
-  its(:whitelist_keys) { is_expected.to be_empty }
+  its(:blocklist_keys) { is_expected.to be_empty }
+  its(:allowlist_keys) { is_expected.to be_empty }
   its(:performance_stats) { is_expected.to eq(true) }
   its(:performance_stats_flush_period) { is_expected.to eq(15) }
   its(:query_stats) { is_expected.to eq(true) }
@@ -167,6 +167,34 @@ RSpec.describe Airbrake::Config do
   describe "#logger" do
     it "sets logger level to Logger::WARN" do
       expect(subject.logger.level).to eq(Logger::WARN)
+    end
+  end
+
+  describe "#blacklist_keys=" do
+    before { allow(Kernel).to receive(:warn) }
+
+    it "sets blocklist_keys instead" do
+      subject.blacklist_keys = [1, 2, 3]
+      expect(subject.blocklist_keys).to eq([1, 2, 3])
+    end
+
+    it "prints a warning" do
+      expect(Kernel).to receive(:warn).with(/use blocklist_keys= instead/)
+      subject.blacklist_keys = [1, 2, 3]
+    end
+  end
+
+  describe "#whitelist_keys=" do
+    before { allow(Kernel).to receive(:warn) }
+
+    it "sets allowlist_keys instead" do
+      subject.whitelist_keys = [1, 2, 3]
+      expect(subject.allowlist_keys).to eq([1, 2, 3])
+    end
+
+    it "prints a warning" do
+      expect(Kernel).to receive(:warn).with(/use allowlist_keys= instead/)
+      subject.whitelist_keys = [1, 2, 3]
     end
   end
 end

--- a/spec/filters/keys_allowlist_spec.rb
+++ b/spec/filters/keys_allowlist_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Airbrake::Filters::KeysWhitelist do
+RSpec.describe Airbrake::Filters::KeysAllowlist do
   subject { described_class.new(patterns) }
 
   let(:notice) { Airbrake::Notice.new(AirbrakeTestError.new) }
@@ -70,10 +70,10 @@ RSpec.describe Airbrake::Filters::KeysWhitelist do
 
       it "logs an error" do
         expect(Airbrake::Loggable.instance).to receive(:error).with(
-          /KeysWhitelist is invalid.+patterns: \[#<Object:.+>\]/,
+          /KeysAllowlist is invalid.+patterns: \[#<Object:.+>\]/,
         )
-        keys_whitelist = described_class.new(patterns)
-        keys_whitelist.call(notice)
+        keys_allowlist = described_class.new(patterns)
+        keys_allowlist.call(notice)
       end
     end
 
@@ -83,10 +83,10 @@ RSpec.describe Airbrake::Filters::KeysWhitelist do
       context "and when the filter is called once" do
         it "logs an error" do
           expect(Airbrake::Loggable.instance).to receive(:error).with(
-            /KeysWhitelist is invalid.+patterns: \[#<Proc:.+>\]/,
+            /KeysAllowlist is invalid.+patterns: \[#<Proc:.+>\]/,
           )
-          keys_whitelist = described_class.new(patterns)
-          keys_whitelist.call(notice)
+          keys_allowlist = described_class.new(patterns)
+          keys_allowlist.call(notice)
         end
 
         include_examples(
@@ -113,10 +113,10 @@ RSpec.describe Airbrake::Filters::KeysWhitelist do
 
     it "logs an error" do
       expect(Airbrake::Loggable.instance).to receive(:error).with(
-        /KeysWhitelist is invalid.+patterns: \[#<Object:.+>\]/,
+        /KeysAllowlist is invalid.+patterns: \[#<Object:.+>\]/,
       )
-      keys_whitelist = described_class.new(patterns)
-      keys_whitelist.call(notice)
+      keys_allowlist = described_class.new(patterns)
+      keys_allowlist.call(notice)
     end
   end
 

--- a/spec/filters/keys_blocklist_spec.rb
+++ b/spec/filters/keys_blocklist_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Airbrake::Filters::KeysBlacklist do
+RSpec.describe Airbrake::Filters::KeysBlocklist do
   subject { described_class.new(patterns) }
 
   let(:notice) { Airbrake::Notice.new(AirbrakeTestError.new) }
@@ -91,10 +91,10 @@ RSpec.describe Airbrake::Filters::KeysBlacklist do
 
       it "logs an error" do
         expect(Airbrake::Loggable.instance).to receive(:error).with(
-          /KeysBlacklist is invalid.+patterns: \[#<Object:.+>\]/,
+          /KeysBlocklist is invalid.+patterns: \[#<Object:.+>\]/,
         )
-        keys_blacklist = described_class.new(patterns)
-        keys_blacklist.call(notice)
+        keys_blocklist = described_class.new(patterns)
+        keys_blocklist.call(notice)
       end
     end
 
@@ -104,10 +104,10 @@ RSpec.describe Airbrake::Filters::KeysBlacklist do
       context "and when the filter is called once" do
         it "logs an error" do
           expect(Airbrake::Loggable.instance).to receive(:error).with(
-            /KeysBlacklist is invalid.+patterns: \[#<Proc:.+>\]/,
+            /KeysBlocklist is invalid.+patterns: \[#<Proc:.+>\]/,
           )
-          keys_blacklist = described_class.new(patterns)
-          keys_blacklist.call(notice)
+          keys_blocklist = described_class.new(patterns)
+          keys_blocklist.call(notice)
         end
       end
 
@@ -133,10 +133,10 @@ RSpec.describe Airbrake::Filters::KeysBlacklist do
 
     it "logs an error" do
       expect(Airbrake::Loggable.instance).to receive(:error).with(
-        /KeysBlacklist is invalid.+patterns: \[#<Object:.+>\]/,
+        /KeysBlocklist is invalid.+patterns: \[#<Object:.+>\]/,
       )
-      keys_blacklist = described_class.new(patterns)
-      keys_blacklist.call(notice)
+      keys_blocklist = described_class.new(patterns)
+      keys_blocklist.call(notice)
     end
   end
 

--- a/spec/filters/sql_filter_spec.rb
+++ b/spec/filters/sql_filter_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Airbrake::Filters::SqlFilter do
     end
   end
 
-  shared_examples "query blacklisting" do |query, opts|
+  shared_examples "query blocklisting" do |query, opts|
     it "ignores '#{query}'" do
       filter = described_class.new('postgres')
       q = Airbrake::Query.new(query: query, method: 'GET', route: '/', timing: 1)
@@ -263,12 +263,12 @@ RSpec.describe Airbrake::Filters::SqlFilter do
 
     'SELECT t.oid, t.typname FROM pg_type as t WHERE t.typname IN (?)',
   ].each do |query|
-    include_examples 'query blacklisting', query, should_ignore: true
+    include_examples 'query blocklisting', query, should_ignore: true
   end
 
   [
     'UPDATE "users" SET "last_sign_in_at" = ? WHERE "users"."id" = ?',
   ].each do |query|
-    include_examples 'query blacklisting', query, should_ignore: false
+    include_examples 'query blocklisting', query, should_ignore: false
   end
 end

--- a/spec/notice_notifier/options_spec.rb
+++ b/spec/notice_notifier/options_spec.rb
@@ -234,14 +234,14 @@ RSpec.describe Airbrake::NoticeNotifier do
       end
     end
 
-    describe ":blacklist_keys" do
+    describe ":blocklist_keys" do
       # Fixes https://github.com/airbrake/airbrake-ruby/issues/276
-      context "when specified along with :whitelist_keys" do
+      context "when specified along with :allowlist_keys" do
         context "and when context payload is present" do
           before do
             Airbrake::Config.instance.merge(
-              blacklist_keys: %i[password password_confirmation],
-              whitelist_keys: [:email, /user/i, 'account_id'],
+              blocklist_keys: %i[password password_confirmation],
+              allowlist_keys: [:email, /user/i, 'account_id'],
             )
           end
 


### PR DESCRIPTION
Replaces #579.

Background:

* The technology industry has began moving away from terms such as master/slave
  and white list /blacklist.

* A recent tweet about this
  https://twitter.com/leahculver/status/1269109776983547904