### PR TITLE
filters/git_last_checkout_spec: support subdomains in e-mail regex

### DIFF
--- a/spec/filters/git_last_checkout_filter_spec.rb
+++ b/spec/filters/git_last_checkout_filter_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Airbrake::Filters::GitLastCheckoutFilter do
     it "attaches last checkouted email" do
       subject.call(notice)
       expect(notice[:context][:lastCheckout][:email]).to(
-        match(/\A\w+[\w.-]*@\w+\.?\w+?\z/),
+        match(/\A\w+[\w.-]*@(\w+\.)*\w+\z/),
       )
     end
 


### PR DESCRIPTION
This test will not pass if your email includes a subdomain. The new regexp
enables subdomain support.

```
[5] pry(main)> "a@a.b.com".match(/\A\w+[\w.-]*@(\w+\.)+\w+\z/)
=> #<MatchData "a@a.b.com" 1:"b.">
[7] pry(main)> "a@foo.com".match(/\A\w+[\w.-]*@(\w+\.)+\w+\z/)
=> #<MatchData "a@foo.com" 1:"foo.">
```

Thanks to: @derSascha