### PR TITLE
config/processor: disable notifier config polling for test envs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Airbrake Ruby Changelog
 
 * Deleted support for dumping/loading the remote config
   ([#621](https://github.com/airbrake/airbrake-ruby/pull/621))
+* Stopped fetching notifier config when Airbrake's environment is configured to
+  `test` ([#622](https://github.com/airbrake/airbrake-ruby/pull/622))
 
 ### [v5.0.2][v5.0.2] (August 18, 2020)
 

--- a/lib/airbrake-ruby/config/processor.rb
+++ b/lib/airbrake-ruby/config/processor.rb
@@ -42,6 +42,7 @@ module Airbrake
       # @return [Airbrake::RemoteSettings]
       def process_remote_configuration
         return unless @project_id
+        return if @config.environment == 'test'
 
         RemoteSettings.poll(@project_id, @config.remote_config_host) do |data|
           @poll_callback.call(data)

--- a/spec/config/processor_spec.rb
+++ b/spec/config/processor_spec.rb
@@ -53,9 +53,18 @@ RSpec.describe Airbrake::Config::Processor do
       end
     end
 
+    context "when the config sets environment to 'test'" do
+      let(:config) { Airbrake::Config.new(project_id: 123, environment: 'test') }
+
+      it "doesn't set remote settings" do
+        expect(Airbrake::RemoteSettings).not_to receive(:poll)
+        described_class.new(config).process_remote_configuration
+      end
+    end
+
     context "when the config defines a project_id" do
       let(:config) do
-        Airbrake::Config.new(project_id: 123)
+        Airbrake::Config.new(project_id: 123, environment: 'not-test')
       end
 
       it "sets remote settings" do


### PR DESCRIPTION
People who depend on this library shouldn't be concerned with stubbing notifier
config HTTP GET calls in their test suites. By tying this with 'environment' we
win a lot: no need to document anything and no need to do anything for those who
depend on airbrake-ruby.