### PR TITLE
Make it possible to configure remote config host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Airbrake Ruby Changelog
   ([#609](https://github.com/airbrake/airbrake-ruby/pull/609))
 * Dropped support for `blacklist_keys` & `whitelist_keys`
   ([#610](https://github.com/airbrake/airbrake-ruby/pull/610))
+* Added the `remote_config_host` option, which is responsible for specifying the
+  host, which provides the remote config
+  ([#611](https://github.com/airbrake/airbrake-ruby/pull/611))
 
 ### [v5.0.0.rc.2][v5.0.0.rc.2] (July 29, 2020)
 

--- a/lib/airbrake-ruby/config.rb
+++ b/lib/airbrake-ruby/config.rb
@@ -124,6 +124,10 @@ module Airbrake
     # @since ?.?.?
     attr_accessor :error_notifications
 
+    # @return [String] the host such as which should be used for fetching remote
+    #   configuration options (example: "https://bucket-name.s3.amazonaws.com")
+    attr_accessor :remote_config_host
+
     # @note Not for public use!
     # @return [Boolean]
     # @api private
@@ -142,7 +146,7 @@ module Airbrake
 
     # @param [Hash{Symbol=>Object}] user_config the hash to be used to build the
     #   config
-    # rubocop:disable Metrics/AbcSize
+    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     def initialize(user_config = {})
       self.proxy = {}
       self.queue_size = 100
@@ -153,6 +157,7 @@ module Airbrake
       self.project_key = user_config[:project_key]
       self.error_host = 'https://api.airbrake.io'
       self.apm_host = 'https://api.airbrake.io'
+      self.remote_config_host = 'https://v1-production-notifier-configs.s3.amazonaws.com'
 
       self.ignore_environments = []
 
@@ -176,7 +181,7 @@ module Airbrake
 
       merge(user_config)
     end
-    # rubocop:enable Metrics/AbcSize
+    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
     # The full URL to the Airbrake Notice API. Based on the +:error_host+ option.
     # @return [URI] the endpoint address

--- a/lib/airbrake-ruby/config/processor.rb
+++ b/lib/airbrake-ruby/config/processor.rb
@@ -42,7 +42,11 @@ module Airbrake
       def process_remote_configuration
         return if !@project_id || !@config.__remote_configuration
 
-        RemoteSettings.poll(@project_id, &method(:poll_callback))
+        RemoteSettings.poll(
+          @project_id,
+          @config.remote_config_host,
+          &method(:poll_callback)
+        )
       end
 
       # @param [Airbrake::NoticeNotifier] notifier

--- a/lib/airbrake-ruby/remote_settings.rb
+++ b/lib/airbrake-ruby/remote_settings.rb
@@ -36,18 +36,20 @@ module Airbrake
     # Polls remote config of the given project.
     #
     # @param [Integer] project_id
+    # @param [String] host
     # @yield [data]
     # @yieldparam data [Airbrake::RemoteSettings::SettingsData]
     # @return [Airbrake::RemoteSettings]
-    def self.poll(project_id, &block)
-      new(project_id, &block).poll
+    def self.poll(project_id, host, &block)
+      new(project_id, host, &block).poll
     end
 
     # @param [Integer] project_id
     # @yield [data]
     # @yieldparam data [Airbrake::RemoteSettings::SettingsData]
-    def initialize(project_id, &block)
+    def initialize(project_id, host, &block)
       @data = SettingsData.new(project_id, {})
+      @host = host
       @block = block
       @poll = nil
     end
@@ -118,7 +120,7 @@ module Airbrake
     end
 
     def build_config_uri
-      uri = URI(@data.config_route)
+      uri = URI(@data.config_route(@host))
       uri.query = QUERY_PARAMS
       uri
     end

--- a/lib/airbrake-ruby/remote_settings/settings_data.rb
+++ b/lib/airbrake-ruby/remote_settings/settings_data.rb
@@ -20,16 +20,15 @@ module Airbrake
       # @return [String] API version of the S3 API to poll
       API_VER = '2020-06-18'.freeze
 
-      # @return [String] what URL to poll
+      # @return [String] what path to poll
       CONFIG_ROUTE_PATTERN =
-        'https://v1-%<bucket>s.s3.amazonaws.com/' \
-        "#{API_VER}/config/%<project_id>s/config.json".freeze
+        "%<host>s/#{API_VER}/config/%<project_id>s/config.json".freeze
 
       # @return [Hash{Symbol=>String}] the hash of all supported settings where
       #   the value is the name of the setting returned by the API
       SETTINGS = {
-        errors: 'errors',
-        apm: 'apm',
+        errors: 'errors'.freeze,
+        apm: 'apm'.freeze,
       }.freeze
 
       # @param [Integer] project_id
@@ -56,17 +55,22 @@ module Airbrake
         @data['poll_sec'] > 0 ? @data['poll_sec'] : DEFAULT_INTERVAL
       end
 
+      # @param [String] remote_config_host
       # @return [String] where the config is stored on S3.
-      def config_route
+      def config_route(remote_config_host)
         if !@data.key?('config_route') || !@data['config_route']
           return format(
             CONFIG_ROUTE_PATTERN,
-            bucket: 'staging-notifier-configs',
+            host: remote_config_host.chomp('/'),
             project_id: @project_id,
           )
         end
 
-        @data['config_route']
+        format(
+          CONFIG_ROUTE_PATTERN,
+          host: @data['config_route'].chomp('/'),
+          project_id: @project_id,
+        )
       end
 
       # @return [Boolean] whether error notifications are enabled

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -26,6 +26,11 @@ RSpec.describe Airbrake::Config do
   its(:query_stats) { is_expected.to eq(true) }
   its(:job_stats) { is_expected.to eq(true) }
   its(:error_notifications) { is_expected.to eq(true) }
+
+  its(:remote_config_host) do
+    is_expected.to eq('https://v1-production-notifier-configs.s3.amazonaws.com')
+  end
+
   its(:__remote_configuration) { is_expected.to eq(false) }
 
   describe "#new" do

--- a/spec/remote_settings_spec.rb
+++ b/spec/remote_settings_spec.rb
@@ -1,9 +1,9 @@
 RSpec.describe Airbrake::RemoteSettings do
   let(:project_id) { 123 }
+  let(:host) { 'https://v1-production-notifier-configs.s3.amazonaws.com' }
 
   let(:endpoint) do
-    "https://v1-staging-notifier-configs.s3.amazonaws.com/2020-06-18/config/" \
-    "#{project_id}/config.json"
+    "#{host}/2020-06-18/config/#{project_id}/config.json"
   end
 
   let(:body) do
@@ -51,7 +51,7 @@ RSpec.describe Airbrake::RemoteSettings do
         expect(File).to receive(:read).with(config_path)
         expect(settings_data).to receive(:merge!).with(body).twice
 
-        remote_settings = described_class.poll(project_id) {}
+        remote_settings = described_class.poll(project_id, host) {}
         sleep(0.2)
         remote_settings.stop_polling
 
@@ -62,7 +62,7 @@ RSpec.describe Airbrake::RemoteSettings do
         block = proc {}
         expect(block).to receive(:call).twice
 
-        remote_settings = described_class.poll(project_id, &block)
+        remote_settings = described_class.poll(project_id, host, &block)
         sleep(0.2)
         remote_settings.stop_polling
 
@@ -76,7 +76,7 @@ RSpec.describe Airbrake::RemoteSettings do
             '**Airbrake: config loading failed: StandardError',
           )
 
-          remote_settings = described_class.poll(project_id) {}
+          remote_settings = described_class.poll(project_id, host) {}
           sleep(0.2)
           remote_settings.stop_polling
 
@@ -87,7 +87,7 @@ RSpec.describe Airbrake::RemoteSettings do
 
     context "when no errors are raised" do
       it "makes a request to AWS S3" do
-        remote_settings = described_class.poll(project_id) {}
+        remote_settings = described_class.poll(project_id, host) {}
         sleep(0.1)
         remote_settings.stop_polling
 
@@ -95,7 +95,7 @@ RSpec.describe Airbrake::RemoteSettings do
       end
 
       it "sends params about the environment with the request" do
-        remote_settings = described_class.poll(project_id) {}
+        remote_settings = described_class.poll(project_id, host) {}
         sleep(0.1)
         remote_settings.stop_polling
 
@@ -107,7 +107,7 @@ RSpec.describe Airbrake::RemoteSettings do
 
       it "fetches remote settings" do
         settings = nil
-        remote_settings = described_class.poll(project_id) do |data|
+        remote_settings = described_class.poll(project_id, host) do |data|
           settings = data
         end
         sleep(0.1)
@@ -126,7 +126,7 @@ RSpec.describe Airbrake::RemoteSettings do
 
       it "doesn't fetch remote settings" do
         settings = nil
-        remote_settings = described_class.poll(project_id) do |data|
+        remote_settings = described_class.poll(project_id, host) do |data|
           settings = data
         end
         sleep(0.1)
@@ -144,7 +144,7 @@ RSpec.describe Airbrake::RemoteSettings do
 
       it "doesn't update settings data" do
         settings = nil
-        remote_settings = described_class.poll(project_id) do |data|
+        remote_settings = described_class.poll(project_id, host) do |data|
           settings = data
         end
         sleep(0.1)
@@ -163,7 +163,7 @@ RSpec.describe Airbrake::RemoteSettings do
 
       it "doesn't update settings data" do
         settings = nil
-        remote_settings = described_class.poll(project_id) do |data|
+        remote_settings = described_class.poll(project_id, host) do |data|
           settings = data
         end
         sleep(0.1)
@@ -189,7 +189,7 @@ RSpec.describe Airbrake::RemoteSettings do
       end
 
       it "makes the next request to the specified config route" do
-        remote_settings = described_class.poll(project_id) {}
+        remote_settings = described_class.poll(project_id, host) {}
         sleep(0.2)
 
         remote_settings.stop_polling
@@ -205,7 +205,7 @@ RSpec.describe Airbrake::RemoteSettings do
       expect(Dir).to receive(:mkdir).with(config_dir)
       expect(File).to receive(:write).with(config_path, body.to_json)
 
-      remote_settings = described_class.poll(project_id) {}
+      remote_settings = described_class.poll(project_id, host) {}
       sleep(0.2)
       remote_settings.stop_polling
 
@@ -219,7 +219,7 @@ RSpec.describe Airbrake::RemoteSettings do
           '**Airbrake: config dumping failed: StandardError',
         )
 
-        remote_settings = described_class.poll(project_id) {}
+        remote_settings = described_class.poll(project_id, host) {}
         sleep(0.2)
         remote_settings.stop_polling
 


### PR DESCRIPTION
At the moment there's a bug with remote configuration. A user would install the
new notifier but the notifier would use our staging S3 bucket to fetch
configs. Instead, we should hardcode the bucket path to production because
that's the goal. A helper option called `remote_config_host` was added. With
help of it can easily test the functionality.