### PR TITLE
Add `base64` to runtime dependencies

### DIFF
--- a/airbrake-ruby.gemspec
+++ b/airbrake-ruby.gemspec
@@ -27,6 +27,8 @@ DESC
     'rubygems_mfa_required' => 'true',
   }
 
+  s.add_dependency 'base64', '~> 0.1'
+
   if defined?(JRuby)
     s.add_dependency 'rbtree-jruby', '~> 0.2'
   else


### PR DESCRIPTION
[`base64`](https://github.com/ruby/base64) will not be part of the default gems since Ruby 3.4.0. This change silences the following warning:
```
/home/runner/work/airbrake-ruby/airbrake-ruby/lib/airbrake-ruby/stat.rb:1: warning: base64 was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add base64 to your Gemfile or gemspec.
```