### PR TITLE
remote_settings: delete the code for config dumping/loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Airbrake Ruby Changelog
 
 ### master
 
+* Deleted support for dumping/loading the remote config
+  ([#621](https://github.com/airbrake/airbrake-ruby/pull/621))
+
 ### [v5.0.2][v5.0.2] (August 18, 2020)
 
 * Remote config: fixed bug where remote config can disappear from the queried


### PR DESCRIPTION
Some of our users complain that our airbrake-ruby notifier tries to dump the
remote config that we pull from S3 to the gem directory. The OS user that is
running the code may not have write access to that directory and therefore
writing the remote config will fail.

There's no good universal location to keep persistent remote config, so it's
easier just to delete the config.