### PR TITLE
airbrake-ruby/filters/git_repository_filter: fix Errno::EAGAIN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Airbrake Ruby Changelog
 
 ### master
 
+* Fixed `Errno::EAGAIN`, which may happen in certain environments when
+  configuring Airbrake
+  ([#684](https://github.com/airbrake/airbrake-ruby/pull/684))
+
 ### [v6.0.2][v6.0.2] (January 10, 2022)
 
 * Fixed `NoMethodError: undefined method `getutc'` for `#notify_request` and

--- a/lib/airbrake-ruby/filters/git_repository_filter.rb
+++ b/lib/airbrake-ruby/filters/git_repository_filter.rb
@@ -49,7 +49,13 @@ module Airbrake
       def detect_git_version
         return unless which('git')
 
-        Gem::Version.new(`git --version`.split[2])
+        begin
+          Gem::Version.new(`git --version`.split[2])
+        rescue Errno::EAGAIN
+          # Bugfix for the case when the system cannot allocate memory for
+          # a fork() call: https://github.com/airbrake/airbrake-ruby/issues/680
+          nil
+        end
       end
 
       # Cross-platform way to tell if an executable is accessible.

--- a/spec/filters/git_repository_filter_spec.rb
+++ b/spec/filters/git_repository_filter_spec.rb
@@ -21,6 +21,14 @@ RSpec.describe Airbrake::Filters::GitRepositoryFilter do
         .to receive(:`).and_return('git version 2.17.2 (Apple Git-113)')
       expect { git_repository_filter }.not_to raise_error
     end
+
+    context "when Errno::EAGAIN is raised when detecting git version" do
+      it "doesn't attach anything to context/repository" do
+        allow_any_instance_of(Kernel).to receive(:`).and_raise(Errno::EAGAIN)
+        git_repository_filter.call(notice)
+        expect(notice[:context][:repository]).to be_nil
+      end
+    end
   end
 
   context "when context/repository is defined" do


### PR DESCRIPTION
Fixes https://github.com/airbrake/airbrake-ruby/issues/680
(Errno::EAGAIN: Resource temporarily unavailable with falcon)