### PR TITLE
Fix undefined method 'close' when config.backlog is set to false

### DIFF
--- a/lib/airbrake-ruby/sync_sender.rb
+++ b/lib/airbrake-ruby/sync_sender.rb
@@ -66,6 +66,8 @@ module Airbrake
     # @return [void]
     # @since v6.2.0
     def close
+      return unless @backlog
+
       @backlog.close
     end
 

--- a/spec/sync_sender_spec.rb
+++ b/spec/sync_sender_spec.rb
@@ -204,5 +204,12 @@ RSpec.describe Airbrake::SyncSender do
       sync_sender.close
       expect(mock_backlog).to have_received(:close)
     end
+
+    it "doesn't error when config.backlog is false" do
+      Airbrake::Config.instance.merge(backlog: false)
+
+      sync_sender.close
+      expect(mock_backlog).not_to have_received(:close)
+    end
   end
 end


### PR DESCRIPTION
Fix issue #730 