### PR TITLE
nested_exception: add support for Ruby 3.1 error with highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Airbrake Ruby Changelog
 
 ### master
 
+* Improved support of Ruby 3.1's error highlighting. The error highlighting now
+  gets stripped from the exception message. The error message with the
+  highlighting gets added to `context/error_message`
+  ([#690](https://github.com/airbrake/airbrake-ruby/pull/690))
+
+
 ### [v6.1.0][v6.1.0] (April 13, 2022)
 
 * Fixed `Errno::EAGAIN`, which may happen in certain environments when

--- a/lib/airbrake-ruby/nested_exception.rb
+++ b/lib/airbrake-ruby/nested_exception.rb
@@ -9,6 +9,15 @@ module Airbrake
     #   can unwrap. Exceptions that have a longer cause chain will be ignored
     MAX_NESTED_EXCEPTIONS = 3
 
+    # On Ruby 3.1+, the error highlighting gem can produce messages that can
+    # span multiple lines. We don't display multiline error messages in the
+    # title of the notice in the Airbrake dashboard. Therefore, we want to strip
+    # out the higlighting part so that the errors look consistent. The full
+    # message with the exception will be attached to the notice body.
+    #
+    # @return [String]
+    RUBY_31_ERROR_HIGHLIGHTING_DIVIDER = "\n\n".freeze
+
     def initialize(exception)
       @exception = exception
     end
@@ -16,7 +25,7 @@ module Airbrake
     def as_json
       unwind_exceptions.map do |exception|
         { type: exception.class.name,
-          message: exception.message,
+          message: exception.message.split(RUBY_31_ERROR_HIGHLIGHTING_DIVIDER).first,
           backtrace: Backtrace.parse(exception) }
       end
     end

--- a/spec/nested_exception_spec.rb
+++ b/spec/nested_exception_spec.rb
@@ -47,6 +47,20 @@ RSpec.describe Airbrake::NestedException do
         expect(exceptions[1][:backtrace]).not_to be_empty
       end
       # rubocop:enable RSpec/MultipleExpectations
+
+      context "and when the exception message contains error highlighting" do
+        it "strips the highlighting part from the message" do
+          raise "undefined method `[]' for nil:NilClass\n\n    " \
+            "data[:result].first[:first_name]\n                       ^^^^^^^^^^^^^"
+        rescue StandardError => ex
+          nested_exception = described_class.new(ex)
+          exceptions = nested_exception.as_json
+
+          expect(exceptions.size).to eq(1)
+          expect(exceptions[0][:message])
+            .to eq("undefined method `[]' for nil:NilClass")
+        end
+      end
     end
 
     context "given exceptions without backtraces" do

--- a/spec/notice_spec.rb
+++ b/spec/notice_spec.rb
@@ -49,6 +49,13 @@ RSpec.describe Airbrake::Notice do
     end
 
     context "truncation" do
+      it "truncates context/error_message" do
+        msg = 'message-' * 64000
+        notice = described_class.new(StandardError.new(msg))
+        expect(notice[:context][:error_message]).to(include('message-[Truncated]'))
+        expect(notice[:context][:error_message].length).to be < msg.length
+      end
+
       shared_examples 'payloads' do |size, msg|
         it msg do
           ex = AirbrakeTestError.new


### PR DESCRIPTION
Addresses https://github.com/airbrake/airbrake/issues/1230

Error highlighting is not good for our grouping. Therefore, we need to strip it from
the error message prior to reporting to Airbrake. The unstripped version of the
error is now attached to `context/error_message`.