### PR TITLE
Disable remote config if remote_config_host is nil

### DIFF
--- a/lib/airbrake-ruby/config/processor.rb
+++ b/lib/airbrake-ruby/config/processor.rb
@@ -43,6 +43,7 @@ module Airbrake
       def process_remote_configuration
         return unless @project_id
         return if @config.environment == 'test'
+        return unless @config.remote_config_host
 
         RemoteSettings.poll(@project_id, @config.remote_config_host) do |data|
           @poll_callback.call(data)

--- a/spec/config/processor_spec.rb
+++ b/spec/config/processor_spec.rb
@@ -72,6 +72,15 @@ RSpec.describe Airbrake::Config::Processor do
         described_class.new(config).process_remote_configuration
       end
     end
+
+    context "when the config doesn't define a remote_config_host" do
+      let(:config) { Airbrake::Config.new(project_id: 123, remote_config_host: nil) }
+
+      it "doesn't set remote settings" do
+        expect(Airbrake::RemoteSettings).not_to receive(:poll)
+        described_class.new(config).process_remote_configuration
+      end
+    end
   end
 
   describe "#add_filters" do


### PR DESCRIPTION
This PR allow to developers to disable the remote config feature if set `remote_config_host` to `nil` in Airbrake configuration. Related with: #626 