### PR TITLE
filters/keys: duplicate hashes while filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Airbrake Ruby Changelog
 
 ### master
 
+* Fixed unwanted mutation of nested hashes passed through `Notice#[]=`
+  ([#597](https://github.com/airbrake/airbrake-ruby/pull/597))
+
 ### [v5.0.0.rc.2][v5.0.0.rc.2] (July 29, 2020)
 
 * Started sending information about notifier name & version, operating system &

--- a/spec/filters/keys_blocklist_spec.rb
+++ b/spec/filters/keys_blocklist_spec.rb
@@ -150,6 +150,16 @@ RSpec.describe Airbrake::Filters::KeysBlocklist do
           { bongo: { bish: '[Filtered]' } },
         ],
       )
+
+      it "doesn't mutate the original hash" do
+        params = { bongo: { bish: 'bash' } }
+        notice[:params] = params
+
+        blocklist = described_class.new([:bish])
+        blocklist.call(notice)
+
+        expect(params[:bongo][:bish]).to eq('bash')
+      end
     end
 
     context "and it is recursive" do

--- a/spec/notice_spec.rb
+++ b/spec/notice_spec.rb
@@ -268,7 +268,7 @@ RSpec.describe Airbrake::Notice do
     it "sets a payload value" do
       hash = { bingo: 'bango' }
       notice[:params] = hash
-      expect(notice[:params]).to equal(hash)
+      expect(notice[:params]).to eq(hash)
     end
 
     it "raises error if notice is ignored" do


### PR DESCRIPTION
Fixes #592 (Session deep values are modified if it contains filtered (blocklist)
keys)