### PR TITLE
usefull add_filter example - exception message match 

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,6 +590,7 @@ Instead, you can ignore notices based on some condition.
 ```ruby
 Airbrake.add_filter do |notice|
   notice.ignore! if notice.stash[:exception].is_a?(StandardError)
+  notice.ignore! if notice.stash[:exception].message.match(/Couldn't find ActiveStorage::Blob with 'id'/)
 end
 ```
 


### PR DESCRIPTION
it's obvious but will help tone of developers that are not aware that Exceptions in ruby can be matched as string