### PR TITLE
config: deprecate 'host'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### master
 
+- Deprecated the `host` option in favor of `error_host`
+  ([#711](https://github.com/airbrake/airbrake-ruby/pull/711))
+
 ### [v6.2.0][v6.2.0] (September 5, 2022)
 
 - Added the `backlog` option to the config, which enables or disables the

--- a/lib/airbrake-ruby/config.rb
+++ b/lib/airbrake-ruby/config.rb
@@ -44,12 +44,8 @@ module Airbrake
     # @return [String] the host, which provides the API endpoint to which
     #   exceptions should be sent
     # @api public
-    attr_accessor :host
-
     # @since v5.0.0
-    alias error_host host
-    # @since v5.0.0
-    alias error_host= host=
+    attr_accessor :error_host
 
     # @return [String] the host, which provides the API endpoint to which
     #   APM data should be sent
@@ -163,8 +159,7 @@ module Airbrake
       self.logger = ::Logger.new(File::NULL).tap { |l| l.level = Logger::WARN }
       self.project_id = user_config[:project_id]
       self.project_key = user_config[:project_key]
-      self.error_host = 'https://api.airbrake.io'
-      self.apm_host = 'https://api.airbrake.io'
+      self.error_host = self.apm_host = 'https://api.airbrake.io'
       self.remote_config_host = 'https://notifier-configs.airbrake.io'
 
       self.ignore_environments = []
@@ -267,6 +262,19 @@ module Airbrake
       else
         promise
       end
+    end
+
+    HOST_DEPRECATION_MSG = "**Airbrake: the 'host' option is deprecated. Use " \
+      "'error_host' instead".freeze
+
+    def host
+      logger.warn(HOST_DEPRECATION_MSG)
+      @error_host
+    end
+
+    def host=(value)
+      logger.warn(HOST_DEPRECATION_MSG)
+      @error_host = value
     end
 
     private

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -186,4 +186,40 @@ RSpec.describe Airbrake::Config do
       expect(config.logger.level).to eq(Logger::WARN)
     end
   end
+
+  describe "#host" do
+    let(:output) { StringIO.new }
+
+    before { config.logger = Logger.new(output) }
+
+    it "prints a deprecation warning" do
+      expect { config.host }
+        .to change(output, :string)
+        .from('')
+        .to(/the 'host' option is deprecated/)
+    end
+
+    it "returns error host" do
+      config.error_host = 'http://whatever'
+      expect(config.host).to eq('http://whatever')
+    end
+  end
+
+  describe "#host=" do
+    let(:output) { StringIO.new }
+
+    before { config.logger = Logger.new(output) }
+
+    it "prints a deprecation warning" do
+      expect { config.host = 'http://whatever' }
+        .to change(output, :string)
+        .from('')
+        .to(/the 'host' option is deprecated/)
+    end
+
+    it "sets error host" do
+      config.host = 'http://whatever'
+      expect(config.error_host).to eq('http://whatever')
+    end
+  end
 end


### PR DESCRIPTION
Fixes #710
(Set error_host and apm_host to host by default)