### PR TITLE
remote_settings: add supports for proxies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Airbrake Ruby Changelog
   thread pool capacity reaches the limit from `error` to `info`. With this new
   severity the message will be silenced by default.
   ([#667](https://github.com/airbrake/airbrake-ruby/pull/667))
+* Added support for proxies when fetching remote configs
+  ([#668](https://github.com/airbrake/airbrake-ruby/pull/668))
 
 ### [v6.0.0][v6.0.0] (September 20, 2021)
 

--- a/spec/remote_settings_spec.rb
+++ b/spec/remote_settings_spec.rb
@@ -85,8 +85,12 @@ RSpec.describe Airbrake::RemoteSettings do
     end
 
     context "when an error is raised while making a HTTP request" do
+      let(:https) { instance_double(Net::HTTP) }
+
       before do
-        allow(Net::HTTP).to receive(:get_response).and_raise(StandardError)
+        allow(Net::HTTP).to receive(:new).and_return(https)
+        allow(https).to receive(:use_ssl=).with(true)
+        allow(https).to receive(:request).and_raise(StandardError)
       end
 
       it "doesn't fetch remote settings" do


### PR DESCRIPTION
Fixes #666 (Enable proxy when fetching remote config)