### PR TITLE
Use #error_host instead of #host to avoid triggering a deprecation warning with deployment tracking

### DIFF
--- a/lib/airbrake-ruby/deploy_notifier.rb
+++ b/lib/airbrake-ruby/deploy_notifier.rb
@@ -27,7 +27,7 @@ module Airbrake
       @sender.send(
         deploy_info,
         promise,
-        URI.join(@config.host, "api/v4/projects/#{@config.project_id}/deploys"),
+        URI.join(@config.error_host, "api/v4/projects/#{@config.project_id}/deploys"),
       )
 
       promise


### PR DESCRIPTION
When using deployment tracking via `Airbrake.notify_deploy` we always get a deprecation warning:

    W, [2023-07-07T14:42:40.940088 #3280]  WARN -- : **Airbrake: the 'host' option is deprecated. Use 'error_host' instead

This commit uses `error_host` instead, so no deprecation warning is triggered.