### PR TITLE
remote_settings: fix bug in #config_route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Airbrake Ruby Changelog
 
 ### master
 
+* Remote config: fixed bug where remote config can disappear from the queried
+  URL ([#616](https://github.com/airbrake/airbrake-ruby/pull/616))
+
 ### [v5.0.1][v5.0.1] (August 17, 2020)
 
 * Remote config: fixed bug where remote config cannot be applied when the remote

--- a/lib/airbrake-ruby/remote_settings/settings_data.rb
+++ b/lib/airbrake-ruby/remote_settings/settings_data.rb
@@ -58,13 +58,8 @@ module Airbrake
       # @param [String] remote_config_host
       # @return [String] where the config is stored on S3.
       def config_route(remote_config_host)
-        if @data.key?('config_route') &&
-           @data['config_route'] && !@data['config_route'].empty?
-          return format(
-            CONFIG_ROUTE_PATTERN,
-            host: @data['config_route'].chomp('/'),
-            project_id: @project_id,
-          )
+        if @data['config_route'] && !@data['config_route'].empty?
+          return remote_config_host.chomp('/') + '/' + @data['config_route']
         end
 
         format(

--- a/spec/remote_settings/settings_data_spec.rb
+++ b/spec/remote_settings/settings_data_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Airbrake::RemoteSettings::SettingsData do
 
       expect(settings_data.interval).to eq(123)
       expect(settings_data.config_route(''))
-        .to eq('abc/2020-06-18/config/123/config.json')
+        .to eq('/abc')
     end
   end
 
@@ -60,78 +60,48 @@ RSpec.describe Airbrake::RemoteSettings::SettingsData do
   end
 
   describe "#config_route" do
-    let(:host) { 'https://v1-production-notifier-configs.s3.amazonaws.com' }
+    let(:host) { 'http://example.com/' }
 
-    context "when given a remote host through the remote config" do
-      context "and when the remote host ends with a slash" do
-        let(:data) do
-          { 'config_route' => 'http://example.com/' }
-        end
-
-        it "returns the route with the host" do
-          expect(described_class.new(project_id, data).config_route(host)).to eq(
-            "http://example.com/2020-06-18/config/#{project_id}/config.json",
-          )
-        end
-      end
-
-      context "and when the remote host doesn't with a slash" do
-        let(:data) do
-          { 'config_route' => 'http://example.com' }
-        end
-
-        it "returns the route with the host" do
-          expect(described_class.new(project_id, data).config_route(host)).to eq(
-            "http://example.com/2020-06-18/config/#{project_id}/config.json",
-          )
-        end
-      end
-    end
-
-    context "when given a remote host through local configuration" do
-      context "and when the remote host ends with a slash" do
-        let(:host) { 'http://example.com/' }
-
-        it "returns the route with the host" do
-          expect(described_class.new(project_id, {}).config_route(host)).to eq(
-            "http://example.com/2020-06-18/config/#{project_id}/config.json",
-          )
-        end
-      end
-
-      context "and when the remote host doesn't with a slash" do
-        let(:host) { 'http://example.com' }
-
-        it "returns the route with the given host" do
-          expect(described_class.new(project_id, {}).config_route(host)).to eq(
-            "http://example.com/2020-06-18/config/#{project_id}/config.json",
-          )
-        end
-      end
-    end
-
-    context "when the given remote host in the remote config is nil" do
+    context "when remote config specifies a config route" do
       let(:data) do
-        { 'config_route' => nil }
+        { 'config_route' => '123/cfg/321/cfg.json' }
       end
 
-      it "returns the route with the given host instead" do
+      it "returns the config route with the provided location" do
         expect(described_class.new(project_id, data).config_route(host)).to eq(
-          'https://v1-production-notifier-configs.s3.amazonaws.com/' \
-          "2020-06-18/config/#{project_id}/config.json",
+          'http://example.com/123/cfg/321/cfg.json',
         )
       end
     end
 
-    context "when the given remote host in the remote config is an empty string" do
+    context "when remote config DOES NOT specify a config route" do
+      it "returns the config route with the default location" do
+        expect(described_class.new(project_id, {}).config_route(host)).to eq(
+          "http://example.com/2020-06-18/config/#{project_id}/config.json",
+        )
+      end
+    end
+
+    context "when a config route is specified but is set to nil" do
+      let(:data) do
+        { 'config_route' => nil }
+      end
+
+      it "returns the config route with the default location" do
+        expect(described_class.new(project_id, data).config_route(host)).to eq(
+          "http://example.com/2020-06-18/config/#{project_id}/config.json",
+        )
+      end
+    end
+
+    context "when a config route is specified but is set to an empty string" do
       let(:data) do
         { 'config_route' => '' }
       end
 
       it "returns the route with the default instead" do
         expect(described_class.new(project_id, data).config_route(host)).to eq(
-          'https://v1-production-notifier-configs.s3.amazonaws.com/' \
-          "2020-06-18/config/#{project_id}/config.json",
+          "http://example.com/2020-06-18/config/#{project_id}/config.json",
         )
       end
     end

--- a/spec/remote_settings_spec.rb
+++ b/spec/remote_settings_spec.rb
@@ -175,16 +175,16 @@ RSpec.describe Airbrake::RemoteSettings do
     end
 
     context "when a config route is specified in the returned data" do
-      let(:new_endpoint) do
-        "http://example.com"
+      let(:new_config_route) do
+        '213/config/111/config.json'
       end
 
       let(:body) do
-        { 'config_route' => new_endpoint, 'poll_sec' => 0.1 }
+        { 'config_route' => new_config_route, 'poll_sec' => 0.1 }
       end
 
       let!(:new_stub) do
-        stub_request(:get, Regexp.new(new_endpoint))
+        stub_request(:get, Regexp.new(new_config_route))
           .to_return(status: 200, body: body.to_json)
       end
 


### PR DESCRIPTION
Normally `config_route` is specified as `2020-01-01/config/...`. However due to
a bug the returned value from the `#config_route` method will be wrong. Instead
of returning the provided host + config_path we return just `config_path`.