### PR TITLE
Add configuration to disable remote settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,19 @@ Airbrake.notify('App crashed!', {
 #     credit_card: '[Filtered]' }
 ```
 
+#### remote_config and remote_config_host
+
+Airbrake Ruby can fetch its configuration from a remote site and updates them in
+regular intervals. By default, this feature is disabled and uses the host
+`https://v1-production-notifier-configs.s3.amazonaws.com`.
+
+```ruby
+Airbrake.configure do |c|
+  c.remote_config = true
+  c.remote_config_host = 'https://some-configuration-bucket.s3.amazonaws.com'
+end
+```
+
 ##### Using Procs to delay filters configuration
 
 If you cannot inline your keys (for example, they should be loaded from external

--- a/lib/airbrake-ruby/config.rb
+++ b/lib/airbrake-ruby/config.rb
@@ -124,6 +124,12 @@ module Airbrake
     # @since 5.0.0
     attr_accessor :error_notifications
 
+    # @return [Boolean] true if the library should fetch remote configurations,
+    #   false otherwise
+    # @api public
+    # @since v5.0.3
+    attr_accessor :remote_config
+
     # @return [String] the host such as which should be used for fetching remote
     #   configuration options (example: "https://bucket-name.s3.amazonaws.com")
     attr_accessor :remote_config_host
@@ -140,7 +146,7 @@ module Airbrake
 
     # @param [Hash{Symbol=>Object}] user_config the hash to be used to build the
     #   config
-    # rubocop:disable Metrics/AbcSize
+    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     def initialize(user_config = {})
       self.proxy = {}
       self.queue_size = 100
@@ -151,6 +157,7 @@ module Airbrake
       self.project_key = user_config[:project_key]
       self.error_host = 'https://api.airbrake.io'
       self.apm_host = 'https://api.airbrake.io'
+      self.remote_config = false
       self.remote_config_host = 'https://v1-production-notifier-configs.s3.amazonaws.com'
 
       self.ignore_environments = []
@@ -174,7 +181,7 @@ module Airbrake
 
       merge(user_config)
     end
-    # rubocop:enable Metrics/AbcSize
+    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
     # The full URL to the Airbrake Notice API. Based on the +:error_host+ option.
     # @return [URI] the endpoint address

--- a/lib/airbrake-ruby/config/processor.rb
+++ b/lib/airbrake-ruby/config/processor.rb
@@ -42,6 +42,7 @@ module Airbrake
       # @return [Airbrake::RemoteSettings]
       def process_remote_configuration
         return unless @project_id
+        return unless @config.remote_config
 
         RemoteSettings.poll(@project_id, @config.remote_config_host) do |data|
           @poll_callback.call(data)

--- a/spec/config/processor_spec.rb
+++ b/spec/config/processor_spec.rb
@@ -53,9 +53,20 @@ RSpec.describe Airbrake::Config::Processor do
       end
     end
 
-    context "when the config defines a project_id" do
+    context "when the config disables remote configurations" do
       let(:config) do
-        Airbrake::Config.new(project_id: 123)
+        Airbrake::Config.new(project_id: 123, remote_config: false)
+      end
+
+      it "doesn't set remote settings" do
+        expect(Airbrake::RemoteSettings).not_to receive(:poll)
+        described_class.new(config).process_remote_configuration
+      end
+    end
+
+    context "when the config defines a project_id and enables remote configurations" do
+      let(:config) do
+        Airbrake::Config.new(project_id: 123, remote_config: true)
       end
 
       it "sets remote settings" do

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe Airbrake::Config do
   its(:job_stats) { is_expected.to eq(true) }
   its(:error_notifications) { is_expected.to eq(true) }
 
+  its(:remote_config) { is_expected.to eq(false) }
   its(:remote_config_host) do
     is_expected.to eq('https://v1-production-notifier-configs.s3.amazonaws.com')
   end

--- a/spec/filters/git_last_checkout_filter_spec.rb
+++ b/spec/filters/git_last_checkout_filter_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Airbrake::Filters::GitLastCheckoutFilter do
     it "attaches last checkouted email" do
       subject.call(notice)
       expect(notice[:context][:lastCheckout][:email]).to(
-        match(/\A\w+[\w.-]*@\w+\.?\w+?\z/),
+        match(/\A\w+[\w.-]*@(\w+\.)*\w+\z/),
       )
     end
 


### PR DESCRIPTION
On internal systems, external sites might be blocked and i guess many people are concerned about leaking information of their systems without asking them before... Another very bad idea is to [write into gem directories](https://github.com/airbrake/airbrake-ruby/blob/master/lib/airbrake-ruby/remote_settings.rb#L142).

This pull request adds a new configuration option to enable/disable the remote configuration feature and adds some information about it to the readme. One of the tests does not like my e-mail address, the pull request includes a fix to support subdomains in the test.