### PR TITLE
Workaround in TimeTruncate with Rails 7.0.0

### DIFF
--- a/lib/airbrake-ruby/time_truncate.rb
+++ b/lib/airbrake-ruby/time_truncate.rb
@@ -9,7 +9,8 @@ module Airbrake
     # @param [Time] time
     # @return [String]
     def self.utc_truncate_minutes(time)
-      tm = time.getutc
+      # time does not have getutc method instead of Time on Rails 7.0.0
+      tm = time.respond_to?(:getutc) ? time.getutc : Time.at(time).getutc
 
       Time.utc(tm.year, tm.month, tm.day, tm.hour, tm.min).to_datetime.rfc3339
     end

--- a/spec/time_truncate_spec.rb
+++ b/spec/time_truncate_spec.rb
@@ -11,5 +11,11 @@ RSpec.describe Airbrake::TimeTruncate do
       expect(described_class.utc_truncate_minutes(time))
         .to eq('2018-01-01T05:00:00+00:00')
     end
+
+    it "converts it well even if the argument is an instance of Float" do
+      time = Time.new(2018, 1, 1, 0, 0, 20, '-05:00').to_f
+      expect(described_class.utc_truncate_minutes(time))
+        .to eq('2018-01-01T05:00:00+00:00')
+    end
   end
 end


### PR DESCRIPTION
`time` argument in `Airbrake::TimeTruncate` is now a Float in Rails 7.0.0 unlike an instance of `Time` in Rails 6.x or earlier.

Relates to airbrake/airbrake#1205

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>