### PR TITLE
config: add the 'error_notifications' option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Airbrake Ruby Changelog
 
 ### master
 
+* Added the `error_notifications` option (enabled by default). This option
+  disables `Airbrake.notify` calls (makes them no-op)
+  ([#583](https://github.com/airbrake/airbrake-ruby/pull/583))
+
 ### [v4.15.0][v4.15.0] (June 17, 2020)
 
 * Deprecated `blacklist_keys` in favor of `blocklist_keys`

--- a/README.md
+++ b/README.md
@@ -407,6 +407,19 @@ Airbrake.configure do |c|
 end
 ```
 
+#### error_notifications
+
+Configures Airbrake error reporting. By default, it's enabled (recommended).
+
+When it's disabled, [`Airbrake.notify`](#airbrakenotify) &
+[`Airbrake.notify_sync`](#airbrakenotify_sync) are no-op.
+
+```ruby
+Airbrake.configure do |c|
+  c.error_notifications = true
+end
+```
+
 ### Asynchronous Airbrake options
 
 The options listed below apply to [`Airbrake.notify`](#airbrakenotify), they do

--- a/lib/airbrake-ruby/config.rb
+++ b/lib/airbrake-ruby/config.rb
@@ -4,6 +4,7 @@ module Airbrake
   #
   # @api public
   # @since v1.0.0
+  # rubocop:disable Metrics/ClassLength
   class Config
     # @return [Integer] the project identificator. This value *must* be set.
     # @api public
@@ -113,6 +114,12 @@ module Airbrake
     # @since v4.12.0
     attr_accessor :job_stats
 
+    # @return [Boolean] true if the library should send error reports to
+    #   Airbrake, false otherwise
+    # @api public
+    # @since ?.?.?
+    attr_accessor :error_notifications
+
     class << self
       # @return [Config]
       attr_writer :instance
@@ -153,6 +160,7 @@ module Airbrake
       self.performance_stats_flush_period = 15
       self.query_stats = true
       self.job_stats = true
+      self.error_notifications = true
 
       merge(user_config)
     end
@@ -261,4 +269,5 @@ module Airbrake
       raise Airbrake::Error, "unknown option '#{option}'"
     end
   end
+  # rubocop:enable Metrics/ClassLength
 end

--- a/lib/airbrake-ruby/config/validator.rb
+++ b/lib/airbrake-ruby/config/validator.rb
@@ -44,6 +44,10 @@ module Airbrake
         def check_notify_ability(config)
           promise = Airbrake::Promise.new
 
+          unless config.error_notifications
+            return promise.reject('error notifications are disabled')
+          end
+
           if ignored_environment?(config)
             return promise.reject(
               "current environment '#{config.environment}' is ignored",

--- a/spec/config/validator_spec.rb
+++ b/spec/config/validator_spec.rb
@@ -169,7 +169,7 @@ RSpec.describe Airbrake::Config::Validator do
         }
       end
 
-      it "returns a rejected promise" do
+      it "returns a resolved promise" do
         promise = described_class.check_notify_ability(config)
         expect(promise).to be_resolved
       end
@@ -178,6 +178,23 @@ RSpec.describe Airbrake::Config::Validator do
         expect(config.logger).to receive(:warn)
           .with(/'ignore_environments' has no effect/)
         described_class.check_notify_ability(config)
+      end
+    end
+
+    context "when the error_notifications option is false" do
+      let(:config_params) do
+        {
+          project_id: valid_id,
+          project_key: valid_key,
+          error_notifications: false,
+        }
+      end
+
+      it "returns a rejected promise" do
+        promise = described_class.check_notify_ability(config)
+        expect(promise.value).to eq(
+          'error' => "error notifications are disabled",
+        )
       end
     end
   end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe Airbrake::Config do
   its(:performance_stats_flush_period) { is_expected.to eq(15) }
   its(:query_stats) { is_expected.to eq(true) }
   its(:job_stats) { is_expected.to eq(true) }
+  its(:error_notifications) { is_expected.to eq(true) }
 
   describe "#new" do
     context "when user config is passed" do


### PR DESCRIPTION
Configures Airbrake error reporting. By default, it's enabled (recommended).