### PR TITLE
filters/thread: delete Thread#name check

### DIFF
--- a/lib/airbrake-ruby/filters/thread_filter.rb
+++ b/lib/airbrake-ruby/filters/thread_filter.rb
@@ -41,8 +41,7 @@ module Airbrake
           thread_info[:fiber_variables] = vars
         end
 
-        # Present in Ruby 2.3+.
-        if th.respond_to?(:name) && (name = th.name)
+        if (name = th.name)
           thread_info[:name] = name
         end
 

--- a/spec/filters/thread_filter_spec.rb
+++ b/spec/filters/thread_filter_spec.rb
@@ -234,7 +234,7 @@ RSpec.describe Airbrake::Filters::ThreadFilter do
     end
   end
 
-  it "appends name", skip: !Thread.current.respond_to?(:name) do
+  it "appends name" do
     new_thread do |th|
       th.name = 'bingo'
       subject.call(notice)


### PR DESCRIPTION
We no longer support Ruby 2.2 and lower, so `#name` is always available to us.