### PR TITLE
Add `remote_config_logging` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,6 +476,22 @@ end
 Note: it is not recommended to disable this feature. It might negatively impact
 how your notifier works. Please use this option with caution.
 
+#### remote_config_logging
+
+Configures logging from the remote configuration feature. At intervals as
+described above, new settings will be fetched and output to the logger. These
+may be disabled to avoid extra log-lines, but maintaining the other logs that
+this gem will write.
+
+To silance the log-lines, configure as such:
+
+```rb
+Airbrake.configure do |c|
+  c.remote_config = true
+  c.remote_config_logging = false
+end
+```
+
 ### Asynchronous Airbrake options
 
 The options listed below apply to [`Airbrake.notify`](#airbrakenotify), they do

--- a/lib/airbrake-ruby/config.rb
+++ b/lib/airbrake-ruby/config.rb
@@ -136,6 +136,11 @@ module Airbrake
     # @since v5.2.0
     attr_accessor :remote_config
 
+    # @return [Boolean] true if notifier should log when fetching remote
+    #   configuration, false otherwise
+    # @api public
+    attr_accessor :remote_config_logging
+
     class << self
       # @return [Config]
       attr_writer :instance
@@ -180,6 +185,7 @@ module Airbrake
       self.job_stats = true
       self.error_notifications = true
       self.remote_config = true
+      self.remote_config_logging = true
 
       merge(user_config)
     end

--- a/lib/airbrake-ruby/remote_settings/callback.rb
+++ b/lib/airbrake-ruby/remote_settings/callback.rb
@@ -6,6 +6,7 @@ module Airbrake
     # @api private
     # @since v5.0.2
     class Callback
+      # @param [Airbrake::Config] config
       def initialize(config)
         @config = config
         @orig_error_notifications = config.error_notifications
@@ -15,8 +16,10 @@ module Airbrake
       # @param [Airbrake::RemoteSettings::SettingsData] data
       # @return [void]
       def call(data)
-        @config.logger.debug do
-          "#{LOG_LABEL} applying remote settings: #{data.to_h}"
+        if @config.remote_config_logging
+          @config.logger.debug do
+            "#{LOG_LABEL} applying remote settings: #{data.to_h}"
+          end
         end
 
         @config.error_host = data.error_host if data.error_host

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe Airbrake::Config do
   its(:job_stats) { is_expected.to eq(true) }
   its(:error_notifications) { is_expected.to eq(true) }
   its(:remote_config) { is_expected.to eq(true) }
+  its(:remote_config_logging) { is_expected.to eq(true) }
 
   its(:remote_config_host) do
     is_expected.to eq('https://notifier-configs.airbrake.io')

--- a/spec/remote_settings/callback_spec.rb
+++ b/spec/remote_settings/callback_spec.rb
@@ -21,11 +21,21 @@ RSpec.describe Airbrake::RemoteSettings::Callback do
       allow(data).to receive(:performance_stats?)
     end
 
-    it "logs given data" do
-      expect(logger).to receive(:debug) do |&block|
-        expect(block.call).to match(/applying remote settings/)
+    context "when remote_config_logging is true" do
+      it "logs given data" do
+        expect(logger).to receive(:debug) do |&block|
+          expect(block.call).to match(/applying remote settings/)
+        end
+        described_class.new(config).call(data)
       end
-      described_class.new(config).call(data)
+    end
+
+    context "when remote_config_logging is false" do
+      it "does not log data" do
+        expect(logger).to_not receive(:debug)
+        config.remote_config_logging = false
+        described_class.new(config).call(data)
+      end
     end
 
     context "when the config disables error notifications" do


### PR DESCRIPTION
Adds a new configuration option `remote_config_logging` to avoid logging in certain situations, such as when running in Rails console (`defined?(Rails::Console)`) or similar.

This idea came from having long-running consoles and/or one-off jobs.

Other ideas:
- Might want to add proc/callable support for the option, to do things such as `config.remote_config_logging = ->{defined?(Rails::Console)}` or more advanced cases. Should run from app-server, but not from sidekiq/resque instance? etc.