### PR TITLE
config: delete __remote_configuration

### DIFF
--- a/lib/airbrake-ruby/config.rb
+++ b/lib/airbrake-ruby/config.rb
@@ -128,12 +128,6 @@ module Airbrake
     #   configuration options (example: "https://bucket-name.s3.amazonaws.com")
     attr_accessor :remote_config_host
 
-    # @note Not for public use!
-    # @return [Boolean]
-    # @api private
-    # @since ?.?.?
-    attr_accessor :__remote_configuration
-
     class << self
       # @return [Config]
       attr_writer :instance
@@ -146,7 +140,7 @@ module Airbrake
 
     # @param [Hash{Symbol=>Object}] user_config the hash to be used to build the
     #   config
-    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    # rubocop:disable Metrics/AbcSize
     def initialize(user_config = {})
       self.proxy = {}
       self.queue_size = 100
@@ -177,11 +171,10 @@ module Airbrake
       self.query_stats = true
       self.job_stats = true
       self.error_notifications = true
-      self.__remote_configuration = false
 
       merge(user_config)
     end
-    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+    # rubocop:enable Metrics/AbcSize
 
     # The full URL to the Airbrake Notice API. Based on the +:error_host+ option.
     # @return [URI] the endpoint address

--- a/lib/airbrake-ruby/config/processor.rb
+++ b/lib/airbrake-ruby/config/processor.rb
@@ -40,7 +40,7 @@ module Airbrake
 
       # @return [Airbrake::RemoteSettings]
       def process_remote_configuration
-        return if !@project_id || !@config.__remote_configuration
+        return unless @project_id
 
         RemoteSettings.poll(
           @project_id,

--- a/spec/config/processor_spec.rb
+++ b/spec/config/processor_spec.rb
@@ -54,26 +54,13 @@ RSpec.describe Airbrake::Config::Processor do
     end
 
     context "when the config defines a project_id" do
-      context "and when remote configuration is false" do
-        let(:config) do
-          Airbrake::Config.new(project_id: 123, __remote_configuration: false)
-        end
-
-        it "doesn't set remote settings" do
-          expect(Airbrake::RemoteSettings).not_to receive(:poll)
-          described_class.new(config).process_remote_configuration
-        end
+      let(:config) do
+        Airbrake::Config.new(project_id: 123)
       end
 
-      context "and when remote configuration is true" do
-        let(:config) do
-          Airbrake::Config.new(project_id: 123, __remote_configuration: true)
-        end
-
-        it "sets remote settings" do
-          expect(Airbrake::RemoteSettings).to receive(:poll)
-          described_class.new(config).process_remote_configuration
-        end
+      it "sets remote settings" do
+        expect(Airbrake::RemoteSettings).to receive(:poll)
+        described_class.new(config).process_remote_configuration
       end
     end
   end
@@ -142,7 +129,6 @@ RSpec.describe Airbrake::Config::Processor do
     let(:config) do
       Airbrake::Config.new(
         project_id: 123,
-        __remote_configuration: true,
         logger: logger,
       )
     end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -31,8 +31,6 @@ RSpec.describe Airbrake::Config do
     is_expected.to eq('https://v1-production-notifier-configs.s3.amazonaws.com')
   end
 
-  its(:__remote_configuration) { is_expected.to eq(false) }
-
   describe "#new" do
     context "when user config is passed" do
       subject { described_class.new(logger: StringIO.new) }


### PR DESCRIPTION
This temporary option was needed for testing the feature, now we can get rid of
it and use the feature by default.