### PR TITLE
Run CI on Ruby 3.2 and 3.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        ruby: [2.5, 2.6, 2.7, 3.0, 3.1, head, jruby, jruby-head]
+        ruby: [2.5, 2.6, 2.7, '3.0', 3.1, 3.2, 3.3, head, jruby, jruby-head]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Added Ruby 3.2 and 3.3 to the CI matrix.
In addition:
- Bump actions/checkout from v3 to v4
- Enclose 3.0 in quotes so that ruby/setup-ruby does not use 3.x instead of 3.0.
Please see https://github.com/ruby/setup-ruby/issues/252 for more details.