### PR TITLE
add_filter example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,6 +590,10 @@ Instead, you can ignore notices based on some condition.
 ```ruby
 Airbrake.add_filter do |notice|
   notice.ignore! if notice.stash[:exception].is_a?(StandardError)
+
+  if notice.stash[:exception].message.match(/Couldn't find Record/)
+    notice.ignore!
+  end
 end
 ```
 


### PR DESCRIPTION
related to discussion in
* https://github.com/airbrake/airbrake-ruby/pull/649
* https://github.com/airbrake/airbrake-ruby/pull/648
@kyrylo 

In the end I've decided just to submit this one example as the example with ENV variables is ugly once limited to 80 chars per line (and will just confuse everyone)