### PR TITLE
async_sender: improve logging when closing thread pools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Airbrake Ruby Changelog
 
 ### master
 
+* Improved logging on closing notifiers
+  ([#644](https://github.com/airbrake/airbrake-ruby/pull/644))
+
 ### [v5.2.0][v5.2.0] (December 4, 2020)
 
 * Added the `remote_config` option. This option configures the remote

--- a/lib/airbrake-ruby/async_sender.rb
+++ b/lib/airbrake-ruby/async_sender.rb
@@ -7,9 +7,10 @@ module Airbrake
   class AsyncSender
     include Loggable
 
-    def initialize(method = :post)
+    def initialize(method = :post, name = 'async-sender')
       @config = Airbrake::Config.instance
       @method = method
+      @name = name
     end
 
     # Asynchronously sends a notice to Airbrake.
@@ -47,6 +48,7 @@ module Airbrake
       @thread_pool ||= begin
         sender = SyncSender.new(@method)
         ThreadPool.new(
+          name: @name,
           worker_size: @config.workers,
           queue_size: @config.queue_size,
           block: proc { |args| sender.send(*args) },

--- a/lib/airbrake-ruby/notice_notifier.rb
+++ b/lib/airbrake-ruby/notice_notifier.rb
@@ -22,7 +22,7 @@ module Airbrake
       @config = Airbrake::Config.instance
       @context = {}
       @filter_chain = FilterChain.new
-      @async_sender = AsyncSender.new
+      @async_sender = AsyncSender.new(:post, self.class.name)
       @sync_sender = SyncSender.new
 
       DEFAULT_FILTERS.each { |filter| add_filter(filter.new) }

--- a/lib/airbrake-ruby/performance_notifier.rb
+++ b/lib/airbrake-ruby/performance_notifier.rb
@@ -12,7 +12,7 @@ module Airbrake
     def initialize
       @config = Airbrake::Config.instance
       @flush_period = Airbrake::Config.instance.performance_stats_flush_period
-      @async_sender = AsyncSender.new(:put)
+      @async_sender = AsyncSender.new(:put, self.class.name)
       @sync_sender = SyncSender.new(:put)
       @schedule_flush = nil
       @filter_chain = FilterChain.new
@@ -51,7 +51,6 @@ module Airbrake
       @payload.synchronize do
         @schedule_flush.kill if @schedule_flush
         @async_sender.close
-        logger.debug("#{LOG_LABEL} performance notifier closed")
       end
     end
 

--- a/lib/airbrake-ruby/thread_pool.rb
+++ b/lib/airbrake-ruby/thread_pool.rb
@@ -6,6 +6,7 @@ module Airbrake
   #   # Initialize a new thread pool with 5 workers and a queue size of 100. Set
   #   # the block to be run concurrently.
   #   thread_pool = ThreadPool.new(
+  #     name: 'performance-notifier',
   #     worker_size: 5,
   #     queue_size: 100,
   #     block: proc { |message| print "ECHO: #{message}..."}
@@ -24,7 +25,8 @@ module Airbrake
     # @note This is exposed for eaiser unit testing
     attr_reader :workers
 
-    def initialize(worker_size:, queue_size:, block:)
+    def initialize(name: nil, worker_size:, queue_size:, block:)
+      @name = name
       @worker_size = worker_size
       @queue_size = queue_size
       @block = block
@@ -111,7 +113,7 @@ module Airbrake
       end
 
       threads.each(&:join)
-      logger.debug("#{LOG_LABEL} thread pool closed")
+      logger.debug("#{LOG_LABEL} #{@name} thread pool closed")
     end
 
     def closed?

--- a/spec/performance_notifier_spec.rb
+++ b/spec/performance_notifier_spec.rb
@@ -605,7 +605,7 @@ RSpec.describe Airbrake::PerformanceNotifier do
     it "logs the exit message" do
       allow(Airbrake::Loggable.instance).to receive(:debug)
       expect(Airbrake::Loggable.instance).to receive(:debug).with(
-        /performance notifier closed/,
+        /Airbrake::PerformanceNotifier thread pool closed/,
       )
       subject.close
     end

--- a/spec/thread_pool_spec.rb
+++ b/spec/thread_pool_spec.rb
@@ -127,13 +127,13 @@ RSpec.describe Airbrake::ThreadPool do
     context "when there's some work to do" do
       it "logs how many tasks are left to process" do
         thread_pool = described_class.new(
-          worker_size: 0, queue_size: 2, block: proc {},
+          name: 'foo', worker_size: 0, queue_size: 2, block: proc {},
         )
 
         expect(Airbrake::Loggable.instance).to receive(:debug).with(
           /waiting to process \d+ task\(s\)/,
         )
-        expect(Airbrake::Loggable.instance).to receive(:debug).with(/closed/)
+        expect(Airbrake::Loggable.instance).to receive(:debug).with(/foo.+closed/)
 
         2.times { thread_pool << 1 }
         thread_pool.close


### PR DESCRIPTION
Instead of printing `thread pool closed` twice (for perf notifier and for notice
notifier), we print two separate log messages, so that it looks less confusing
why the same message was printed twice.