### PR TITLE
usefull add_filter example - exception condition by ENV variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,6 +590,7 @@ Instead, you can ignore notices based on some condition.
 ```ruby
 Airbrake.add_filter do |notice|
   notice.ignore! if notice.stash[:exception].is_a?(StandardError)
+  notice.ignore! if notice.stash[:exception].is_a?(Net::ReadTimeout) if ENV['HOSTNAME'].match('storage-server')
 end
 ```
 


### PR DESCRIPTION
for more inspirations for developers trying to avoid Airbrake notifying every message on every host 