### PR TITLE
Release v6.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,14 @@
 
 ### master
 
-- Deprecated the `host` option in favor of `error_host`
-  ([#711](https://github.com/airbrake/airbrake-ruby/pull/711))
+- No pending changes to be released
+
+### [v6.2.1][v6.2.1] (March 22, 2023)
+
+- Fixed ruby/timeout issue by avoiding `ThreadGroup#enclose` ([#714](https://github.com/airbrake/airbrake-ruby/pull/714))
+- Deprecated the `host` option in favor of `error_host` ([#711](https://github.com/airbrake/airbrake-ruby/pull/711))
+- Updated YARD dependency to work with most recent ruby ([#715](https://github.com/airbrake/airbrake-ruby/pull/715))
+- Improved a spec that was depending on the GitHub actions git setup ([#716](https://github.com/airbrake/airbrake-ruby/pull/716))
 
 ### [v6.2.0][v6.2.0] (September 5, 2022)
 

--- a/lib/airbrake-ruby/version.rb
+++ b/lib/airbrake-ruby/version.rb
@@ -3,7 +3,7 @@
 module Airbrake
   # @return [String] the library version
   # @api public
-  AIRBRAKE_RUBY_VERSION = '6.2.0'.freeze
+  AIRBRAKE_RUBY_VERSION = '6.2.1'.freeze
 
   # @return [Hash{Symbol=>String}] the information about the notifier library
   # @since v5.0.0


### PR DESCRIPTION
- Fixed ruby/timeout issue by avoiding `ThreadGroup#enclose` ([#714](https://github.com/airbrake/airbrake-ruby/pull/714))
- Deprecated the `host` option in favor of `error_host` ([#711](https://github.com/airbrake/airbrake-ruby/pull/711))
- Updated YARD dependency to work with most recent ruby ([#715](https://github.com/airbrake/airbrake-ruby/pull/715))
- Improved a spec that was depending on the GitHub actions git setup ([#716](https://github.com/airbrake/airbrake-ruby/pull/716))