### PR TITLE
Add Backlog

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,6 +478,23 @@ end
 Note: it is not recommended to disable this feature. It might negatively impact
 how your notifier works. Please use this option with caution.
 
+#### backlog
+
+Turns on/off the backlog feature. The backlog keeps track of errors or events
+that Airbrake Ruby couldn't send due to a faulty network, Airbake API being at
+send time, etc. The backlog is flushed every 2 minutes, meaning everything in
+the backlog will be attempted to be sent to the Airbrake API again. If the error
+or event can't be successfully sent from the backlog, it gets rejected
+permanently.
+
+The maximum backlog size is 100. By default, it's enabled.
+
+```ruby
+Airbrake.configure do |c|
+  c.backlog = true
+end
+```
+
 ### Asynchronous Airbrake options
 
 The options listed below apply to [`Airbrake.notify`](#airbrakenotify), they do

--- a/lib/airbrake-ruby.rb
+++ b/lib/airbrake-ruby.rb
@@ -18,9 +18,9 @@ require 'airbrake-ruby/remote_settings/settings_data'
 require 'airbrake-ruby/remote_settings'
 require 'airbrake-ruby/promise'
 require 'airbrake-ruby/thread_pool'
+require 'airbrake-ruby/response'
 require 'airbrake-ruby/sync_sender'
 require 'airbrake-ruby/async_sender'
-require 'airbrake-ruby/response'
 require 'airbrake-ruby/nested_exception'
 require 'airbrake-ruby/ignorable'
 require 'airbrake-ruby/inspectable'
@@ -59,6 +59,7 @@ require 'airbrake-ruby/monotonic_time'
 require 'airbrake-ruby/timed_trace'
 require 'airbrake-ruby/queue'
 require 'airbrake-ruby/context'
+require 'airbrake-ruby/backlog'
 
 # Airbrake is a thin wrapper around instances of the notifier classes (such as
 # notice, performance & deploy notifiers). It creates a way to access them via a

--- a/lib/airbrake-ruby/async_sender.rb
+++ b/lib/airbrake-ruby/async_sender.rb
@@ -9,7 +9,7 @@ module Airbrake
 
     def initialize(method = :post, name = 'async-sender')
       @config = Airbrake::Config.instance
-      @method = method
+      @sync_sender = SyncSender.new(method)
       @name = name
     end
 
@@ -29,6 +29,7 @@ module Airbrake
 
     # @return [void]
     def close
+      @sync_sender.close
       thread_pool.close
     end
 
@@ -45,15 +46,12 @@ module Airbrake
     private
 
     def thread_pool
-      @thread_pool ||= begin
-        sender = SyncSender.new(@method)
-        ThreadPool.new(
-          name: @name,
-          worker_size: @config.workers,
-          queue_size: @config.queue_size,
-          block: proc { |args| sender.send(*args) },
-        )
-      end
+      @thread_pool ||= ThreadPool.new(
+        name: @name,
+        worker_size: @config.workers,
+        queue_size: @config.queue_size,
+        block: proc { |args| @sync_sender.send(*args) },
+      )
     end
   end
 end

--- a/lib/airbrake-ruby/backlog.rb
+++ b/lib/airbrake-ruby/backlog.rb
@@ -1,0 +1,114 @@
+module Airbrake
+  # Backlog accepts notices and APM events and synchronously sends them in the
+  # background at regular intervals. The backlog is a queue of data that failed
+  # to be sent due to some error. In a nutshell, it's a retry mechanism.
+  #
+  # @api private
+  # @since v6.2.0
+  class Backlog
+    include Loggable
+
+    # @return [Integer] how many records to keep in the backlog
+    BACKLOG_SIZE = 100
+
+    # @return [Integer] flush period in seconds
+    TWO_MINUTES = 60 * 2
+
+    def initialize(sync_sender, flush_period = TWO_MINUTES)
+      @sync_sender = sync_sender
+      @flush_period = flush_period
+      @queue = SizedQueue.new(BACKLOG_SIZE).extend(MonitorMixin)
+      @has_backlog_data = @queue.new_cond
+      @schedule_flush = nil
+
+      @seen = Set.new
+    end
+
+    # Appends data to the backlog. Once appended, the flush schedule will
+    # start. Chainable.
+    #
+    # @example
+    #   backlog << [{ 'data' => 1 }, 'https://airbrake.io/api']
+    #
+    # @param [Array<#to_json, String>] data An array of two elements, where the
+    #   first element is the data we are sending and the second element is the
+    #   URL that we are sending to
+    # @return [self]
+    def <<(data)
+      @queue.synchronize do
+        return self if @seen.include?(data)
+
+        @seen << data
+
+        begin
+          @queue.push(data, true)
+        rescue ThreadError
+          logger.error("#{LOG_LABEL} Backlog is full")
+          return self
+        end
+
+        @has_backlog_data.signal
+        schedule_flush
+
+        self
+      end
+    end
+
+    # Closes all the resources that this sender has allocated.
+    #
+    # @return [void]
+    # @since v6.2.0
+    def close
+      @queue.synchronize { @schedule_flush.kill if @schedule_flush }
+    end
+
+    private
+
+    def schedule_flush
+      @schedule_flush ||= Thread.new do
+        loop do
+          @queue.synchronize do
+            wait
+            next if @queue.empty?
+
+            flush
+          end
+        end
+      end
+    end
+
+    def wait
+      @has_backlog_data.wait(@flush_period) while time_elapsed < @flush_period
+      @last_flush = nil
+    end
+
+    def time_elapsed
+      MonotonicTime.time_in_s - last_flush
+    end
+
+    def last_flush
+      @last_flush ||= MonotonicTime.time_in_s
+    end
+
+    def flush
+      unless @queue.empty?
+        logger.debug("#{LOG_LABEL} backlog: flushing #{@queue.size} messages")
+      end
+
+      failed = 0
+
+      until @queue.empty?
+        data, endpoint = @queue.pop
+        promise = Airbrake::Promise.new
+        @sync_sender.send(data, promise, endpoint)
+        failed += 1 if promise.rejected?
+      end
+
+      if failed > 0
+        logger.debug("#{LOG_LABEL} backlog: #{failed} messages were not flushed")
+      end
+
+      @seen.clear
+    end
+  end
+end

--- a/lib/airbrake-ruby/backlog.rb
+++ b/lib/airbrake-ruby/backlog.rb
@@ -43,7 +43,7 @@ module Airbrake
         begin
           @queue.push(data, true)
         rescue ThreadError
-          logger.error("#{LOG_LABEL} Backlog is full")
+          logger.error("#{LOG_LABEL} Airbrake::Backlog full")
           return self
         end
 
@@ -59,7 +59,12 @@ module Airbrake
     # @return [void]
     # @since v6.2.0
     def close
-      @queue.synchronize { @schedule_flush.kill if @schedule_flush }
+      @queue.synchronize do
+        if @schedule_flush
+          @schedule_flush.kill
+          logger.debug("#{LOG_LABEL} Airbrake::Backlog closed")
+        end
+      end
     end
 
     private
@@ -92,7 +97,9 @@ module Airbrake
 
     def flush
       unless @queue.empty?
-        logger.debug("#{LOG_LABEL} backlog: flushing #{@queue.size} messages")
+        logger.debug(
+          "#{LOG_LABEL} Airbrake::Backlog flushing #{@queue.size} messages",
+        )
       end
 
       failed = 0
@@ -105,7 +112,9 @@ module Airbrake
       end
 
       if failed > 0
-        logger.debug("#{LOG_LABEL} backlog: #{failed} messages were not flushed")
+        logger.debug(
+          "#{LOG_LABEL} Airbrake::Backlog #{failed} messages were not flushed",
+        )
       end
 
       @seen.clear

--- a/lib/airbrake-ruby/config.rb
+++ b/lib/airbrake-ruby/config.rb
@@ -136,6 +136,12 @@ module Airbrake
     # @since v5.2.0
     attr_accessor :remote_config
 
+    # @return [Boolean] true if the library should keep a backlog of failed
+    #   notices or APM events and retry them after an interval, false otherwise
+    # @api public
+    # @since v6.2.0
+    attr_accessor :backlog
+
     class << self
       # @return [Config]
       attr_writer :instance
@@ -180,6 +186,7 @@ module Airbrake
       self.job_stats = true
       self.error_notifications = true
       self.remote_config = true
+      self.backlog = true
 
       merge(user_config)
     end

--- a/lib/airbrake-ruby/notice_notifier.rb
+++ b/lib/airbrake-ruby/notice_notifier.rb
@@ -68,6 +68,7 @@ module Airbrake
 
     # @see Airbrake.close
     def close
+      @sync_sender.close
       @async_sender.close
     end
 

--- a/lib/airbrake-ruby/performance_notifier.rb
+++ b/lib/airbrake-ruby/performance_notifier.rb
@@ -50,6 +50,7 @@ module Airbrake
     def close
       @payload.synchronize do
         @schedule_flush.kill if @schedule_flush
+        @sync_sender.close
         @async_sender.close
       end
     end

--- a/lib/airbrake-ruby/sync_sender.rb
+++ b/lib/airbrake-ruby/sync_sender.rb
@@ -9,6 +9,20 @@ module Airbrake
     # @return [String] body for HTTP requests
     CONTENT_TYPE = 'application/json'.freeze
 
+    # @return [Array<Integer>] response codes that are good to be backlogged
+    # @since v6.2.0
+    BACKLOGGABLE_STATUS_CODES = [
+      Response::BAD_REQUEST,
+      Response::FORBIDDEN,
+      Response::ENHANCE_YOUR_CALM,
+      Response::REQUEST_TIMEOUT,
+      Response::CONFLICT,
+      Response::TOO_MANY_REQUESTS,
+      Response::INTERNAL_SERVER_ERROR,
+      Response::BAD_GATEWAY,
+      Response::GATEWAY_TIMEOUT,
+    ].freeze
+
     include Loggable
 
     # @param [Symbol] method HTTP method to use to send payload
@@ -16,6 +30,7 @@ module Airbrake
       @config = Airbrake::Config.instance
       @method = method
       @rate_limit_reset = Time.now
+      @backlog = Backlog.new(self)
     end
 
     # Sends a POST or PUT request to the given +endpoint+ with the +data+ payload.
@@ -46,9 +61,19 @@ module Airbrake
         @rate_limit_reset = parsed_resp['rate_limit_reset']
       end
 
+      @backlog << [data, endpoint] if add_to_backlog?(parsed_resp)
+
       return promise.reject(parsed_resp['error']) if parsed_resp.key?('error')
 
       promise.resolve(parsed_resp)
+    end
+
+    # Closes all the resources that this sender has allocated.
+    #
+    # @return [void]
+    # @since v6.2.0
+    def close
+      @backlog.close
     end
 
     private
@@ -84,6 +109,12 @@ module Airbrake
         "Ruby/#{RUBY_VERSION}"
 
       req
+    end
+
+    def add_to_backlog?(parsed_resp)
+      return false unless parsed_resp.key?('code')
+
+      BACKLOGGABLE_STATUS_CODES.include?(parsed_resp['code'])
     end
 
     def proxy_params

--- a/lib/airbrake-ruby/sync_sender.rb
+++ b/lib/airbrake-ruby/sync_sender.rb
@@ -30,7 +30,7 @@ module Airbrake
       @config = Airbrake::Config.instance
       @method = method
       @rate_limit_reset = Time.now
-      @backlog = Backlog.new(self)
+      @backlog = Backlog.new(self) if @config.backlog
     end
 
     # Sends a POST or PUT request to the given +endpoint+ with the +data+ payload.
@@ -41,15 +41,11 @@ module Airbrake
     def send(data, promise, endpoint = @config.error_endpoint)
       return promise if rate_limited_ip?(promise)
 
-      response = nil
       req = build_request(endpoint, data)
-
       return promise if missing_body?(req, promise)
 
-      https = build_https(endpoint)
-
       begin
-        response = https.request(req)
+        response = build_https(endpoint).request(req)
       rescue StandardError => ex
         reason = "#{LOG_LABEL} HTTP error: #{ex}"
         logger.error(reason)
@@ -57,10 +53,7 @@ module Airbrake
       end
 
       parsed_resp = Response.parse(response)
-      if parsed_resp.key?('rate_limit_reset')
-        @rate_limit_reset = parsed_resp['rate_limit_reset']
-      end
-
+      handle_rate_limit(parsed_resp)
       @backlog << [data, endpoint] if add_to_backlog?(parsed_resp)
 
       return promise.reject(parsed_resp['error']) if parsed_resp.key?('error')
@@ -111,8 +104,15 @@ module Airbrake
       req
     end
 
+    def handle_rate_limit(parsed_resp)
+      return unless parsed_resp.key?('rate_limit_reset')
+
+      @rate_limit_reset = parsed_resp['rate_limit_reset']
+    end
+
     def add_to_backlog?(parsed_resp)
-      return false unless parsed_resp.key?('code')
+      return unless @backlog
+      return unless parsed_resp.key?('code')
 
       BACKLOGGABLE_STATUS_CODES.include?(parsed_resp['code'])
     end

--- a/spec/backlog_spec.rb
+++ b/spec/backlog_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Airbrake::Backlog do
         sleep 0.2
 
         expect(Airbrake::Loggable.instance).to have_received(:error).with(
-          '**Airbrake: Backlog is full',
+          '**Airbrake: Airbrake::Backlog full',
         ).twice
       end
     end

--- a/spec/backlog_spec.rb
+++ b/spec/backlog_spec.rb
@@ -1,0 +1,76 @@
+RSpec.describe Airbrake::Backlog do
+  subject(:backlog) { described_class.new(sync_sender, 0.1) }
+
+  let(:sync_sender) { Airbrake::SyncSender.new }
+  let(:error_endpoint) { '/error' }
+  let(:event_endpoint) { '/event' }
+  let(:promise) { an_instance_of(Airbrake::Promise) }
+
+  before { allow(sync_sender).to receive(:send) }
+
+  after { backlog.close }
+
+  describe "#<<" do
+    it "returns self" do
+      expect(backlog << 1).to eq(backlog)
+    end
+
+    it "waits for the data to be processed" do
+      backlog << [1, error_endpoint] << [2, event_endpoint]
+
+      expect(sync_sender).not_to have_received(:send)
+        .with(1, promise, error_endpoint)
+      expect(sync_sender).not_to have_received(:send)
+        .with(2, promise, event_endpoint)
+    end
+
+    it "processed the data on flush" do
+      backlog << [1, error_endpoint] << [2, event_endpoint]
+
+      sleep 0.2
+
+      expect(sync_sender).to have_received(:send)
+        .with(1, promise, error_endpoint)
+      expect(sync_sender).to have_received(:send)
+        .with(2, promise, event_endpoint)
+    end
+
+    it "clears the queue after flushing" do
+      backlog << [1, error_endpoint] << [2, event_endpoint]
+
+      sleep 0.2
+
+      backlog << [3, event_endpoint] << [4, error_endpoint]
+
+      sleep 0.2
+
+      expect(sync_sender).to have_received(:send)
+        .with(3, promise, event_endpoint)
+      expect(sync_sender).to have_received(:send)
+        .with(4, promise, error_endpoint)
+    end
+
+    it "doesn't append an already appended item" do
+      backlog << [1, error_endpoint] << [1, error_endpoint] << [1, error_endpoint]
+
+      sleep 0.2
+
+      expect(sync_sender).to have_received(:send)
+        .with(1, promise, error_endpoint).once
+    end
+
+    context "when then backlog reaches its capacity of 100" do
+      before { allow(Airbrake::Loggable.instance).to receive(:error) }
+
+      it "logs errors" do
+        102.times { |i| backlog << [i, error_endpoint] }
+
+        sleep 0.2
+
+        expect(Airbrake::Loggable.instance).to have_received(:error).with(
+          '**Airbrake: Backlog is full',
+        ).twice
+      end
+    end
+  end
+end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe Airbrake::Config do
   its(:job_stats) { is_expected.to be(true) }
   its(:error_notifications) { is_expected.to be(true) }
   its(:remote_config) { is_expected.to be(true) }
+  its(:backlog) { is_expected.to be(true) }
 
   its(:remote_config_host) do
     is_expected.to eq('https://notifier-configs.airbrake.io')

--- a/spec/notice_notifier_spec.rb
+++ b/spec/notice_notifier_spec.rb
@@ -342,9 +342,24 @@ RSpec.describe Airbrake::NoticeNotifier do
   end
 
   describe "#close" do
+    let(:mock_async_sender) { instance_double(Airbrake::AsyncSender) }
+    let(:mock_sync_sender) { instance_double(Airbrake::SyncSender) }
+
+    before do
+      allow(Airbrake::AsyncSender).to receive(:new).and_return(mock_async_sender)
+      allow(Airbrake::SyncSender).to receive(:new).and_return(mock_sync_sender)
+      allow(mock_async_sender).to receive(:close)
+      allow(mock_sync_sender).to receive(:close)
+    end
+
     it "sends the close message to async sender" do
-      expect_any_instance_of(Airbrake::AsyncSender).to receive(:close)
       notice_notifier.close
+      expect(mock_async_sender).to have_received(:close)
+    end
+
+    it "sends the close message to sync sender" do
+      notice_notifier.close
+      expect(mock_sync_sender).to have_received(:close)
     end
   end
 

--- a/spec/response_spec.rb
+++ b/spec/response_spec.rb
@@ -76,13 +76,13 @@ RSpec.describe Airbrake::Response do
 
       it "returns an error response" do
         resp = described_class.parse(response)
-        expect(resp).to eq('error' => 'foo')
+        expect(resp).to eq('code' => 500, 'error' => 'foo')
       end
 
       it "truncates body" do
         response.body *= 1000
         resp = described_class.parse(response)
-        expect(resp).to eq('error' => "#{'foo' * 33}fo...")
+        expect(resp).to eq('code' => 500, 'error' => "#{'foo' * 33}fo...")
       end
     end
 


### PR DESCRIPTION
The Backlog class accepts notices and APM events and synchronously sends them in
the background at regular intervals (2 minutes).

The notices that it accepts are those that have failed to be sent due to network
issues or Airbrake servers struggling. If the second attempt fails, then such
data is discarded forever.

The maximum backlog size is 100. If we cannot add to the backlog anymore, the
item would be skipped and an error would be logged.