### PR TITLE
Update Supported Rubies section on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1291,7 +1291,7 @@ HTTP call, you need to configure your [environment](#environment) to `test`.
 
 ## Supported Rubies
 
-- CRuby >= 2.3.0
+- CRuby >= 2.5.0
 - JRuby >= 9k
 
 ## Contact


### PR DESCRIPTION
Ruby 2.3 and 2.4 are no longer supported with #663.