### PR TITLE
Separate lint tasks in another workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,16 +22,27 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
 
-      - name: Rubocop lint
-        run: if [[ "$RUBY_ENGINE" == "ruby" ]]; then bundle exec rubocop; fi
-
-      - name: YARD lint
-        run: |
-          touch README # Workaround for "incorrect" anchor links in README.md
-          bundle exec yardoc --fail-on-warning --no-progress --readme=README
-
       - name: Display Ruby version
         run: ruby -v
 
       - name: Test
         run: bundle exec rake
+
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.3
+          bundler-cache: true
+
+      - name: Rubocop lint
+        run: bundle exec rubocop
+
+      - name: YARD lint
+        run: |
+          touch README # Workaround for "incorrect" anchor links in README.md
+          bundle exec yardoc --fail-on-warning --no-progress --readme=README


### PR DESCRIPTION
I believe that lint doesn't need to be run on various Ruby versions, so it will be run only once.

By the way, there has been offences in RuboCop for some time, but it was not detected by CI.
```
Inspecting 121 files
..C........C....................................C..C....C...CC......CCCCCCCCCCCCCCCCCCCCCCCCC.CCCCCCWCCCCCCCCCCC.CCCCCCCC

Offenses:

...(truncated)

121 files inspected, 86 offenses detected, 20 offenses autocorrectable
```

Since there are many offences detected, this PR does not fix them.