### PR TITLE
remote_settings/settings_data: update S3 bucket name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Airbrake Ruby Changelog
 * Started sending information about notifier name & version, operating system &
   language with every remote config GET request
   ([#594](https://github.com/airbrake/airbrake-ruby/pull/594))
+* Remote settings: updated S3 bucket name, which fixed config fetching
+  ([#595](https://github.com/airbrake/airbrake-ruby/pull/595))
 
 ### [v5.0.0.rc.1][v5.0.0.rc.1] (July 13, 2020)
 

--- a/lib/airbrake-ruby/remote_settings/settings_data.rb
+++ b/lib/airbrake-ruby/remote_settings/settings_data.rb
@@ -22,7 +22,7 @@ module Airbrake
 
       # @return [String] what URL to poll
       CONFIG_ROUTE_PATTERN =
-        'https://%<bucket>s.s3.amazonaws.com/' \
+        'https://v1-%<bucket>s.s3.amazonaws.com/' \
         "#{API_VER}/config/%<project_id>s/config.json".freeze
 
       # @return [Hash{Symbol=>String}] the hash of all supported settings where

--- a/spec/remote_settings/settings_data_spec.rb
+++ b/spec/remote_settings/settings_data_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Airbrake::RemoteSettings::SettingsData do
 
       it "returns the default pathname" do
         expect(described_class.new(project_id, data).config_route).to eq(
-          'https://staging-notifier-configs.s3.amazonaws.com/' \
+          'https://v1-staging-notifier-configs.s3.amazonaws.com/' \
           "2020-06-18/config/#{project_id}/config.json",
         )
       end

--- a/spec/remote_settings_spec.rb
+++ b/spec/remote_settings_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Airbrake::RemoteSettings do
   let(:project_id) { 123 }
 
   let(:endpoint) do
-    "https://staging-notifier-configs.s3.amazonaws.com/2020-06-18/config/" \
+    "https://v1-staging-notifier-configs.s3.amazonaws.com/2020-06-18/config/" \
     "#{project_id}/config.json"
   end
 


### PR DESCRIPTION
The old bucket is gone, so we need to update the code to use a new name.