### PR TITLE
Patch level update to fix yard issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ coverage
 .ruby-version
 .ruby-gemset
 config
+README

--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,4 @@ gem 'rubocop-rspec', '~> 2.3', require: false
 gem 'simplecov', '~> 0.16', require: false
 
 gem 'webrick', '~> 1.7' if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.0')
+gem 'yard', '0.9.28'


### PR DESCRIPTION
yard 0.9.26 is not playing well with ruby@HEAD(3.3.0 at this point) Update to 0.9.28 to fix the problem we were seeing in the github action build failures. Also ignores the README file we touch for local testing.

build failure: https://github.com/airbrake/airbrake-ruby/actions/runs/4452042204/jobs/7819342230
```
home/runner/work/airbrake-ruby/airbrake-ruby/vendor/bundle/ruby/3.3.0+0/gems/yard-0.9.26/lib/yard/templates/template.rb:179:in
`load_setup_rb': undefined method `taint' for an instance of String (NoMethodError)

            module_eval(File.read(setup_file).taint, setup_file, 1)
                                             ^^^^^^
	from /home/runner/work/airbrake-ruby/airbrake-ruby/vendor/bundle/ruby/3.3.0+0/gems/yard-0.9.26/lib/yard/templates/template.rb:87:in `initialize'
	from /home/runner/work/airbrake-ruby/airbrake-ruby/vendor/bundle/ruby/3.3.0+0/gems/yard-0.9.26/lib/yard/templates/engine.rb:61:in `template!'
	from /home/runner/work/airbrake-ruby/airbrake-ruby/vendor/bundle/ruby/3.3.0+0/gems/yard-0.9.26/lib/yard/templates/engine.rb:43:in `template'
	from /home/runner/work/airbrake-ruby/airbrake-ruby/vendor/bundle/ruby/3.3.0+0/gems/yard-0.9.26/lib/yard/templates/engine.rb:105:in `generate'
	from /home/runner/work/airbrake-ruby/airbrake-ruby/vendor/bundle/ruby/3.3.0+0/gems/yard-0.9.26/lib/yard/cli/yardoc.rb:356:in `run_generate'
	from /home/runner/work/airbrake-ruby/airbrake-ruby/vendor/bundle/ruby/3.3.0+0/gems/yard-0.9.26/lib/yard/cli/yardoc.rb:267:in `run'
	from /home/runner/work/airbrake-ruby/airbrake-ruby/vendor/bundle/ruby/3.3.0+0/gems/yard-0.9.26/lib/yard/cli/command.rb:14:in `run'
	from /home/runner/work/airbrake-ruby/airbrake-ruby/vendor/bundle/ruby/3.3.0+0/gems/yard-0.9.26/bin/yardoc:13:in `<top (required)>'
	from /home/runner/work/airbrake-ruby/airbrake-ruby/vendor/bundle/ruby/3.3.0+0/bin/yardoc:25:in `load'
	from /home/runner/work/airbrake-ruby/airbrake-ruby/vendor/bundle/ruby/3.3.0+0/bin/yardoc:25:in `<top (required)>'
	from /home/runner/.rubies/ruby-head/lib/ruby/3.3.0+0/bundler/cli/exec.rb:58:in `load'
	from /home/runner/.rubies/ruby-head/lib/ruby/3.3.0+0/bundler/cli/exec.rb:58:in `kernel_load'
	from /home/runner/.rubies/ruby-head/lib/ruby/3.3.0+0/bundler/cli/exec.rb:23:in `run'
	from /home/runner/.rubies/ruby-head/lib/ruby/3.3.0+0/bundler/cli.rb:492:in `exec'
	from /home/runner/.rubies/ruby-head/lib/ruby/3.3.0+0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
	from /home/runner/.rubies/ruby-head/lib/ruby/3.3.0+0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
	from /home/runner/.rubies/ruby-head/lib/ruby/3.3.0+0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
	from /home/runner/.rubies/ruby-head/lib/ruby/3.3.0+0/bundler/cli.rb:34:in `dispatch'
	from /home/runner/.rubies/ruby-head/lib/ruby/3.3.0+0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
	from /home/runner/.rubies/ruby-head/lib/ruby/3.3.0+0/bundler/cli.rb:28:in `start'
	from /home/runner/.rubies/ruby-head/lib/ruby/gems/3.3.0+0/gems/bundler-2.5.0.dev/libexec/bundle:45:in `block in <top (required)>'
	from /home/runner/.rubies/ruby-head/lib/ruby/3.3.0+0/bundler/friendly_errors.rb:117:in `with_friendly_errors'
	from /home/runner/.rubies/ruby-head/lib/ruby/gems/3.3.0+0/gems/bundler-2.5.0.dev/libexec/bundle:33:in `<top (required)>'
	from /home/runner/.rubies/ruby-head/bin/bundle:25:in `load'
	from /home/runner/.rubies/ruby-head/bin/bundle:25:in `<main>'
```
