### PR TITLE
remote_settings: ignore empty string in 'config_route'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Airbrake Ruby Changelog
 
 ### master
 
+* Remote config: fixed bug where remote config cannot be applied when the remote
+  config's `config_route` is an empty string
+  ([#614](https://github.com/airbrake/airbrake-ruby/pull/614))
+
 ### [v5.0.0][v5.0.0] (August 17, 2020)
 
 Breaking changes:

--- a/lib/airbrake-ruby/remote_settings/settings_data.rb
+++ b/lib/airbrake-ruby/remote_settings/settings_data.rb
@@ -58,17 +58,18 @@ module Airbrake
       # @param [String] remote_config_host
       # @return [String] where the config is stored on S3.
       def config_route(remote_config_host)
-        if !@data.key?('config_route') || !@data['config_route']
+        if @data.key?('config_route') &&
+           @data['config_route'] && !@data['config_route'].empty?
           return format(
             CONFIG_ROUTE_PATTERN,
-            host: remote_config_host.chomp('/'),
+            host: @data['config_route'].chomp('/'),
             project_id: @project_id,
           )
         end
 
         format(
           CONFIG_ROUTE_PATTERN,
-          host: @data['config_route'].chomp('/'),
+          host: remote_config_host.chomp('/'),
           project_id: @project_id,
         )
       end

--- a/spec/remote_settings/settings_data_spec.rb
+++ b/spec/remote_settings/settings_data_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe Airbrake::RemoteSettings::SettingsData do
       context "and when the remote host doesn't with a slash" do
         let(:host) { 'http://example.com' }
 
-        it "returns the route with the host" do
+        it "returns the route with the given host" do
           expect(described_class.new(project_id, {}).config_route(host)).to eq(
             "http://example.com/2020-06-18/config/#{project_id}/config.json",
           )
@@ -116,6 +116,19 @@ RSpec.describe Airbrake::RemoteSettings::SettingsData do
       end
 
       it "returns the route with the given host instead" do
+        expect(described_class.new(project_id, data).config_route(host)).to eq(
+          'https://v1-production-notifier-configs.s3.amazonaws.com/' \
+          "2020-06-18/config/#{project_id}/config.json",
+        )
+      end
+    end
+
+    context "when the given remote host in the remote config is an empty string" do
+      let(:data) do
+        { 'config_route' => '' }
+      end
+
+      it "returns the route with the default instead" do
         expect(described_class.new(project_id, data).config_route(host)).to eq(
           'https://v1-production-notifier-configs.s3.amazonaws.com/' \
           "2020-06-18/config/#{project_id}/config.json",


### PR DESCRIPTION
If `config_route` is `''`, then it will be used as the host for the remote
config. This is a bug, empty strings should be ignored and the default host
should be used.