### PR TITLE
Do not enclose the worker ThreadGroup

### DIFF
--- a/lib/airbrake-ruby/thread_pool.rb
+++ b/lib/airbrake-ruby/thread_pool.rb
@@ -122,7 +122,6 @@ module Airbrake
 
     def spawn_workers
       @worker_size.times { @workers.add(spawn_worker) }
-      @workers.enclose
     end
 
     private

--- a/spec/thread_pool_spec.rb
+++ b/spec/thread_pool_spec.rb
@@ -180,9 +180,13 @@ RSpec.describe Airbrake::ThreadPool do
   describe "#spawn_workers" do
     after { thread_pool.close }
 
-    it "spawns an enclosed thread group" do
+    let(:worker_size) { 3 }
+
+    # We avoid enclosed thread groups since they cause issues for anyone using timeout 0.3.1
+    # More info: https://github.com/airbrake/airbrake-ruby/issues/713
+    it "spawns an unenclosed thread group" do
       expect(thread_pool.workers).to be_a(ThreadGroup)
-      expect(thread_pool.workers).to be_enclosed
+      expect(thread_pool.workers).not_to be_enclosed
     end
 
     it "spawns threads that are alive" do
@@ -190,7 +194,7 @@ RSpec.describe Airbrake::ThreadPool do
     end
 
     it "spawns exactly `workers_size` workers" do
-      expect(thread_pool.workers.list.size).to eq(worker_size)
+      expect(thread_pool.workers.list.size).to eq(3)
     end
   end
 end


### PR DESCRIPTION
Enclosing the ThreadGroup has caused issues for anyone using version 0.3.1 of the timeout gem. @thompiler and I were able to replicate the issue by running a rails 7.0.4 app with ruby version 3.2.1 and the timeout gem at version 0.3.1 `timeout, '= 0.3.1'` in the Gemfile. It was also important to run the rails server with `WEB_CONCURRENCY=3`.

```
WEB_CONCURRENCY=3 bin/rails s
```
Then watch the airbrake logs you may need to enable this in your airbrake.rb initializer. Any Net::HTTP request will trigger a timeout on the enclosed ThreadGroup and cause an issue. This could be sending an Airbrake notice, performance data or fetching the remote config.