### PR TITLE
thread_pool: change severity of "full queue" msg from error to info

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -137,3 +137,6 @@ RSpec/MultipleMemoizedHelpers:
 
 RSpec/AnyInstance:
   Enabled: false
+
+Layout/LineEndStringConcatenationIndentation:
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ Airbrake Ruby Changelog
 
 ### master
 
+* Changed the severity of the log message that gets printed when AsyncSender's
+  thread pool capacity reaches the limit from `error` to `info`. With this new
+  severity the message will be silenced by default.
+  ([#667](https://github.com/airbrake/airbrake-ruby/pull/667))
+
 ### [v6.0.0][v6.0.0] (September 20, 2021)
 
 Breaking changes:

--- a/lib/airbrake-ruby/filters/git_last_checkout_filter.rb
+++ b/lib/airbrake-ruby/filters/git_last_checkout_filter.rb
@@ -72,7 +72,7 @@ module Airbrake
         return unless File.exist?(head_path)
 
         last_line = nil
-        IO.foreach(head_path) do |line|
+        File.foreach(head_path) do |line|
           last_line = line if checkout_line?(line)
         end
         last_line

--- a/lib/airbrake-ruby/thread_pool.rb
+++ b/lib/airbrake-ruby/thread_pool.rb
@@ -48,11 +48,11 @@ module Airbrake
     #   false if the queue is full
     def <<(message)
       if backlog >= @queue_size
-        logger.error(
+        logger.info do
           "#{LOG_LABEL} ThreadPool has reached its capacity of " \
           "#{@queue_size} and the following message will not be " \
-          "processed: #{message.inspect}",
-        )
+          "processed: #{message.inspect}"
+        end
         return false
       end
 

--- a/spec/filters/git_revision_filter_spec.rb
+++ b/spec/filters/git_revision_filter_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Airbrake::Filters::GitRevisionFilter do
         end
       end
 
-      context "and also when HEAD starts with 'ref: " do
+      context "and also when HEAD starts with 'ref: '" do
         before do
           allow(File).to(
             receive(:read).with('root/dir/.git/HEAD').and_return("ref: refs/foo\n"),

--- a/spec/thread_pool_spec.rb
+++ b/spec/thread_pool_spec.rb
@@ -55,14 +55,13 @@ RSpec.describe Airbrake::ThreadPool do
       end
 
       it "logs discarded tasks" do
-        allow(Airbrake::Loggable.instance).to receive(:error)
+        allow(Airbrake::Loggable.instance).to receive(:info)
 
         15.times { full_thread_pool << 1 }
         full_thread_pool.close
 
-        expect(Airbrake::Loggable.instance).to have_received(:error).with(
-          /reached its capacity/,
-        ).exactly(15).times
+        expect(Airbrake::Loggable.instance)
+          .to have_received(:info).exactly(15).times
       end
     end
   end


### PR DESCRIPTION
Some of our users complained that `message.inspect` "pressures" their server
memory. Indeed, the dumped string can be large (up to 64KB).

Instead, let's change the severity of this message to `info`, so that it won't
be printed by default. It's not really an error anyway, and the `info` severity
suits it perfectly.

`message.inspect` also won't be called by default anymore, since it's wrapped in
a block now.
