### PR TITLE
remote_settings/settings_data: add support for host configuration

### DIFF
--- a/lib/airbrake-ruby.rb
+++ b/lib/airbrake-ruby.rb
@@ -579,6 +579,7 @@ module Airbrake
     private
 
     # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
+    # rubocop:disable Metrics/MethodLength, Metrics/PerceivedComplexity
     def process_config_options(config)
       if config.blocklist_keys.any?
         blocklist = Airbrake::Filters::KeysBlocklist.new(config.blocklist_keys)
@@ -593,6 +594,9 @@ module Airbrake
       if config.project_id && config.__remote_configuration
         @remote_settings ||= RemoteSettings.poll(config.project_id) do |data|
           config.logger.debug("#{LOG_LABEL} applying remote settings: #{data.to_h}")
+
+          config.error_host = data.error_host if data.error_host
+          config.apm_host = data.apm_host if data.apm_host
 
           config.error_notifications = data.error_notifications?
           config.performance_stats = data.performance_stats?
@@ -613,6 +617,7 @@ module Airbrake
       end
     end
     # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity
+    # rubocop:enable Metrics/MethodLength, Metrics/PerceivedComplexity
   end
 end
 # rubocop:enable Metrics/ModuleLength

--- a/lib/airbrake-ruby/async_sender.rb
+++ b/lib/airbrake-ruby/async_sender.rb
@@ -16,7 +16,7 @@ module Airbrake
     #
     # @param [Hash] payload Whatever needs to be sent
     # @return [Airbrake::Promise]
-    def send(payload, promise, endpoint = @config.endpoint)
+    def send(payload, promise, endpoint = @config.error_endpoint)
       unless thread_pool << [payload, promise, endpoint]
         return promise.reject(
           "AsyncSender has reached its capacity of #{@config.queue_size}",

--- a/lib/airbrake-ruby/config.rb
+++ b/lib/airbrake-ruby/config.rb
@@ -47,6 +47,17 @@ module Airbrake
     # @api public
     attr_accessor :host
 
+    # @since v?.?.?
+    alias error_host host
+    # @since v?.?.?
+    alias error_host= host=
+
+    # @return [String] the host, which provides the API endpoint to which
+    #   APM data should be sent
+    # @api public
+    # @since v?.?.?
+    attr_accessor :apm_host
+
     # @return [String, Pathname] the working directory of your project
     # @api public
     attr_accessor :root_directory
@@ -147,7 +158,8 @@ module Airbrake
       self.logger = ::Logger.new(File::NULL).tap { |l| l.level = Logger::WARN }
       self.project_id = user_config[:project_id]
       self.project_key = user_config[:project_key]
-      self.host = 'https://api.airbrake.io'
+      self.error_host = 'https://api.airbrake.io'
+      self.apm_host = 'https://api.airbrake.io'
 
       self.ignore_environments = []
 
@@ -191,14 +203,14 @@ module Airbrake
       self.allowlist_keys = keys
     end
 
-    # The full URL to the Airbrake Notice API. Based on the +:host+ option.
+    # The full URL to the Airbrake Notice API. Based on the +:error_host+ option.
     # @return [URI] the endpoint address
     def error_endpoint
       @error_endpoint ||=
         begin
-          self.host = ('https://' << host) if host !~ %r{\Ahttps?://}
+          self.error_host = ('https://' << error_host) if error_host !~ %r{\Ahttps?://}
           api = "api/v3/projects/#{project_id}/notices"
-          URI.join(host, api)
+          URI.join(error_host, api)
         end
     end
 

--- a/lib/airbrake-ruby/config.rb
+++ b/lib/airbrake-ruby/config.rb
@@ -193,8 +193,8 @@ module Airbrake
 
     # The full URL to the Airbrake Notice API. Based on the +:host+ option.
     # @return [URI] the endpoint address
-    def endpoint
-      @endpoint ||=
+    def error_endpoint
+      @error_endpoint ||=
         begin
           self.host = ('https://' << host) if host !~ %r{\Ahttps?://}
           api = "api/v3/projects/#{project_id}/notices"

--- a/lib/airbrake-ruby/performance_notifier.rb
+++ b/lib/airbrake-ruby/performance_notifier.rb
@@ -144,7 +144,7 @@ module Airbrake
 
       with_grouped_payload(payload) do |resource_hash, destination|
         url = URI.join(
-          @config.host,
+          @config.apm_host,
           "api/v5/projects/#{@config.project_id}/#{destination}",
         )
 

--- a/lib/airbrake-ruby/remote_settings/settings_data.rb
+++ b/lib/airbrake-ruby/remote_settings/settings_data.rb
@@ -83,6 +83,22 @@ module Airbrake
         s['enabled']
       end
 
+      # @return [String, nil] the host, which provides the API endpoint to which
+      #   exceptions should be sent
+      def error_host
+        return unless (s = find_setting(SETTINGS[:errors]))
+
+        s['endpoint']
+      end
+
+      # @return [String, nil] the host, which provides the API endpoint to which
+      #   APM data should be sent
+      def apm_host
+        return unless (s = find_setting(SETTINGS[:apm]))
+
+        s['endpoint']
+      end
+
       # @return [Hash{String=>Object}] raw representation of JSON payload
       def to_h
         @data.dup

--- a/lib/airbrake-ruby/sync_sender.rb
+++ b/lib/airbrake-ruby/sync_sender.rb
@@ -23,7 +23,7 @@ module Airbrake
     # @param [#to_json] data
     # @param [URI::HTTPS] endpoint
     # @return [Hash{String=>String}] the parsed HTTP response
-    def send(data, promise, endpoint = @config.endpoint)
+    def send(data, promise, endpoint = @config.error_endpoint)
       return promise if rate_limited_ip?(promise)
 
       response = nil

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Airbrake::Config do
   its(:app_version) { is_expected.to be_nil }
   its(:versions) { is_expected.to be_empty }
   its(:host) { is_expected.to eq('https://api.airbrake.io') }
-  its(:endpoint) { is_expected.not_to be_nil }
+  its(:error_endpoint) { is_expected.not_to be_nil }
   its(:workers) { is_expected.to eq(1) }
   its(:queue_size) { is_expected.to eq(100) }
   its(:root_directory) { is_expected.to eq(Bundler.root.realpath.to_s) }
@@ -65,13 +65,13 @@ RSpec.describe Airbrake::Config do
     end
   end
 
-  describe "#endpoint" do
+  describe "#error_endpoint" do
     subject { described_class.new(valid_params.merge(user_config)) }
 
     context "when host ends with a URL with a slug with a trailing slash" do
       let(:user_config) { { host: 'https://localhost/bingo/' } }
 
-      its(:endpoint) do
+      its(:error_endpoint) do
         is_expected.to eq(URI('https://localhost/bingo/api/v3/projects/1/notices'))
       end
     end
@@ -79,7 +79,7 @@ RSpec.describe Airbrake::Config do
     context "when host ends with a URL with a slug without a trailing slash" do
       let(:user_config) { { host: 'https://localhost/bingo' } }
 
-      its(:endpoint) do
+      its(:error_endpoint) do
         is_expected.to eq(URI('https://localhost/api/v3/projects/1/notices'))
       end
     end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe Airbrake::Config do
   its(:app_version) { is_expected.to be_nil }
   its(:versions) { is_expected.to be_empty }
   its(:host) { is_expected.to eq('https://api.airbrake.io') }
+  its(:error_host) { is_expected.to eq('https://api.airbrake.io') }
+  its(:apm_host) { is_expected.to eq('https://api.airbrake.io') }
   its(:error_endpoint) { is_expected.not_to be_nil }
   its(:workers) { is_expected.to eq(1) }
   its(:queue_size) { is_expected.to eq(100) }

--- a/spec/remote_settings/settings_data_spec.rb
+++ b/spec/remote_settings/settings_data_spec.rb
@@ -188,6 +188,108 @@ RSpec.describe Airbrake::RemoteSettings::SettingsData do
     end
   end
 
+  describe "#error_host" do
+    context "when the 'errors' setting is present" do
+      context "and when 'endpoint' is specified" do
+        let(:endpoint) { 'https://api.example.com/' }
+
+        let(:data) do
+          {
+            'settings' => [
+              {
+                'name' => 'errors',
+                'enabled' => true,
+                'endpoint' => endpoint,
+              },
+            ],
+          }
+        end
+
+        it "returns the endpoint" do
+          expect(described_class.new(project_id, data).error_host).to eq(endpoint)
+        end
+      end
+
+      context "and when an endpoint is NOT specified" do
+        let(:data) do
+          {
+            'settings' => [
+              {
+                'name' => 'errors',
+                'enabled' => true,
+              },
+            ],
+          }
+        end
+
+        it "returns nil" do
+          expect(described_class.new(project_id, data).error_host).to be_nil
+        end
+      end
+    end
+
+    context "when the 'errors' setting is missing" do
+      let(:data) do
+        { 'settings' => [] }
+      end
+
+      it "returns nil" do
+        expect(described_class.new(project_id, data).error_host).to be_nil
+      end
+    end
+  end
+
+  describe "#apm_host" do
+    context "when the 'apm' setting is present" do
+      context "and when 'endpoint' is specified" do
+        let(:endpoint) { 'https://api.example.com/' }
+
+        let(:data) do
+          {
+            'settings' => [
+              {
+                'name' => 'apm',
+                'enabled' => true,
+                'endpoint' => endpoint,
+              },
+            ],
+          }
+        end
+
+        it "returns the endpoint" do
+          expect(described_class.new(project_id, data).apm_host).to eq(endpoint)
+        end
+      end
+
+      context "and when an endpoint is NOT specified" do
+        let(:data) do
+          {
+            'settings' => [
+              {
+                'name' => 'apm',
+                'enabled' => true,
+              },
+            ],
+          }
+        end
+
+        it "returns nil" do
+          expect(described_class.new(project_id, data).apm_host).to be_nil
+        end
+      end
+    end
+
+    context "when the 'apm' setting is missing" do
+      let(:data) do
+        { 'settings' => [] }
+      end
+
+      it "returns nil" do
+        expect(described_class.new(project_id, data).apm_host).to be_nil
+      end
+    end
+  end
+
   describe "#to_h" do
     let(:data) do
       {


### PR DESCRIPTION
We need to be able to use different API hosts when sending APM and Error
data. This will be useful for us when we introduce remote configuration.