### PR TITLE
config: don't poll remote config if the current env is ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Airbrake Ruby Changelog
 * Fixed `Errno::EAGAIN`, which may happen in certain environments when
   configuring Airbrake
   ([#684](https://github.com/airbrake/airbrake-ruby/pull/684))
+* The `ignore_environments` option can now control remote configuration. If the
+  current `environment` matches an environment specified in
+  `ignore_environments`, then the remote configuration won't be fetched. This is
+  equivalent to having `remote_config = false`
+  ([#685](https://github.com/airbrake/airbrake-ruby/pull/685))
 
 ### [v6.0.2][v6.0.2] (January 10, 2022)
 

--- a/lib/airbrake-ruby/config/processor.rb
+++ b/lib/airbrake-ruby/config/processor.rb
@@ -43,7 +43,13 @@ module Airbrake
       def process_remote_configuration
         return unless @config.remote_config
         return unless @project_id
+
+        # Never poll remote configuration in the test environment.
         return if @config.environment == 'test'
+
+        # If the current environment is ignored, don't try to poll remote
+        # configuration.
+        return if @config.ignore_environments.include?(@config.environment)
 
         RemoteSettings.poll(@project_id, @config.remote_config_host) do |data|
           @poll_callback.call(data)

--- a/spec/config/processor_spec.rb
+++ b/spec/config/processor_spec.rb
@@ -68,6 +68,22 @@ RSpec.describe Airbrake::Config::Processor do
       end
     end
 
+    context "when the config sets :ignore_environments and :environment matches" do
+      let(:config) do
+        Airbrake::Config.new(
+          project_id: 123,
+          ignore_environments: %w[dev],
+          environment: 'dev',
+        )
+      end
+
+      it "doesn't set remote settings" do
+        described_class.new(config).process_remote_configuration
+
+        expect(Airbrake::RemoteSettings).not_to have_received(:poll)
+      end
+    end
+
     context "when the config defines a project_id" do
       let(:config) do
         Airbrake::Config.new(project_id: 123, environment: 'not-test')


### PR DESCRIPTION
Fixes #679
(Remote configuration is polled for despite ignore_environments)