### PR TITLE
Implement support for the remote config

### DIFF
--- a/lib/airbrake-ruby/config.rb
+++ b/lib/airbrake-ruby/config.rb
@@ -120,6 +120,12 @@ module Airbrake
     # @since ?.?.?
     attr_accessor :error_notifications
 
+    # @note Not for public use!
+    # @return [Boolean]
+    # @api private
+    # @since ?.?.?
+    attr_accessor :__remote_configuration
+
     class << self
       # @return [Config]
       attr_writer :instance
@@ -161,6 +167,7 @@ module Airbrake
       self.query_stats = true
       self.job_stats = true
       self.error_notifications = true
+      self.__remote_configuration = false
 
       merge(user_config)
     end

--- a/lib/airbrake-ruby/remote_settings.rb
+++ b/lib/airbrake-ruby/remote_settings.rb
@@ -1,0 +1,86 @@
+module Airbrake
+  # RemoteSettings polls the remote config of the passed project at fixed
+  # intervals. The fetched config is yielded as a callback parameter so that the
+  # invoker can define read config values.
+  #
+  # @example Disable/enable error notifications based on the remote value
+  #   RemoteSettings.new do |data|
+  #     config.error_notifications = data.error_notifications?
+  #   end
+  #
+  # @since ?.?.?
+  # @api private
+  class RemoteSettings
+    include Airbrake::Loggable
+
+    # Polls remote config of the given project.
+    #
+    # @param [Integer] project_id
+    # @yield [data]
+    # @yieldparam data [Airbrake::RemoteSettings::SettingsData]
+    # @return [Airbrake::RemoteSettings]
+    def self.poll(project_id, &block)
+      new(project_id, &block).poll
+    end
+
+    # @param [Integer] project_id
+    # @yield [data]
+    # @yieldparam data [Airbrake::RemoteSettings::SettingsData]
+    def initialize(project_id, &block)
+      @data = SettingsData.new(project_id, {})
+      @block = block
+      @poll = nil
+    end
+
+    # Polls remote config of the given project in background.
+    #
+    # @return [self]
+    def poll
+      @poll ||= Thread.new do
+        loop do
+          @block.call(@data.merge!(fetch_config))
+
+          sleep(@data.interval)
+        end
+      end
+
+      self
+    end
+
+    # Stops the background poller thread.
+    #
+    # @return [void]
+    def stop_polling
+      @poll.kill if @poll
+    end
+
+    private
+
+    def fetch_config
+      response = nil
+      begin
+        response = Net::HTTP.get(URI(@data.config_route))
+      rescue StandardError => ex
+        logger.error(ex)
+        return {}
+      end
+
+      # AWS S3 API returns XML when request is not valid. In this case we just
+      # print the returned body and exit the method.
+      if response.start_with?('<?xml ')
+        logger.error(response)
+        return {}
+      end
+
+      json = nil
+      begin
+        json = JSON.parse(response)
+      rescue JSON::ParserError => ex
+        logger.error(ex)
+        return {}
+      end
+
+      json
+    end
+  end
+end

--- a/lib/airbrake-ruby/remote_settings/settings_data.rb
+++ b/lib/airbrake-ruby/remote_settings/settings_data.rb
@@ -1,0 +1,100 @@
+module Airbrake
+  class RemoteSettings
+    # SettingsData is a container, which wraps JSON payload returned by the
+    # remote settings API. It exposes the payload via convenient methods and
+    # also ensures that in case some data from the payload is missing, a default
+    # value would be returned instead.
+    #
+    # @example
+    #   # Create the object and pass initial data (empty hash).
+    #   settings_data = SettingsData.new({})
+    #
+    #   settings_data.interval #=> 600
+    #
+    # @since ?.?.?
+    # @api private
+    class SettingsData
+      # @return [Integer] how frequently we should poll the config API
+      DEFAULT_INTERVAL = 600
+
+      # @return [String] API version of the S3 API to poll
+      API_VER = '2020-06-18'.freeze
+
+      # @return [String] what URL to poll
+      CONFIG_ROUTE_PATTERN =
+        'https://%<bucket>s.s3.amazonaws.com/' \
+        "#{API_VER}/config/%<project_id>s/config.json".freeze
+
+      # @return [Hash{Symbol=>String}] the hash of all supported settings where
+      #   the value is the name of the setting returned by the API
+      SETTINGS = {
+        errors: 'errors',
+        apm: 'apm',
+      }.freeze
+
+      # @param [Integer] project_id
+      # @param [Hash{String=>Object}] data
+      def initialize(project_id, data)
+        @project_id = project_id
+        @data = data
+      end
+
+      # Merges the given +hash+ with internal data.
+      #
+      # @param [Hash{String=>Object}] hash
+      # @return [self]
+      def merge!(hash)
+        @data.merge!(hash)
+
+        self
+      end
+
+      # @return [Integer] how frequently we should poll for the config
+      def interval
+        return DEFAULT_INTERVAL if !@data.key?('poll_sec') || !@data['poll_sec']
+
+        @data['poll_sec'] > 0 ? @data['poll_sec'] : DEFAULT_INTERVAL
+      end
+
+      # @return [String] where the config is stored on S3.
+      def config_route
+        if !@data.key?('config_route') || !@data['config_route']
+          return format(
+            CONFIG_ROUTE_PATTERN,
+            bucket: 'staging-notifier-configs',
+            project_id: @project_id,
+          )
+        end
+
+        @data['config_route']
+      end
+
+      # @return [Boolean] whether error notifications are enabled
+      def error_notifications?
+        return true unless (s = find_setting(SETTINGS[:errors]))
+
+        s['enabled']
+      end
+
+      # @return [Boolean] whether APM is enabled
+      def performance_stats?
+        return true unless (s = find_setting(SETTINGS[:apm]))
+
+        s['enabled']
+      end
+
+      # @return [Hash{String=>Object}] raw representation of JSON payload
+      def to_h
+        @data.dup
+      end
+
+      private
+
+      def find_setting(name)
+        return unless @data.key?('settings')
+
+        @data['settings'].find { |s| s['title'] == name }
+      end
+    end
+  end
+end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe Airbrake::Config do
   its(:query_stats) { is_expected.to eq(true) }
   its(:job_stats) { is_expected.to eq(true) }
   its(:error_notifications) { is_expected.to eq(true) }
+  its(:__remote_configuration) { is_expected.to eq(false) }
 
   describe "#new" do
     context "when user config is passed" do

--- a/spec/remote_settings_spec.rb
+++ b/spec/remote_settings_spec.rb
@@ -1,0 +1,132 @@
+RSpec.describe Airbrake::RemoteSettings do
+  let(:project_id) { 123 }
+
+  let(:endpoint) do
+    "https://staging-notifier-configs.s3.amazonaws.com/2020-06-18/config/" \
+    "#{project_id}/config.json"
+  end
+
+  let(:body) do
+    {
+      'poll_sec' => 1,
+      'settings' => [
+        {
+          'title' => 'apm',
+          'enabled' => false,
+        },
+        {
+          'title' => 'errors',
+          'enabled' => true,
+        },
+      ],
+    }
+  end
+
+  before do
+    stub_request(:get, endpoint).to_return(status: 200, body: body.to_json)
+  end
+
+  describe ".poll" do
+    context "when no errors are raised" do
+      it "makes a request to AWS S3" do
+        remote_settings = described_class.poll(project_id) {}
+        sleep(0.1)
+        remote_settings.stop_polling
+
+        expect(a_request(:get, endpoint)).to have_been_made.at_least_once
+      end
+
+      it "fetches remote settings" do
+        settings = nil
+        remote_settings = described_class.poll(project_id) do |data|
+          settings = data
+        end
+        sleep(0.1)
+        remote_settings.stop_polling
+
+        expect(settings.error_notifications?).to eq(true)
+        expect(settings.performance_stats?).to eq(false)
+        expect(settings.interval).to eq(1)
+      end
+    end
+
+    context "when an error is raised while making a HTTP request" do
+      before do
+        allow(Net::HTTP).to receive(:get).and_raise(StandardError)
+      end
+
+      it "doesn't fetch remote settings" do
+        settings = nil
+        remote_settings = described_class.poll(project_id) do |data|
+          settings = data
+        end
+        sleep(0.1)
+        remote_settings.stop_polling
+
+        expect(a_request(:get, endpoint)).not_to have_been_made
+        expect(settings.interval).to eq(600)
+      end
+    end
+
+    context "when an error is raised while parsing returned JSON" do
+      before do
+        allow(JSON).to receive(:parse).and_raise(JSON::ParserError)
+      end
+
+      it "doesn't update settings data" do
+        settings = nil
+        remote_settings = described_class.poll(project_id) do |data|
+          settings = data
+        end
+        sleep(0.1)
+        remote_settings.stop_polling
+
+        expect(a_request(:get, endpoint)).to have_been_made.once
+        expect(settings.interval).to eq(600)
+      end
+    end
+
+    context "when API returns an XML response" do
+      before do
+        stub_request(:get, endpoint).to_return(status: 200, body: '<?xml ...')
+      end
+
+      it "doesn't update settings data" do
+        settings = nil
+        remote_settings = described_class.poll(project_id) do |data|
+          settings = data
+        end
+        sleep(0.1)
+        remote_settings.stop_polling
+
+        expect(a_request(:get, endpoint)).to have_been_made.once
+        expect(settings.interval).to eq(600)
+      end
+    end
+
+    context "when a config route is specified in the returned data" do
+      let(:new_endpoint) { 'http://example.com' }
+
+      let(:body) do
+        { 'config_route' => new_endpoint, 'poll_sec' => 0.1 }
+      end
+
+      before do
+        stub_request(:get, new_endpoint).to_return(status: 200, body: body.to_json)
+      end
+
+      it "makes the next request to the specified config route" do
+        settings = nil
+        remote_settings = described_class.poll(project_id) do |data|
+          settings = data
+        end
+        sleep(0.2)
+
+        remote_settings.stop_polling
+
+        expect(a_request(:get, endpoint)).to have_been_made.once
+        expect(a_request(:get, new_endpoint)).to have_been_made.once
+      end
+    end
+  end
+end


### PR DESCRIPTION
A remote config is a WIP feature which will allow you to configure your notifier
from your project settings.