### PR TITLE
airbrake: factor out complex configuration logic to Processor

### DIFF
--- a/lib/airbrake-ruby.rb
+++ b/lib/airbrake-ruby.rb
@@ -12,6 +12,7 @@ require 'airbrake-ruby/mergeable'
 require 'airbrake-ruby/grouppable'
 require 'airbrake-ruby/config'
 require 'airbrake-ruby/config/validator'
+require 'airbrake-ruby/config/processor'
 require 'airbrake-ruby/remote_settings/settings_data'
 require 'airbrake-ruby/remote_settings'
 require 'airbrake-ruby/promise'
@@ -119,7 +120,15 @@ module Airbrake
     def configure
       yield config = Airbrake::Config.instance
       Airbrake::Loggable.instance = config.logger
-      process_config_options(config)
+
+      config_processor = Airbrake::Config::Processor.new(config)
+
+      config_processor.process_blocklist(notice_notifier)
+      config_processor.process_allowlist(notice_notifier)
+
+      @remote_settings ||= config_processor.process_remote_configuration
+
+      config_processor.add_filters(notice_notifier)
     end
 
     # @since v4.2.3
@@ -575,49 +584,6 @@ module Airbrake
       self.notice_notifier = NoticeNotifier.new
       self.deploy_notifier = DeployNotifier.new
     end
-
-    private
-
-    # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
-    # rubocop:disable Metrics/MethodLength, Metrics/PerceivedComplexity
-    def process_config_options(config)
-      if config.blocklist_keys.any?
-        blocklist = Airbrake::Filters::KeysBlocklist.new(config.blocklist_keys)
-        notice_notifier.add_filter(blocklist)
-      end
-
-      if config.allowlist_keys.any?
-        allowlist = Airbrake::Filters::KeysAllowlist.new(config.allowlist_keys)
-        notice_notifier.add_filter(allowlist)
-      end
-
-      if config.project_id && config.__remote_configuration
-        @remote_settings ||= RemoteSettings.poll(config.project_id) do |data|
-          config.logger.debug("#{LOG_LABEL} applying remote settings: #{data.to_h}")
-
-          config.error_host = data.error_host if data.error_host
-          config.apm_host = data.apm_host if data.apm_host
-
-          config.error_notifications = data.error_notifications?
-          config.performance_stats = data.performance_stats?
-        end
-      end
-
-      return unless config.root_directory
-
-      [
-        Airbrake::Filters::RootDirectoryFilter,
-        Airbrake::Filters::GitRevisionFilter,
-        Airbrake::Filters::GitRepositoryFilter,
-        Airbrake::Filters::GitLastCheckoutFilter,
-      ].each do |filter|
-        next if notice_notifier.has_filter?(filter)
-
-        notice_notifier.add_filter(filter.new(config.root_directory))
-      end
-    end
-    # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity
-    # rubocop:enable Metrics/MethodLength, Metrics/PerceivedComplexity
   end
 end
 # rubocop:enable Metrics/ModuleLength

--- a/lib/airbrake-ruby/config/processor.rb
+++ b/lib/airbrake-ruby/config/processor.rb
@@ -1,0 +1,80 @@
+module Airbrake
+  class Config
+    # Processor is a helper class, which is responsible for setting default
+    # config values, default notifier filters and remote configuration changes.
+    #
+    # @since v?.?.?
+    # @api private
+    class Processor
+      # @param [Airbrake::Config] config
+      # @return [Airbrake::Config::Processor]
+      def self.process(config)
+        new(config).process
+      end
+
+      # @param [Airbrake::Config] config
+      def initialize(config)
+        @config = config
+        @blocklist_keys = @config.blocklist_keys
+        @allowlist_keys = @config.allowlist_keys
+        @project_id = @config.project_id
+      end
+
+      # @param [Airbrake::NoticeNotifier] notifier
+      # @return [void]
+      def process_blocklist(notifier)
+        return if @blocklist_keys.none?
+
+        blocklist = Airbrake::Filters::KeysBlocklist.new(@blocklist_keys)
+        notifier.add_filter(blocklist)
+      end
+
+      # @param [Airbrake::NoticeNotifier] notifier
+      # @return [void]
+      def process_allowlist(notifier)
+        return if @allowlist_keys.none?
+
+        allowlist = Airbrake::Filters::KeysAllowlist.new(@allowlist_keys)
+        notifier.add_filter(allowlist)
+      end
+
+      # @return [Airbrake::RemoteSettings]
+      def process_remote_configuration
+        return if !@project_id || !@config.__remote_configuration
+
+        RemoteSettings.poll(@project_id, &method(:poll_callback))
+      end
+
+      # @param [Airbrake::NoticeNotifier] notifier
+      # @return [void]
+      def add_filters(notifier)
+        return unless @config.root_directory
+
+        [
+          Airbrake::Filters::RootDirectoryFilter,
+          Airbrake::Filters::GitRevisionFilter,
+          Airbrake::Filters::GitRepositoryFilter,
+          Airbrake::Filters::GitLastCheckoutFilter,
+        ].each do |filter|
+          next if notifier.has_filter?(filter)
+
+          notifier.add_filter(filter.new(@config.root_directory))
+        end
+      end
+
+      # @param [Airbrake::RemoteSettings::SettingsData] data
+      # @return [void]
+      def poll_callback(data)
+        @config.logger.debug(
+          "#{LOG_LABEL} applying remote settings: #{data.to_h}",
+        )
+
+        @config.error_host = data.error_host if data.error_host
+        @config.apm_host = data.apm_host if data.apm_host
+
+        @config.error_notifications = data.error_notifications?
+        @config.performance_stats = data.performance_stats?
+      end
+    end
+  end
+end

--- a/spec/airbrake_spec.rb
+++ b/spec/airbrake_spec.rb
@@ -189,35 +189,6 @@ RSpec.describe Airbrake do
         described_class.configure { |c| c.root_directory = '/my/path' }
       end
     end
-
-    context "when the config doesn't define a project_id" do
-      it "doesn't set remote settings" do
-        expect(Airbrake::RemoteSettings).not_to receive(:poll)
-        described_class.configure { |c| c.project_id = nil }
-      end
-    end
-
-    context "when the config defines a project_id" do
-      context "and when remote configuration is false" do
-        it "doesn't set remote settings" do
-          expect(Airbrake::RemoteSettings).not_to receive(:poll)
-          described_class.configure do |c|
-            c.project_id = 1337
-            c.__remote_configuration = false
-          end
-        end
-      end
-
-      context "and when remote configuration is true" do
-        it "sets remote settings" do
-          expect(Airbrake::RemoteSettings).to receive(:poll)
-          described_class.configure do |c|
-            c.project_id = 1337
-            c.__remote_configuration = true
-          end
-        end
-      end
-    end
   end
 
   describe ".notify_request" do

--- a/spec/config/processor_spec.rb
+++ b/spec/config/processor_spec.rb
@@ -1,0 +1,223 @@
+RSpec.describe Airbrake::Config::Processor do
+  let(:notifier) { Airbrake::NoticeNotifier.new }
+
+  describe "#process_blocklist" do
+    let(:config) { Airbrake::Config.new(blocklist_keys: %w[a b c]) }
+
+    context "when there ARE blocklist keys" do
+      it "adds the blocklist filter" do
+        described_class.new(config).process_blocklist(notifier)
+        expect(notifier.has_filter?(Airbrake::Filters::KeysBlocklist)).to eq(true)
+      end
+    end
+
+    context "when there are NO blocklist keys" do
+      let(:config) { Airbrake::Config.new(blocklist_keys: %w[]) }
+
+      it "doesn't add the blocklist filter" do
+        described_class.new(config).process_blocklist(notifier)
+        expect(notifier.has_filter?(Airbrake::Filters::KeysBlocklist))
+          .to eq(false)
+      end
+    end
+  end
+
+  describe "#process_allowlist" do
+    let(:config) { Airbrake::Config.new(allowlist_keys: %w[a b c]) }
+
+    context "when there ARE allowlist keys" do
+      it "adds the allowlist filter" do
+        described_class.new(config).process_allowlist(notifier)
+        expect(notifier.has_filter?(Airbrake::Filters::KeysAllowlist)).to eq(true)
+      end
+    end
+
+    context "when there are NO allowlist keys" do
+      let(:config) { Airbrake::Config.new(allowlist_keys: %w[]) }
+
+      it "doesn't add the allowlist filter" do
+        described_class.new(config).process_allowlist(notifier)
+        expect(notifier.has_filter?(Airbrake::Filters::KeysAllowlist))
+          .to eq(false)
+      end
+    end
+  end
+
+  describe "#process_remote_configuration" do
+    context "when the config doesn't define a project_id" do
+      let(:config) { Airbrake::Config.new(project_id: nil) }
+
+      it "doesn't set remote settings" do
+        expect(Airbrake::RemoteSettings).not_to receive(:poll)
+        described_class.new(config).process_remote_configuration
+      end
+    end
+
+    context "when the config defines a project_id" do
+      context "and when remote configuration is false" do
+        let(:config) do
+          Airbrake::Config.new(project_id: 123, __remote_configuration: false)
+        end
+
+        it "doesn't set remote settings" do
+          expect(Airbrake::RemoteSettings).not_to receive(:poll)
+          described_class.new(config).process_remote_configuration
+        end
+      end
+
+      context "and when remote configuration is true" do
+        let(:config) do
+          Airbrake::Config.new(project_id: 123, __remote_configuration: true)
+        end
+
+        it "sets remote settings" do
+          expect(Airbrake::RemoteSettings).to receive(:poll)
+          described_class.new(config).process_remote_configuration
+        end
+      end
+    end
+  end
+
+  describe "#add_filters" do
+    context "when there's a root directory" do
+      let(:config) { Airbrake::Config.new(root_directory: '/abc') }
+
+      it "adds RootDirectoryFilter" do
+        described_class.new(config).add_filters(notifier)
+        expect(notifier.has_filter?(Airbrake::Filters::RootDirectoryFilter))
+          .to eq(true)
+      end
+
+      it "adds GitRevisionFilter" do
+        described_class.new(config).add_filters(notifier)
+        expect(notifier.has_filter?(Airbrake::Filters::GitRevisionFilter))
+          .to eq(true)
+      end
+
+      it "adds GitRepositoryFilter" do
+        described_class.new(config).add_filters(notifier)
+        expect(notifier.has_filter?(Airbrake::Filters::GitRepositoryFilter))
+          .to eq(true)
+      end
+
+      it "adds GitLastCheckoutFilter" do
+        described_class.new(config).add_filters(notifier)
+        expect(notifier.has_filter?(Airbrake::Filters::GitLastCheckoutFilter))
+          .to eq(true)
+      end
+    end
+
+    context "when there's NO root directory" do
+      let(:config) { Airbrake::Config.new(root_directory: nil) }
+
+      it "doesn't add RootDirectoryFilter" do
+        described_class.new(config).add_filters(notifier)
+        expect(notifier.has_filter?(Airbrake::Filters::RootDirectoryFilter))
+          .to eq(false)
+      end
+
+      it "doesn't add GitRevisionFilter" do
+        described_class.new(config).add_filters(notifier)
+        expect(notifier.has_filter?(Airbrake::Filters::GitRevisionFilter))
+          .to eq(false)
+      end
+
+      it "doesn't add GitRepositoryFilter" do
+        described_class.new(config).add_filters(notifier)
+        expect(notifier.has_filter?(Airbrake::Filters::GitRepositoryFilter))
+          .to eq(false)
+      end
+
+      it "doesn't add GitLastCheckoutFilter" do
+        described_class.new(config).add_filters(notifier)
+        expect(notifier.has_filter?(Airbrake::Filters::GitLastCheckoutFilter))
+          .to eq(false)
+      end
+    end
+  end
+
+  describe "#poll_callback" do
+    let(:logger) { Logger.new(File::NULL) }
+
+    let(:config) do
+      Airbrake::Config.new(
+        project_id: 123,
+        __remote_configuration: true,
+        logger: logger,
+      )
+    end
+
+    let(:data) do
+      instance_double(Airbrake::RemoteSettings::SettingsData)
+    end
+
+    before do
+      allow(data).to receive(:to_h)
+      allow(data).to receive(:error_host)
+      allow(data).to receive(:apm_host)
+      allow(data).to receive(:error_notifications?)
+      allow(data).to receive(:performance_stats?)
+    end
+
+    it "logs given data" do
+      expect(logger).to receive(:debug).with(/applying remote settings/)
+      described_class.new(config).poll_callback(data)
+    end
+
+    it "sets the error_notifications option" do
+      config.error_notifications = false
+      expect(data).to receive(:error_notifications?).and_return(true)
+
+      described_class.new(config).poll_callback(data)
+      expect(config.error_notifications).to eq(true)
+    end
+
+    it "sets the performance_stats option" do
+      config.performance_stats = false
+      expect(data).to receive(:performance_stats?).and_return(true)
+
+      described_class.new(config).poll_callback(data)
+      expect(config.performance_stats).to eq(true)
+    end
+
+    context "when error_host returns a value" do
+      it "sets the error_host option" do
+        config.error_host = 'http://api.airbrake.io'
+        allow(data).to receive(:error_host).and_return('https://api.example.com')
+
+        described_class.new(config).poll_callback(data)
+        expect(config.error_host).to eq('https://api.example.com')
+      end
+    end
+
+    context "when error_host returns nil" do
+      it "doesn't modify the error_host option" do
+        config.error_host = 'http://api.airbrake.io'
+        allow(data).to receive(:error_host).and_return(nil)
+
+        described_class.new(config).poll_callback(data)
+        expect(config.error_host).to eq('http://api.airbrake.io')
+      end
+    end
+
+    context "when apm_host returns a value" do
+      it "sets the apm_host option" do
+        config.apm_host = 'http://api.airbrake.io'
+        allow(data).to receive(:apm_host).and_return('https://api.example.com')
+
+        described_class.new(config).poll_callback(data)
+        expect(config.apm_host).to eq('https://api.example.com')
+      end
+    end
+
+    context "when apm_host returns nil" do
+      it "doesn't modify the apm_host option" do
+        config.apm_host = 'http://api.airbrake.io'
+        allow(data).to receive(:apm_host).and_return(nil)
+
+        described_class.new(config).poll_callback(data)
+        expect(config.apm_host).to eq('http://api.airbrake.io')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Rubocop is going crazy about the complexity of `process_config_options`. It's
high time to refactor it! Adding a helper class helps to achieve better
testability and lessen the complexity. Rubocop is happy now (and probably your
brain, too).