### PR TITLE
Add `remote_config` and use it instead of `remote_config_host: nil` to disable notifier config polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,6 @@ Airbrake Ruby Changelog
 
 ### master
 
-* Added ability to disable remote configuration by setting `remote_config_host`
-  to `nil` ([#632](https://github.com/airbrake/airbrake-ruby/pull/632))
 * Added the `remote_config` option. This option configures the remote
   configuration feature
   ([#634](https://github.com/airbrake/airbrake-ruby/pull/634))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Airbrake Ruby Changelog
 
 * Added ability to disable remote configuration by setting `remote_config_host`
   to `nil` ([#632](https://github.com/airbrake/airbrake-ruby/pull/632))
+* Added the `remote_config` option. This option configures the remote
+  configuration feature
+  ([#634](https://github.com/airbrake/airbrake-ruby/pull/634))
 
 ### [v5.1.1][v5.1.1] (November 17, 2020)
 

--- a/README.md
+++ b/README.md
@@ -458,10 +458,6 @@ Airbrake.configure do |c|
 end
 ```
 
-Note: setting this option to `nil` will disable the remote configuration
-feature. It also might negatively impact how your notifier works. Please use
-this option with caution.
-
 #### remote_config
 
 Configures the remote configuration feature. At regular intervals the notifier

--- a/README.md
+++ b/README.md
@@ -462,6 +462,16 @@ Note: setting this option to `nil` will disable the remote configuration
 feature. It also might negatively impact how your notifier works. Please use
 this option with caution.
 
+#### remote_config
+
+Configures the remote configuration feature. At regular intervals the notifier
+will be making `GET` requests to Airbrake servers and fetching a JSON document
+containing configuration settings of the notifier. The notifier will apply these
+new settings at runtime. By default, it is enabled.
+
+Note: it is not recommended to disable this feature. It might negatively impact
+how your notifier works. Please use this option with caution.
+
 ### Asynchronous Airbrake options
 
 The options listed below apply to [`Airbrake.notify`](#airbrakenotify), they do

--- a/lib/airbrake-ruby/config.rb
+++ b/lib/airbrake-ruby/config.rb
@@ -130,6 +130,12 @@ module Airbrake
     # @since v5.0.0
     attr_accessor :remote_config_host
 
+    # @return [String] true if notifier should periodically fetch remote
+    #   configuration, false otherwise
+    # @api public
+    # @since v5.2.0
+    attr_accessor :remote_config
+
     class << self
       # @return [Config]
       attr_writer :instance
@@ -142,7 +148,7 @@ module Airbrake
 
     # @param [Hash{Symbol=>Object}] user_config the hash to be used to build the
     #   config
-    # rubocop:disable Metrics/AbcSize
+    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     def initialize(user_config = {})
       self.proxy = {}
       self.queue_size = 100
@@ -173,10 +179,11 @@ module Airbrake
       self.query_stats = true
       self.job_stats = true
       self.error_notifications = true
+      self.remote_config = true
 
       merge(user_config)
     end
-    # rubocop:enable Metrics/AbcSize
+    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
     # The full URL to the Airbrake Notice API. Based on the +:error_host+ option.
     # @return [URI] the endpoint address

--- a/lib/airbrake-ruby/config/processor.rb
+++ b/lib/airbrake-ruby/config/processor.rb
@@ -41,9 +41,9 @@ module Airbrake
 
       # @return [Airbrake::RemoteSettings]
       def process_remote_configuration
+        return unless @config.remote_config
         return unless @project_id
         return if @config.environment == 'test'
-        return unless @config.remote_config_host
 
         RemoteSettings.poll(@project_id, @config.remote_config_host) do |data|
           @poll_callback.call(data)

--- a/spec/config/processor_spec.rb
+++ b/spec/config/processor_spec.rb
@@ -73,8 +73,8 @@ RSpec.describe Airbrake::Config::Processor do
       end
     end
 
-    context "when the config doesn't define a remote_config_host" do
-      let(:config) { Airbrake::Config.new(project_id: 123, remote_config_host: nil) }
+    context "when the config disables the remote_config option" do
+      let(:config) { Airbrake::Config.new(project_id: 123, remote_config: false) }
 
       it "doesn't set remote settings" do
         expect(Airbrake::RemoteSettings).not_to receive(:poll)

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe Airbrake::Config do
   its(:query_stats) { is_expected.to eq(true) }
   its(:job_stats) { is_expected.to eq(true) }
   its(:error_notifications) { is_expected.to eq(true) }
+  its(:remote_config) { is_expected.to eq(true) }
 
   its(:remote_config_host) do
     is_expected.to eq('https://notifier-configs.airbrake.io')


### PR DESCRIPTION
Instead of setting `remote_config_host` to `nil`, which looks like a hack, users
are supposed to configure the `remote_config` option.