### PR TITLE
nested_exception: don't crash when the exception's message is nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Airbrake Ruby Changelog
 * Fixed `ArgumentError: invalid byte sequence in UTF-8` which could be raised
   during notifying exceptions with invalid characters in their messages
   ([#694](https://github.com/airbrake/airbrake-ruby/pull/694))
+* Fixed `NoMethodError: undefined method `split' for nil:NilClass` when the
+  given exception sets its message to `nil`
+  ([#698](https://github.com/airbrake/airbrake-ruby/pull/698))
 
 ### [v6.1.1][v6.1.1] (June 15, 2022)
 

--- a/lib/airbrake-ruby/nested_exception.rb
+++ b/lib/airbrake-ruby/nested_exception.rb
@@ -48,8 +48,9 @@ module Airbrake
     end
 
     def message(exception)
-      exception
-        .message
+      return unless (msg = exception.message)
+
+      msg
         .encode(Encoding::UTF_8, **ENCODING_OPTIONS)
         .split(RUBY_31_ERROR_HIGHLIGHTING_DIVIDER)
         .first

--- a/spec/nested_exception_spec.rb
+++ b/spec/nested_exception_spec.rb
@@ -95,4 +95,20 @@ RSpec.describe Airbrake::NestedException do
       raise 'expected JSON.parse to raise JSON::ParserError but nothing was raised'
     end
   end
+
+  context "when the exception's message is nil" do
+    subject(:exception) {  Class.new(StandardError) { def message; end }.new }
+
+    it "leaves the message field empty" do
+      expect(described_class.new(exception).as_json).to eq(
+        [
+          {
+            backtrace: [],
+            message: nil,
+            type: nil,
+          },
+        ],
+      )
+    end
+  end
 end


### PR DESCRIPTION
Fixes #697
(Exceptions with nil for message cause error in v6.1.1)